### PR TITLE
Fix remote directory browsing errors

### DIFF
--- a/app/stores/gateway/errors.ts
+++ b/app/stores/gateway/errors.ts
@@ -1,4 +1,5 @@
 import type { ErrorMessageLabels } from "./thread-utils/identity";
+import { gatewayErrorMessage, gatewayErrorPayload } from "@/utils/gateway-error";
 
 export type GatewayErrorKind = "appServerTurn" | "http" | "rpc" | "realtime" | "unknown";
 
@@ -86,13 +87,8 @@ export function unknownGatewayErrorFromError(
   fallback: string,
   labels: ErrorMessageLabels,
 ) {
-  const payload = error?.data || error?.response?._data || error;
-  const message =
-    payload?.message ||
-    payload?.statusMessage ||
-    error?.statusMessage ||
-    error?.message ||
-    fallback;
+  const payload = gatewayErrorPayload(error);
+  const message = gatewayErrorMessage(error, fallback);
   const details = payload?.details;
   if (!details || typeof details !== "object") {
     return new UnknownGatewayDisplayError(message);
@@ -168,12 +164,7 @@ export function isServerOverloadedAppError(error: unknown) {
 }
 
 export function isServerOverloadedRequestError(error: any) {
-  const message =
-    error?.data?.message ||
-    error?.response?._data?.message ||
-    error?.message ||
-    error?.statusMessage ||
-    null;
+  const message = gatewayErrorMessage(error, "");
   return (
     message === APP_SERVER_SERVER_OVERLOADED_MESSAGE ||
     message === APP_SERVER_RPC_OVERLOADED_MESSAGE

--- a/app/utils/gateway-api.ts
+++ b/app/utils/gateway-api.ts
@@ -5,6 +5,7 @@ import {
   currentGatewayConfigRevision,
   GatewayConfigConflictError,
 } from "./gateway-config-revision";
+import { gatewayErrorPayload } from "./gateway-error";
 
 export async function gatewayApi<T>(
   request: NitroFetchRequest,
@@ -37,10 +38,7 @@ export async function gatewayConfigApi<T>(
   try {
     return await gatewayApi<T>(request, { ...options, headers });
   } catch (error: any) {
-    if (
-      error?.data?.code === "configConflict" ||
-      error?.response?._data?.code === "configConflict"
-    ) {
+    if (gatewayErrorPayload(error).code === "configConflict") {
       throw new GatewayConfigConflictError();
     }
     throw error;

--- a/app/utils/gateway-error.ts
+++ b/app/utils/gateway-error.ts
@@ -1,0 +1,27 @@
+export interface GatewayErrorPayload {
+  code?: string;
+  details?: Record<string, unknown>;
+  message?: string;
+  statusCode?: number;
+  statusMessage?: string;
+}
+
+export function gatewayErrorPayload(error: any): GatewayErrorPayload {
+  const candidates = [error?.response?._data, error?.data, error];
+  return (
+    candidates.find(
+      (candidate) =>
+        candidate &&
+        typeof candidate === "object" &&
+        (typeof candidate.message === "string" ||
+          typeof candidate.statusMessage === "string" ||
+          typeof candidate.code === "string" ||
+          (candidate.details && typeof candidate.details === "object")),
+    ) ?? {}
+  );
+}
+
+export function gatewayErrorMessage(error: any, fallback: string) {
+  const payload = gatewayErrorPayload(error);
+  return payload.message || payload.statusMessage || error?.message || fallback;
+}

--- a/server/utils/gateway/infra/remote-files.ts
+++ b/server/utils/gateway/infra/remote-files.ts
@@ -3,6 +3,21 @@ import { shellQuote } from "./shell";
 import type { SshConnectionPool } from "./ssh-connection";
 import type { RemoteFileResult, HostWithSecret } from "./ssh-types";
 
+export class RemoteDirectoryNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "remoteDirectoryNotFound";
+
+  constructor(
+    readonly inputPath: string,
+    readonly resolvedPath: string,
+  ) {
+    super(
+      `Remote directory does not exist or is not a directory: ${inputPath} (resolved to ${resolvedPath})`,
+    );
+    this.name = "RemoteDirectoryNotFoundError";
+  }
+}
+
 export class RemoteFileService {
   constructor(private readonly ssh: SshConnectionPool) {}
 
@@ -14,11 +29,12 @@ input=$1
 case "$input" in
   "~") base=$HOME ;;
   "~/"*) base=$HOME/\${input#~/} ;;
-  *) base=$input ;;
+  /*) base=$input ;;
+  *) base=$HOME/$input ;;
 esac
 if ! [ -d "$base" ]; then
-  echo "Remote path is not a directory: $input" >&2
-  exit 1
+  printf '%s' "$base"
+  exit 44
 fi
 base=$(cd "$base" && pwd -P)
 printf 'BASE\\t%s\\n' "$base"
@@ -40,6 +56,9 @@ done
       `sh -c ${shellQuote(script)} sh ${shellQuote(normalizedPath)}`,
     );
     const result = await this.ssh.exec(host, command);
+    if (result.code === 44) {
+      throw new RemoteDirectoryNotFoundError(normalizedPath, result.stdout.trim());
+    }
     if (result.code !== 0) {
       throw new Error(result.stderr || `Failed to list remote directory: ${normalizedPath}`);
     }

--- a/tests/e2e/remote-host-project.spec.ts
+++ b/tests/e2e/remote-host-project.spec.ts
@@ -23,7 +23,9 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
   await expect(page.getByPlaceholder("输入后续修改要求")).toBeHidden();
   await expect.poll(() => realtimeSockets.size, { timeout: 10_000 }).toBe(1);
 
-  const host = await addRemoteHost(page, remote);
+  const hostName = `docker-codex-${Date.now()}`;
+  const host = await addRemoteHost(page, remote, hostName);
+  await verifyRemoteDirectoryBrowser(page, remote, host.id, hostName);
   const discovered = await createRemoteHistoricalRollout(remote);
   const discoveryResponse = await authenticatedFetch<any>(page, {
     url: `/api/threads?hostId=${host.id}&limit=50`,
@@ -233,6 +235,42 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
   expect(deleteProjectResponse.ok(), await deleteProjectResponse.text()).toBe(true);
   await expect(page.getByTestId(`project-button-${project.id}`)).toBeHidden();
 });
+
+async function verifyRemoteDirectoryBrowser(
+  page: Page,
+  remote: Awaited<ReturnType<typeof readRemoteEnv>>,
+  hostId: number,
+  hostName: string,
+) {
+  const directoryName = `gateway-directory-${Date.now()}`;
+  await execRemoteSsh(remote, `mkdir -p "$HOME/media/${directoryName}"`);
+
+  await page.getByTestId(`host-button-${hostId}`).click({ button: "right" });
+  await page.getByRole("menuitem", { name: /添加项目|Add project/ }).click();
+  await page.getByTestId("project-browse-path-input").fill("media/");
+  await page.getByRole("button", { name: /浏览|Browse/ }).click();
+  await expect(page.getByTestId("project-browse-path-input")).toHaveValue(
+    `/home/${remote.username}/media`,
+  );
+  await expect(page.getByRole("button", { name: directoryName })).toBeVisible();
+
+  const missingPath = `missing-directory-${Date.now()}`;
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/remote/directories?") && response.request().method() === "GET",
+  );
+  await page.getByTestId("project-browse-path-input").fill(missingPath);
+  await page.getByRole("button", { name: /浏览|Browse/ }).click();
+  const response = await responsePromise;
+  expect(response.status()).toBe(404);
+  const payload = await response.json();
+  expect(payload.code).toBe("remoteDirectoryNotFound");
+  expect(payload.message).toContain(missingPath);
+  expect(payload.message).toContain(`/home/${remote.username}/${missingPath}`);
+  await expect(page.getByText(new RegExp(`Remote directory.*${missingPath}`))).toBeVisible();
+  await expect(page.getByText(new RegExp(`主机: ${hostName}|Host: ${hostName}`))).toBeVisible();
+  await page.keyboard.press("Escape");
+}
 
 function trackActiveRealtimeSockets(page: Page) {
   const sockets = new Set<WebSocket>();


### PR DESCRIPTION
## Summary

- resolve relative remote directory paths from the SSH user home
- return a structured 404 with the original and resolved path for missing directories
- centralize frontend gateway error payload parsing so detailed server errors and host context reach the UI
- cover valid and invalid relative paths through the real SSH E2E environment

## Validation

- pnpm lint
- pnpm test:e2e (45 passed)