### PR TITLE
Fix nested agent output scrolling

### DIFF
--- a/app/components/common/chat-virtualizer/ChatStickToBottomScrollArea.vue
+++ b/app/components/common/chat-virtualizer/ChatStickToBottomScrollArea.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import type { ComponentPublicInstance, HTMLAttributes } from "vue";
-import { computed, onMounted, ref, watch } from "vue";
+import { useResizeObserver } from "@vueuse/core";
+import type { HTMLAttributes } from "vue";
+import { nextTick, onMounted, ref, watch } from "vue";
 import ChatVirtualScrollFrame from "./ChatVirtualScrollFrame.vue";
-import { useChatVirtualizer } from "./useChatVirtualizer";
+import { useStickToBottom } from "./stick-to-bottom";
 
 const props = withDefaults(
   defineProps<{
@@ -12,95 +13,47 @@ const props = withDefaults(
     allowHorizontalOverflow?: boolean;
     threshold?: number;
     followKey?: unknown;
-    estimateSize?: number;
-    naturalHeight?: boolean;
   }>(),
   {
     threshold: 120,
-    estimateSize: 320,
   },
 );
 
 const scrollFrameRef = ref<InstanceType<typeof ChatVirtualScrollFrame> | null>(null);
-const contentRef = ref<Element | null>(null);
-const measuredContentHeight = ref(0);
+const contentRef = ref<HTMLElement | null>(null);
 
-const chatVirtualizer = useChatVirtualizer({
-  count: 1,
+const sticky = useStickToBottom({
   getViewport: scrollViewport,
-  getItemKey: () => "content",
-  estimateSize: () => props.estimateSize,
-  getItemElement: () => contentRef.value,
   threshold: () => props.threshold,
+  scrollToBottom: (viewport) => {
+    viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+  },
 });
-const virtualizer = chatVirtualizer.virtualizer;
-
-const virtualRow = computed(() => virtualizer.value.getVirtualItems()[0] ?? null);
-const totalSize = computed(() => virtualizer.value.getTotalSize());
-// Chat subpanels have an explicit flex height, but compact command output and
-// diff blocks should grow naturally until their max-height kicks in. Because
-// the virtual row is absolutely positioned, it cannot otherwise size the root.
-const rootStyle = computed(() =>
-  props.naturalHeight
-    ? { height: `${Math.max(1, measuredContentHeight.value || totalSize.value)}px` }
-    : undefined,
-);
 
 function scrollViewport() {
   return scrollFrameRef.value?.getViewport() ?? null;
 }
 
-function setContentRef(refValue: Element | ComponentPublicInstance | null) {
-  const element = chatVirtualizer.measureElement(refValue);
-  contentRef.value = element;
-  if (!element) {
-    return;
-  }
-  measureContent();
-}
-
-function measureContent() {
-  if (contentRef.value) {
-    const element = contentRef.value as HTMLElement;
-    // Measure the real slotted content, not the scroll viewport. This keeps the
-    // single virtual row accurate even when the viewport starts collapsed.
-    measuredContentHeight.value = Math.max(
-      element.scrollHeight,
-      element.getBoundingClientRect().height,
-    );
-    if (element.dataset.index !== undefined) {
-      chatVirtualizer.measureElement(contentRef.value);
-    } else {
-      // TanStack Virtual's default measureElement reads data-index from the
-      // measured row. The non-virtual fallback content has no row index yet, so
-      // ask the virtualizer to remeasure globally instead of emitting a warning.
-      virtualizer.value.measure();
-    }
-  } else {
-    measuredContentHeight.value = 0;
-    virtualizer.value.measure();
-  }
-  chatVirtualizer.measureVisibleItems();
-}
+useResizeObserver(contentRef, () => sticky.followContentChange());
 
 watch(
   () => props.followKey,
-  () => {
-    measureContent();
+  async () => {
+    await nextTick();
+    sticky.followContentChange();
   },
   { flush: "post" },
 );
 
 onMounted(() => {
-  chatVirtualizer.bindInputListeners();
-  chatVirtualizer.reset();
-  void chatVirtualizer.settleAndStick();
+  sticky.bindInputListeners();
+  sticky.reset();
+  void sticky.settleAndStick();
 });
 
 function handleViewportReady() {
-  chatVirtualizer.refresh();
-  chatVirtualizer.bindInputListeners();
-  chatVirtualizer.stickIfFollowing();
+  sticky.bindInputListeners();
+  sticky.stickIfFollowing();
 }
 </script>
 
@@ -112,33 +65,13 @@ function handleViewportReady() {
     :viewport-class="
       props.allowHorizontalOverflow ? ['overflow-auto', props.viewportClass] : props.viewportClass
     "
-    :style="rootStyle"
     @viewport-ready="handleViewportReady"
   >
     <div
-      class="relative"
-      :class="props.allowHorizontalOverflow ? 'min-w-full w-max' : 'w-full'"
-      :ref="chatVirtualizer.containerRef"
+      ref="contentRef"
+      :class="[props.allowHorizontalOverflow ? 'min-w-full w-max' : 'w-full', props.contentClass]"
     >
-      <div
-        v-if="virtualRow"
-        :ref="setContentRef"
-        :data-index="virtualRow.index"
-        :class="[
-          'absolute left-0 top-0',
-          props.allowHorizontalOverflow ? 'min-w-full w-max' : 'w-full',
-          props.contentClass,
-        ]"
-      >
-        <slot />
-      </div>
-      <div
-        v-else
-        :ref="setContentRef"
-        :class="[props.allowHorizontalOverflow ? 'min-w-full w-max' : 'w-full', props.contentClass]"
-      >
-        <slot />
-      </div>
+      <slot />
     </div>
   </ChatVirtualScrollFrame>
 </template>

--- a/app/components/common/chat-virtualizer/stick-to-bottom.ts
+++ b/app/components/common/chat-virtualizer/stick-to-bottom.ts
@@ -2,10 +2,10 @@ import { nextTick, onBeforeUnmount } from "vue";
 import { createStickToBottomState, type ThresholdSource } from "./stick-to-bottom-state";
 import { createViewportInputIntent } from "./viewport-input-intent";
 
-type VirtualStickToBottomOptions = {
+type StickToBottomOptions = {
   threshold?: ThresholdSource;
   getViewport: () => HTMLElement | null;
-  measure: () => void;
+  measure?: () => void;
   onViewportScroll?: (viewport: HTMLElement) => void;
   scrollToBottom: (viewport: HTMLElement) => void;
 };
@@ -14,7 +14,7 @@ function nextFrame() {
   return new Promise((resolve) => requestAnimationFrame(resolve));
 }
 
-export function useVirtualStickToBottom(options: VirtualStickToBottomOptions) {
+export function useStickToBottom(options: StickToBottomOptions) {
   const state = createStickToBottomState({
     threshold: options.threshold,
     getViewport: options.getViewport,
@@ -36,12 +36,12 @@ export function useVirtualStickToBottom(options: VirtualStickToBottomOptions) {
     if (version !== state.currentVersion() || !state.followLatest.value) {
       return;
     }
-    options.measure();
+    options.measure?.();
     await nextFrame();
     if (version !== state.currentVersion() || !state.followLatest.value) {
       return;
     }
-    options.measure();
+    options.measure?.();
     const viewport = options.getViewport();
     if (viewport) {
       options.scrollToBottom(viewport);
@@ -56,7 +56,7 @@ export function useVirtualStickToBottom(options: VirtualStickToBottomOptions) {
     if (!state.followLatest.value) {
       return;
     }
-    options.measure();
+    options.measure?.();
     const viewport = options.getViewport();
     if (viewport) {
       options.scrollToBottom(viewport);
@@ -83,11 +83,11 @@ export function useVirtualStickToBottom(options: VirtualStickToBottomOptions) {
   async function settleAndStick(frameCount = 4) {
     // Some containers first mount at height 0 while wrappers such as
     // CollapsibleContent and syntax highlighters settle. A few post-mount
-    // frames prevent virtual rows from keeping that stale zero measurement.
+    // frames prevent the initial bottom alignment from using stale geometry.
     for (let index = 0; index < frameCount; index += 1) {
       await nextFrame();
       bindInputListeners();
-      options.measure();
+      options.measure?.();
       if (state.followLatest.value) {
         const viewport = options.getViewport();
         if (viewport) {

--- a/app/components/common/chat-virtualizer/useChatVirtualizer.ts
+++ b/app/components/common/chat-virtualizer/useChatVirtualizer.ts
@@ -3,7 +3,7 @@ import { computed, toValue, type ComponentPublicInstance, type MaybeRefOrGetter 
 import { createChatVirtualizerBehavior } from "./anchoring";
 import { useDirectDomVirtualizer } from "./direct-dom-virtualizer";
 import { shouldAdjustDetachedResize } from "./measurement";
-import { useVirtualStickToBottom } from "./stick-to-bottom";
+import { useStickToBottom } from "./stick-to-bottom";
 import type { ThresholdSource } from "./stick-to-bottom-state";
 
 interface ChatVirtualizerOptions {
@@ -21,7 +21,7 @@ interface ChatVirtualizerOptions {
 
 export function useChatVirtualizer(options: ChatVirtualizerOptions) {
   const threshold = () => toValue(options.threshold) ?? 120;
-  const sticky = useVirtualStickToBottom({
+  const sticky = useStickToBottom({
     threshold,
     getViewport: options.getViewport,
     measure: measureVisibleItems,

--- a/app/components/thread/items/CommandExecutionItem.vue
+++ b/app/components/thread/items/CommandExecutionItem.vue
@@ -101,9 +101,7 @@ async function respond(decision: "accept" | "decline") {
         class="mt-2 max-h-56 rounded-lg border border-hairline bg-canvas-soft"
         viewport-class="max-h-56"
         allow-horizontal-overflow
-        natural-height
         :threshold="48"
-        :estimate-size="44"
         :follow-key="rawOutput.length"
       >
         <HighlightedCode

--- a/app/components/thread/items/FileChangeDiffPanel.vue
+++ b/app/components/thread/items/FileChangeDiffPanel.vue
@@ -20,7 +20,6 @@ const props = defineProps<{
     class="diff-markdown max-h-[min(55vh,26rem)] border-t border-hairline bg-surface"
     viewport-class="max-h-[min(55vh,26rem)]"
     allow-horizontal-overflow
-    natural-height
     :threshold="48"
     :follow-key="fileChangeFollowKey(props.change)"
   >

--- a/tests/e2e/thread-diff-rendering.spec.ts
+++ b/tests/e2e/thread-diff-rendering.spec.ts
@@ -168,6 +168,114 @@ test("streaming diff keeps user-selected horizontal scroll position", async ({ p
   await expect.poll(() => diffScrollLeft(page, "wide_line_001")).toBeLessThanOrEqual(98);
 });
 
+test("switching threads keeps asynchronously rendered diff content in normal flow", async ({
+  page,
+}) => {
+  await openApp(page);
+  const diffThreadId = "e2e-async-diff-layout-thread";
+  const shortThreadId = "e2e-async-diff-short-thread";
+  const finalMarker = "final answer after the asynchronously highlighted diff";
+  const diff = [
+    "diff --git a/src/async.py b/src/async.py",
+    "--- a/src/async.py",
+    "+++ b/src/async.py",
+    "@@ -1,1 +1,120 @@",
+    ...Array.from(
+      { length: 120 },
+      (_, index) => `+async_diff_line_${String(index + 1).padStart(3, "0")} = ${index + 1}`,
+    ),
+  ].join("\n");
+  const diffHistory = {
+    thread: {
+      id: diffThreadId,
+      turns: [
+        {
+          id: "turn-async-diff",
+          status: "running",
+          items: [
+            {
+              id: "file-async-diff",
+              type: "fileChange",
+              status: "completed",
+              changes: [{ path: "src/async.py", kind: "update", diff }],
+            },
+            {
+              id: "agent-after-async-diff",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: finalMarker,
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const shortHistory = {
+    thread: {
+      id: shortThreadId,
+      turns: [
+        {
+          id: "turn-short",
+          status: "completed",
+          items: [
+            {
+              id: "agent-short",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "short thread content",
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  await seedGatewayThread(page, {
+    threadId: diffThreadId,
+    projectId: 1,
+    status: "running",
+    currentThread: { id: diffThreadId, name: "Async Diff" },
+    history: diffHistory,
+    threads: [
+      { id: diffThreadId, name: "Async Diff", updatedAt: 2 },
+      { id: shortThreadId, name: "Short Thread", updatedAt: 1 },
+    ],
+    threadViews: {
+      [`1:${diffThreadId}`]: cachedThreadView(diffThreadId, diffHistory),
+      [`1:${shortThreadId}`]: cachedThreadView(shortThreadId, shortHistory),
+    },
+  });
+
+  await page.getByTestId(`thread-button-${shortThreadId}`).click();
+  await expect(page.getByText("short thread content")).toBeVisible();
+  await page.getByTestId(`thread-button-${diffThreadId}`).click();
+  await expect(page.getByText("async_diff_line_120")).toBeVisible();
+  await expect(page.getByText(finalMarker)).toBeVisible();
+  await expect.poll(() => diffEndsBeforeText(page, finalMarker)).toBe(true);
+});
+
+function cachedThreadView(threadId: string, history: unknown) {
+  return {
+    hostId: 1,
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId },
+    history,
+    events: [],
+    olderTurnsCursor: null,
+    newerTurnsCursor: null,
+    lastEventId: 0,
+    loading: false,
+    error: null,
+  };
+}
+
+async function diffEndsBeforeText(page: import("@playwright/test").Page, text: string) {
+  const diffBox = await page.locator(".diff-markdown").first().boundingBox();
+  const textBox = await page.getByText(text).boundingBox();
+  return Boolean(diffBox && textBox && diffBox.y + diffBox.height <= textBox.y + 1);
+}
+
 async function openIntermediateSteps(page: import("@playwright/test").Page) {
   const toggle = page.getByRole("button", { name: /中间过程/ }).first();
   await expect(toggle).toBeVisible();


### PR DESCRIPTION
## Summary

- keep TanStack virtualization only on the outer agent timeline
- render bounded diff and command output in normal document flow
- share one stick-to-bottom state machine between virtual and bounded scroll areas
- observe asynchronous diff size changes with VueUse instead of bridging height manually
- cover thread switching with an asynchronously highlighted large diff and no wheel interaction

## Validation

- pnpm lint
- pnpm test:e2e (46 passed; first run had one unrelated config revision setup race, clean rerun passed 46/46)