### PR TITLE
Recover from deployment chunk load failures

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,9 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },
+  experimental: {
+    emitRouteChunkError: "automatic-immediate",
+  },
   css: ["~/assets/css/tailwind.css"],
   modules: [
     "@pinia/nuxt",


### PR DESCRIPTION
## Summary
- use Nuxt automatic-immediate chunk error recovery
- preserve Nuxt state while reloading after a failed dynamic import
- rely on Nuxt built-in reload TTL to prevent loops

## Verification
- pnpm lint
- pnpm build
- pnpm test:e2e (47 passed)