### PR TITLE
Group projects with missing remote directories

### DIFF
--- a/app/components/sidebar/GatewaySidebar.vue
+++ b/app/components/sidebar/GatewaySidebar.vue
@@ -72,10 +72,12 @@ function openEditProject(project: any) {
 
           <HostTree
             :hosts="sidebarTree.hosts.value"
-            :projects-by-host="sidebarTree.projectsByHost.value"
+            :available-projects-by-host="sidebarTree.availableProjectsByHost.value"
+            :missing-projects-by-host="sidebarTree.missingProjectsByHost.value"
             :project-threads="sidebarTree.projectThreads.value"
             :expanded-host-ids="sidebarTree.expandedHostIds.value"
             :expanded-project-ids="sidebarTree.expandedProjectIds.value"
+            :expanded-missing-project-host-ids="sidebarTree.expandedMissingProjectHostIds.value"
             :selected-host-id="sidebarTree.selectedHostId.value"
             :selected-project-id="sidebarTree.selectedProjectId.value"
             :selected-thread-id="sidebarTree.selectedThreadId.value"
@@ -89,6 +91,7 @@ function openEditProject(project: any) {
             @add-project="openAddProject"
             @delete-host="store.deleteHost"
             @select-project="sidebarTree.selectProject"
+            @toggle-missing-projects="sidebarTree.toggleMissingProjects"
             @edit-project="openEditProject"
             @delete-project="store.deleteProject"
             @start-thread-in-project="sidebarTree.startThreadInProject"

--- a/app/components/sidebar/HostTree.vue
+++ b/app/components/sidebar/HostTree.vue
@@ -3,8 +3,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   FolderIcon,
-  FolderOpenIcon,
-  PlusIcon,
+  FolderXIcon,
   ServerIcon,
   Trash2Icon,
 } from "@lucide/vue";
@@ -19,14 +18,17 @@ import type { ThreadRuntimeStatus } from "@/stores/gateway";
 import { formatRelative, selectedRowClass } from "./sidebar-utils";
 import HostStatusIndicator from "./HostStatusIndicator.vue";
 import SidebarRowLabel from "./SidebarRowLabel.vue";
+import SidebarProjectRow from "./SidebarProjectRow.vue";
 import ThreadRow from "./ThreadRow.vue";
 
 const props = defineProps<{
   hosts: any[];
-  projectsByHost: Map<number, any[]>;
+  availableProjectsByHost: Map<number, any[]>;
+  missingProjectsByHost: Map<number, any[]>;
   projectThreads: any[];
   expandedHostIds: Set<number>;
   expandedProjectIds: Set<number>;
+  expandedMissingProjectHostIds: Set<number>;
   selectedHostId: number | null;
   selectedProjectId: number | null;
   selectedThreadId: string | null;
@@ -43,6 +45,7 @@ const emit = defineEmits<{
   addProject: [host: any];
   deleteHost: [hostId: number];
   selectProject: [projectId: number, event: MouseEvent];
+  toggleMissingProjects: [hostId: number];
   editProject: [project: any];
   deleteProject: [projectId: number];
   startThreadInProject: [project: any];
@@ -104,49 +107,20 @@ function hostConnectionStatus(hostId: number) {
 
         <div v-if="expandedHostIds.has(host.id)" class="mt-1 space-y-1 pl-5">
           <div
-            v-for="project in projectsByHost.get(host.id) ?? []"
+            v-for="project in availableProjectsByHost.get(host.id) ?? []"
             :key="project.id"
             class="space-y-1"
           >
-            <div @click.capture="emit('selectProject', project.id, $event)">
-              <ContextMenu>
-                <ContextMenuTrigger as-child>
-                  <Button
-                    :data-testid="`project-button-${project.id}`"
-                    v-bind="longPressHandlers"
-                    variant="ghost"
-                    class="h-10 w-full justify-start gap-2 rounded-lg px-3 text-[0.9375rem] font-normal hover:bg-surface"
-                    :class="selectedRowClass(project.id === selectedProjectId)"
-                  >
-                    <ChevronDownIcon
-                      v-if="expandedProjectIds.has(project.id)"
-                      class="size-3.5 shrink-0 text-ink-muted"
-                    />
-                    <ChevronRightIcon v-else class="size-3.5 shrink-0 text-ink-muted" />
-                    <FolderIcon class="size-4 shrink-0" />
-                    <SidebarRowLabel :title="project.name" />
-                    <span class="ml-auto size-2 shrink-0 rounded-full bg-accent-green" />
-                  </Button>
-                </ContextMenuTrigger>
-                <ContextMenuContent :collision-padding="12" prioritize-position class="w-44">
-                  <ContextMenuItem @select="emit('editProject', project)">
-                    <FolderOpenIcon class="mr-2 size-4" />
-                    {{ $t("app.editProject") }}
-                  </ContextMenuItem>
-                  <ContextMenuItem @select="emit('startThreadInProject', project)">
-                    <PlusIcon class="mr-2 size-4" />
-                    {{ $t("app.newThread") }}
-                  </ContextMenuItem>
-                  <ContextMenuItem
-                    class="text-destructive focus:text-destructive"
-                    @select="emit('deleteProject', project.id)"
-                  >
-                    <Trash2Icon class="mr-2 size-4" />
-                    {{ $t("app.deleteProject") }}
-                  </ContextMenuItem>
-                </ContextMenuContent>
-              </ContextMenu>
-            </div>
+            <SidebarProjectRow
+              :project="project"
+              :expanded="expandedProjectIds.has(project.id)"
+              :selected="project.id === selectedProjectId"
+              :long-press-handlers="longPressHandlers"
+              @select="emit('selectProject', project.id, $event)"
+              @edit="emit('editProject', project)"
+              @delete="emit('deleteProject', project.id)"
+              @start-thread="emit('startThreadInProject', project)"
+            />
 
             <div v-if="expandedProjectIds.has(project.id)" class="space-y-1 pl-7">
               <template v-if="project.id === selectedProjectId && projectThreads.length">
@@ -189,8 +163,44 @@ function hostConnectionStatus(hostId: number) {
             </div>
           </div>
 
+          <div v-if="(missingProjectsByHost.get(host.id) ?? []).length" class="space-y-1">
+            <Button
+              :data-testid="`missing-projects-toggle-${host.id}`"
+              variant="ghost"
+              class="h-9 w-full justify-start gap-2 rounded-lg px-3 text-xs font-normal text-ink-muted hover:bg-surface"
+              @click="emit('toggleMissingProjects', host.id)"
+            >
+              <ChevronDownIcon
+                v-if="expandedMissingProjectHostIds.has(host.id)"
+                class="size-3.5 shrink-0"
+              />
+              <ChevronRightIcon v-else class="size-3.5 shrink-0" />
+              <FolderXIcon class="size-4 shrink-0 text-destructive/70" />
+              <span class="min-w-0 flex-1 truncate text-left">{{ $t("app.missingProjects") }}</span>
+              <span class="shrink-0 tabular-nums">{{
+                missingProjectsByHost.get(host.id)?.length
+              }}</span>
+            </Button>
+            <div v-if="expandedMissingProjectHostIds.has(host.id)" class="space-y-1">
+              <SidebarProjectRow
+                v-for="project in missingProjectsByHost.get(host.id) ?? []"
+                :key="project.id"
+                :project="project"
+                :expanded="false"
+                :selected="project.id === selectedProjectId"
+                :missing="true"
+                :long-press-handlers="longPressHandlers"
+                @edit="emit('editProject', project)"
+                @delete="emit('deleteProject', project.id)"
+              />
+            </div>
+          </div>
+
           <div
-            v-if="!(projectsByHost.get(host.id) ?? []).length"
+            v-if="
+              !(availableProjectsByHost.get(host.id) ?? []).length &&
+              !(missingProjectsByHost.get(host.id) ?? []).length
+            "
             class="rounded-lg px-3 py-2 text-xs text-ink-muted"
           >
             {{ $t("app.noProjects") }}

--- a/app/components/sidebar/SidebarProjectRow.vue
+++ b/app/components/sidebar/SidebarProjectRow.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  FolderXIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "@lucide/vue";
+import type { ProjectRecord } from "~~/shared/types";
+import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { selectedRowClass } from "./sidebar-utils";
+import SidebarRowLabel from "./SidebarRowLabel.vue";
+
+const props = defineProps<{
+  project: ProjectRecord;
+  expanded: boolean;
+  selected: boolean;
+  missing?: boolean;
+  longPressHandlers?: Record<string, unknown>;
+}>();
+
+const emit = defineEmits<{
+  select: [event: MouseEvent];
+  edit: [];
+  delete: [];
+  startThread: [];
+}>();
+
+function selectProject(event: MouseEvent) {
+  if (!props.missing) {
+    emit("select", event);
+  }
+}
+</script>
+
+<template>
+  <ContextMenu>
+    <ContextMenuTrigger as-child>
+      <Button
+        :data-testid="`project-button-${project.id}`"
+        v-bind="longPressHandlers"
+        variant="ghost"
+        class="h-10 w-full justify-start gap-2 rounded-lg px-3 text-[0.9375rem] font-normal hover:bg-surface"
+        :class="[selectedRowClass(selected), missing ? 'text-ink-faint' : '']"
+        :data-project-missing="missing ? 'true' : 'false'"
+        @click="selectProject"
+      >
+        <template v-if="!missing">
+          <ChevronDownIcon v-if="expanded" class="size-3.5 shrink-0 text-ink-muted" />
+          <ChevronRightIcon v-else class="size-3.5 shrink-0 text-ink-muted" />
+        </template>
+        <span v-else class="w-3.5 shrink-0" />
+        <FolderXIcon v-if="missing" class="size-4 shrink-0 text-destructive/70" />
+        <FolderIcon v-else class="size-4 shrink-0" />
+        <SidebarRowLabel
+          :title="project.name"
+          :subtitle="missing ? $t('app.projectDirectoryMissing') : undefined"
+        />
+        <span v-if="!missing" class="ml-auto size-2 shrink-0 rounded-full bg-accent-green" />
+      </Button>
+    </ContextMenuTrigger>
+    <ContextMenuContent :collision-padding="12" prioritize-position class="w-44">
+      <ContextMenuItem @select="emit('edit')">
+        <FolderOpenIcon class="mr-2 size-4" />
+        {{ $t("app.editProject") }}
+      </ContextMenuItem>
+      <ContextMenuItem v-if="!missing" @select="emit('startThread')">
+        <PlusIcon class="mr-2 size-4" />
+        {{ $t("app.newThread") }}
+      </ContextMenuItem>
+      <ContextMenuItem class="text-destructive focus:text-destructive" @select="emit('delete')">
+        <Trash2Icon class="mr-2 size-4" />
+        {{ $t("app.deleteProject") }}
+      </ContextMenuItem>
+    </ContextMenuContent>
+  </ContextMenu>
+</template>

--- a/app/components/sidebar/useSidebarTree.ts
+++ b/app/components/sidebar/useSidebarTree.ts
@@ -10,6 +10,7 @@ export function useSidebarTree(store: GatewayStore, longPressTriggered: Ref<bool
     hosts,
     threads,
     projects,
+    projectDirectoryAvailability,
     pinnedThreads,
     openingPinnedThreadKey,
     unviewedCompletedThreadKeys,
@@ -21,6 +22,7 @@ export function useSidebarTree(store: GatewayStore, longPressTriggered: Ref<bool
   } = storeToRefs(store);
   const expandedHostIds = ref<Set<number>>(new Set());
   const expandedProjectIds = ref<Set<number>>(new Set());
+  const expandedMissingProjectHostIds = ref<Set<number>>(new Set());
   const suppressTreeAutoExpand = ref(false);
 
   const projectThreads = computed(() =>
@@ -36,15 +38,21 @@ export function useSidebarTree(store: GatewayStore, longPressTriggered: Ref<bool
         pinnedThreadId(thread) === String(selectedThreadId.value),
     );
   });
-  const projectsByHost = computed(() => {
+  const availableProjectsByHost = computed(() => groupProjectsByHost(false));
+  const missingProjectsByHost = computed(() => groupProjectsByHost(true));
+
+  function groupProjectsByHost(missing: boolean) {
     const byHost = new Map<number, typeof projects.value>();
     for (const project of projects.value) {
+      if ((projectDirectoryAvailability.value[project.id] === "missing") !== missing) {
+        continue;
+      }
       const group = byHost.get(project.hostId) ?? [];
       group.push(project);
       byHost.set(project.hostId, group);
     }
     return byHost;
-  });
+  }
 
   function openThread(
     threadId: string,
@@ -100,6 +108,13 @@ export function useSidebarTree(store: GatewayStore, longPressTriggered: Ref<bool
     if (!isProjectListVisible) {
       void store.selectProject(projectId);
     }
+  }
+
+  function toggleMissingProjects(hostId: number) {
+    const next = new Set(expandedMissingProjectHostIds.value);
+    if (next.has(hostId)) next.delete(hostId);
+    else next.add(hostId);
+    expandedMissingProjectHostIds.value = next;
   }
 
   function startThreadInProject(project: any) {
@@ -162,6 +177,19 @@ export function useSidebarTree(store: GatewayStore, longPressTriggered: Ref<bool
     expandedProjectIds.value = new Set();
   });
 
+  watch(
+    [selectedProjectId, projectDirectoryAvailability],
+    ([projectId]) => {
+      if (!projectId || projectDirectoryAvailability.value[projectId] !== "missing") return;
+      const project = projects.value.find((item) => item.id === projectId);
+      if (!project) return;
+      expandedMissingProjectHostIds.value = new Set(expandedMissingProjectHostIds.value).add(
+        project.hostId,
+      );
+    },
+    { immediate: true, deep: true },
+  );
+
   return {
     hosts,
     threads,
@@ -173,12 +201,15 @@ export function useSidebarTree(store: GatewayStore, longPressTriggered: Ref<bool
     selectedThreadId,
     expandedHostIds,
     expandedProjectIds,
+    expandedMissingProjectHostIds,
     projectThreads,
-    projectsByHost,
+    availableProjectsByHost,
+    missingProjectsByHost,
     openThread,
     openPinnedThread,
     selectHost,
     selectProject,
+    toggleMissingProjects,
     startThreadInProject,
     threadRuntimeStatus,
     threadCompletionAttention,

--- a/app/stores/gateway/actions/core.ts
+++ b/app/stores/gateway/actions/core.ts
@@ -101,6 +101,7 @@ export function createCoreActions(ctx: GatewayStoreContext) {
         const routeSelection = readGatewayRouteSelection();
         useGatewayRealtimeStore().connectHostLifecycleEvents();
         ctx.state.projects = [];
+        ctx.state.projectDirectoryAvailability = {};
         ctx.state.threads = [];
         ctx.state.models = [];
         ctx.state.modelsHostId = null;

--- a/app/stores/gateway/actions/hosts.ts
+++ b/app/stores/gateway/actions/hosts.ts
@@ -45,7 +45,17 @@ export function createHostActions(ctx: GatewayStoreContext) {
       await gatewayApi(`/api/hosts/${hostId}`, { method: "DELETE" });
       useGatewayRealtimeStore().closeHostThreadEvents(hostId);
       ctx.state.hosts = ctx.state.hosts.filter((host) => host.id !== hostId);
+      const removedProjectIds = new Set(
+        ctx.state.projects
+          .filter((project) => project.hostId === hostId)
+          .map((project) => project.id),
+      );
       ctx.state.projects = ctx.state.projects.filter((project) => project.hostId !== hostId);
+      ctx.state.projectDirectoryAvailability = Object.fromEntries(
+        Object.entries(ctx.state.projectDirectoryAvailability).filter(
+          ([projectId]) => !removedProjectIds.has(Number(projectId)),
+        ),
+      );
       ctx.state.gatewayConfig.projects = ctx.state.gatewayConfig.projects.filter(
         (project) => project.hostId !== hostId,
       );

--- a/app/stores/gateway/actions/projects.ts
+++ b/app/stores/gateway/actions/projects.ts
@@ -142,7 +142,11 @@ export function createProjectActions(ctx: GatewayStoreContext) {
         item.id === projectId ? project : item,
       );
       upsertConfiguredProject(ctx, project);
+      const { [projectId]: _removed, ...remainingAvailability } =
+        ctx.state.projectDirectoryAvailability;
+      ctx.state.projectDirectoryAvailability = remainingAvailability;
       if (ctx.state.selectedProjectId !== projectId) {
+        await ctx.refreshHostProjects(project.hostId);
         return project;
       }
 
@@ -170,6 +174,9 @@ export function createProjectActions(ctx: GatewayStoreContext) {
       const project = ctx.state.projects.find((item) => item.id === projectId);
       await gatewayApi(`/api/projects/${projectId}`, { method: "DELETE" });
       ctx.state.projects = ctx.state.projects.filter((item) => item.id !== projectId);
+      const { [projectId]: _removed, ...remainingAvailability } =
+        ctx.state.projectDirectoryAvailability;
+      ctx.state.projectDirectoryAvailability = remainingAvailability;
       ctx.state.gatewayConfig.projects = ctx.state.gatewayConfig.projects.filter(
         (item) => item.id !== projectId,
       );

--- a/app/stores/gateway/actions/thread-list.ts
+++ b/app/stores/gateway/actions/thread-list.ts
@@ -4,6 +4,17 @@ import { messageFromError, pinnedKey, sortThreads } from "../thread-utils/identi
 import { runtimeStatusFromAppThreadStatus } from "../thread-utils/status";
 
 export function createThreadListActions(ctx: GatewayStoreContext) {
+  async function loadHostOverview(hostId: number) {
+    const response = await gatewayApi<ThreadListResponse>("/api/threads", {
+      query: { hostId, limit: 50 },
+    });
+    if (response.projects) {
+      ctx.mergeProjects(response.projects);
+    }
+    applyProjectDirectoryAvailability(ctx, response);
+    syncThreadStatusesFromList(ctx, hostId, response.data ?? []);
+  }
+
   return {
     async connectAllHosts() {
       const hosts = [...ctx.state.hosts];
@@ -18,16 +29,7 @@ export function createThreadListActions(ctx: GatewayStoreContext) {
             [host.id]: { status: "connecting", updatedAt: Date.now() },
           };
           try {
-            const response = await gatewayApi<ThreadListResponse>("/api/threads", {
-              query: {
-                hostId: host.id,
-                limit: 50,
-              },
-            });
-            if (response.projects) {
-              ctx.mergeProjects(response.projects);
-            }
-            syncThreadStatusesFromList(ctx, host.id, response.data ?? []);
+            await loadHostOverview(host.id);
             ctx.state.hostConnectionStatuses = {
               ...ctx.state.hostConnectionStatuses,
               [host.id]: { status: "connected", updatedAt: Date.now() },
@@ -45,6 +47,10 @@ export function createThreadListActions(ctx: GatewayStoreContext) {
         }),
       );
       ctx.persistConfig();
+    },
+
+    async refreshHostProjects(hostId: number) {
+      await loadHostOverview(hostId);
     },
 
     async listThreads(searchTerm = "") {
@@ -78,6 +84,7 @@ export function createThreadListActions(ctx: GatewayStoreContext) {
         if (response.projects) {
           ctx.mergeProjects(response.projects);
         }
+        applyProjectDirectoryAvailability(ctx, response);
         ctx.state.hostConnectionStatuses = {
           ...ctx.state.hostConnectionStatuses,
           [hostId]: { status: "connected", updatedAt: Date.now() },
@@ -122,6 +129,16 @@ export function createThreadListActions(ctx: GatewayStoreContext) {
           : false,
       }));
     },
+  };
+}
+
+function applyProjectDirectoryAvailability(ctx: GatewayStoreContext, response: ThreadListResponse) {
+  if (!response.projectDirectoryAvailability) {
+    return;
+  }
+  ctx.state.projectDirectoryAvailability = {
+    ...ctx.state.projectDirectoryAvailability,
+    ...response.projectDirectoryAvailability,
   };
 }
 

--- a/app/stores/gateway/state.ts
+++ b/app/stores/gateway/state.ts
@@ -5,6 +5,7 @@ export function createGatewayState(): GatewayStoreState {
   return {
     hosts: [],
     projects: [],
+    projectDirectoryAvailability: {},
     threads: [],
     models: [],
     modelsHostId: null,

--- a/app/stores/gateway/types.ts
+++ b/app/stores/gateway/types.ts
@@ -5,6 +5,7 @@ import type {
   ModelRecord,
   PinnedThreadRecord,
   ProjectRecord,
+  ProjectDirectoryAvailability,
   TerminalOpenTarget,
   TerminalSessionSnapshot,
   ThreadGoal,
@@ -33,6 +34,7 @@ export interface ThreadListResponse {
   nextCursor?: string | null;
   backwardsCursor?: string | null;
   projects?: ProjectRecord[];
+  projectDirectoryAvailability?: Record<number, ProjectDirectoryAvailability>;
 }
 
 export interface ThreadViewState {
@@ -88,6 +90,7 @@ export interface GatewayErrorState {
 export interface GatewayStoreState {
   hosts: HostRecord[];
   projects: ProjectRecord[];
+  projectDirectoryAvailability: Record<number, ProjectDirectoryAvailability>;
   threads: Array<any>;
   models: ModelRecord[];
   modelsHostId: number | null;
@@ -156,6 +159,7 @@ export interface GatewayStoreContext {
   loadConfigFromServer: () => Promise<void>;
   refresh: () => Promise<void>;
   connectAllHosts: () => Promise<void>;
+  refreshHostProjects: (hostId: number) => Promise<void>;
   listModels: () => Promise<void>;
   ensureSelectedHostModels: () => Promise<void>;
   listThreads: (searchTerm?: string) => Promise<void>;

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -19,6 +19,8 @@
     "pinned": "Pinned",
     "noThreads": "No threads",
     "noProjects": "No projects",
+    "missingProjects": "Missing directories",
+    "projectDirectoryMissing": "Remote directory does not exist",
     "refreshThreadsHint": "Click search or refresh to read real Codex threads",
     "projects": "Projects",
     "settings": "Settings",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -19,6 +19,8 @@
     "pinned": "已固定",
     "noThreads": "暂无会话",
     "noProjects": "暂无项目",
+    "missingProjects": "目录已删除",
+    "projectDirectoryMissing": "远端目录不存在",
     "refreshThreadsHint": "点击搜索或刷新，从 Codex 读取真实会话",
     "projects": "项目",
     "settings": "设置",

--- a/server/api/threads/index.get.ts
+++ b/server/api/threads/index.get.ts
@@ -10,6 +10,7 @@ import { threadListSchema } from "../../utils/gateway/http/validation/threads";
 import { hostStore } from "../../utils/gateway/state/hosts";
 import { projectStore } from "../../utils/gateway/state/projects";
 import { threadMetadataStore } from "../../utils/gateway/state/thread-metadata";
+import { remoteFiles } from "../../utils/gateway/infra/host-services";
 import { withAllThreadSources } from "../../utils/gateway/protocol/thread-list";
 
 export default defineGatewayEventHandler(async (event) => {
@@ -48,12 +49,41 @@ export default defineGatewayEventHandler(async (event) => {
     }),
     query.searchTerm ?? null,
   );
+  const projects = projectStore.list(host.id);
+  const projectDirectoryAvailability = await inspectProjectAvailability(host, projects);
   return {
     ...(result as Record<string, unknown>),
     data: mergedThreads,
-    projects: projectStore.list(host.id),
+    projects,
+    projectDirectoryAvailability,
   };
 });
+
+async function inspectProjectAvailability(
+  host: any,
+  projects: Array<{ id: number; remotePath: string }>,
+) {
+  try {
+    const byPath = await remoteFiles.inspectProjectDirectories(
+      host,
+      projects.map((project) => project.remotePath),
+    );
+    return Object.fromEntries(
+      projects.flatMap((project) => {
+        const availability = byPath.get(project.remotePath.trim());
+        return availability ? [[project.id, availability]] : [];
+      }),
+    );
+  } catch (error) {
+    // Availability is advisory; an SFTP outage must not hide projects or fail thread listing.
+    console.warn("[gateway] project directory inspection failed", {
+      hostId: host.id,
+      hostName: host.name,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {};
+  }
+}
 
 function shouldDiscoverHostProjects(query: {
   projectId?: number | null;

--- a/server/utils/gateway/infra/remote-files.ts
+++ b/server/utils/gateway/infra/remote-files.ts
@@ -3,6 +3,7 @@ import { posix } from "node:path";
 import { remoteLoginShellCommand } from "./remote-command";
 import { shellQuote } from "./shell";
 import type { SshConnectionPool } from "./ssh-connection";
+import type { ProjectDirectoryAvailability } from "~~/shared/types";
 import type { HostWithSecret, RemoteFileMetadata, RemoteFileResult } from "./ssh-types";
 
 export class RemoteDirectoryNotFoundError extends Error {
@@ -57,6 +58,24 @@ export class RemoteFileService {
     await new Promise<void>((resolve, reject) => {
       sftp.unlink(path, (error) => (error ? reject(error) : resolve()));
     });
+  }
+
+  async inspectProjectDirectories(host: HostWithSecret, paths: string[]) {
+    const absolutePaths = [
+      ...new Set(paths.map((path) => path.trim()).filter((path) => path.startsWith("/"))),
+    ];
+    if (!absolutePaths.length) {
+      return new Map<string, ProjectDirectoryAvailability>();
+    }
+    const sftp = await this.ssh.sftp(host);
+    const entries = await Promise.all(
+      absolutePaths.map(async (path) => [path, await inspectDirectory(sftp, path)] as const),
+    );
+    return new Map(
+      entries.filter((entry): entry is readonly [string, ProjectDirectoryAvailability] =>
+        Boolean(entry[1]),
+      ),
+    );
   }
 
   async statRemoteFile(
@@ -169,6 +188,26 @@ pwd -P
     }
     return result.stdout.trim();
   }
+}
+
+async function inspectDirectory(
+  sftp: Awaited<ReturnType<SshConnectionPool["sftp"]>>,
+  path: string,
+) {
+  return new Promise<ProjectDirectoryAvailability | null>((resolve) => {
+    sftp.stat(path, (error, stats) => {
+      if (error) {
+        resolve(isMissingSftpPath(error) ? "missing" : null);
+        return;
+      }
+      resolve(stats.isDirectory() ? "available" : "missing");
+    });
+  });
+}
+
+function isMissingSftpPath(error: unknown) {
+  const code = (error as { code?: unknown })?.code;
+  return code === 2 || code === "ENOENT";
 }
 
 function directoryResult(path: string, source: FileEntryWithStats[]) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5,6 +5,7 @@ export type {
   HostUpdateInput,
   ProjectCreateInput,
   ProjectRecord,
+  ProjectDirectoryAvailability,
   ProjectUpdateInput,
   RpcEnvelope,
   GatewayEvent,

--- a/shared/types/records.ts
+++ b/shared/types/records.ts
@@ -25,6 +25,8 @@ export interface ProjectRecord {
   updatedAt: string;
 }
 
+export type ProjectDirectoryAvailability = "available" | "missing";
+
 export interface HostCreateInput {
   name: string;
   sshHost: string;

--- a/tests/e2e/remote-host-project.spec.ts
+++ b/tests/e2e/remote-host-project.spec.ts
@@ -209,7 +209,8 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
 
   await page.getByTestId(`host-button-${host.id}`).click();
   await expect(page.getByTestId(`project-button-${project.id}`)).toBeVisible();
-  const updatedProjectPath = `${remote.projectPath}/nested-workdir-${Date.now()}`;
+  const updatedProjectPath = `/home/${remote.username}/nested-workdir-${Date.now()}`;
+  await execRemoteSsh(remote, `mkdir -p '${updatedProjectPath}'`);
   const editProjectResponsePromise = page.waitForResponse(
     (response) =>
       response.url().endsWith(`/api/projects/${project.id}`) &&
@@ -234,6 +235,64 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
   const deleteProjectResponse = await deleteProjectResponsePromise;
   expect(deleteProjectResponse.ok(), await deleteProjectResponse.text()).toBe(true);
   await expect(page.getByTestId(`project-button-${project.id}`)).toBeHidden();
+});
+
+test("groups projects whose remote directories were deleted", async ({ page }) => {
+  const remote = await readRemoteEnv();
+  await openApp(page);
+
+  const host = await addRemoteHost(page, remote, `missing-project-host-${Date.now()}`);
+  const suffix = Date.now();
+  const availablePath = `/home/${remote.username}/available-project-${suffix}`;
+  const missingPath = `/home/${remote.username}/missing-project-${suffix}`;
+  const recoveredPath = `/home/${remote.username}/recovered-project-${suffix}`;
+  await execRemoteSsh(
+    remote,
+    `mkdir -p '${availablePath}' '${recoveredPath}'; rm -rf '${missingPath}'`,
+  );
+
+  const availableProject = await authenticatedFetch<any>(page, {
+    url: "/api/projects",
+    method: "POST",
+    body: { hostId: host.id, name: "Available Project", remotePath: availablePath },
+  });
+  const missingProject = await authenticatedFetch<any>(page, {
+    url: "/api/projects",
+    method: "POST",
+    body: { hostId: host.id, name: "Missing Project", remotePath: missingPath },
+  });
+
+  await reloadApp(page);
+  const missingToggle = page.getByTestId(`missing-projects-toggle-${host.id}`);
+  await expect(missingToggle).toBeVisible({ timeout: 120_000 });
+  await expect(page.getByTestId(`project-button-${availableProject.id}`)).toBeVisible();
+  await expect(page.getByTestId(`project-button-${missingProject.id}`)).toBeHidden();
+
+  await missingToggle.click();
+  const missingProjectButton = page.getByTestId(`project-button-${missingProject.id}`);
+  await expect(missingProjectButton).toBeVisible();
+  await expect(missingProjectButton).toHaveAttribute("data-project-missing", "true");
+  await missingProjectButton.click({ button: "right" });
+  const menu = page
+    .getByRole("menu")
+    .filter({ has: page.getByRole("menuitem", { name: /编辑项目/ }) });
+  await expect(menu.getByRole("menuitem", { name: /编辑项目/ })).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: /删除项目/ })).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: /新建/ })).toBeHidden();
+  await menu.getByRole("menuitem", { name: /编辑项目/ }).click();
+
+  const updateResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/projects/${missingProject.id}`) &&
+      response.request().method() === "PATCH",
+  );
+  await page.getByTestId("project-path-input").fill(recoveredPath);
+  await page.getByTestId("add-project-button").click();
+  expect((await updateResponse).ok()).toBe(true);
+
+  await expect(missingToggle).toBeHidden({ timeout: 30_000 });
+  await expect(missingProjectButton).toBeVisible();
+  await expect(missingProjectButton).toHaveAttribute("data-project-missing", "false");
 });
 
 async function verifyRemoteDirectoryBrowser(


### PR DESCRIPTION
## Summary
- inspect project directories through the shared host SFTP connection
- group missing projects in a collapsed section at the bottom of each host
- keep edit/delete management actions and restore projects after a valid path update

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e (47 passed)