### PR TITLE
Align sidebar trigger with pinned heading

### DIFF
--- a/app/components/sidebar/GatewaySidebar.vue
+++ b/app/components/sidebar/GatewaySidebar.vue
@@ -50,14 +50,6 @@ function openEditProject(project: any) {
     v-bind="$attrs"
     class="relative flex min-h-0 flex-col border-r border-hairline bg-canvas-soft"
   >
-    <div class="flex h-12 shrink-0 items-center justify-end border-b border-hairline px-3">
-      <SidebarTrigger
-        data-testid="desktop-sidebar-collapse"
-        :title="$t('app.hideSidebar')"
-        :aria-label="$t('app.hideSidebar')"
-      />
-    </div>
-
     <div class="flex min-h-0 flex-1 overflow-hidden px-3 py-3">
       <SidebarScrollArea>
         <div class="space-y-4 pr-1">
@@ -77,7 +69,16 @@ function openEditProject(project: any) {
             @submit-rename="threadRename.submitRename"
             @rename-keydown="threadRename.handleRenameKeydown"
             @update:rename-value="threadRename.renameValue.value = $event"
-          />
+          >
+            <template #header-action>
+              <SidebarTrigger
+                data-testid="desktop-sidebar-collapse"
+                class="-mr-1 size-7"
+                :title="$t('app.hideSidebar')"
+                :aria-label="$t('app.hideSidebar')"
+              />
+            </template>
+          </PinnedThreadList>
 
           <HostTree
             :hosts="sidebarTree.hosts.value"

--- a/app/components/sidebar/PinnedThreadList.vue
+++ b/app/components/sidebar/PinnedThreadList.vue
@@ -37,9 +37,12 @@ function isSelectedPinnedThread(thread: any) {
 </script>
 
 <template>
-  <section v-if="threads.length" class="flex flex-col">
-    <div class="px-2 pb-2 text-sm text-ink-muted">{{ $t("app.pinned") }}</div>
-    <div class="space-y-1">
+  <section class="flex flex-col">
+    <div class="flex h-8 items-center justify-between gap-2 px-2 pb-2 text-sm text-ink-muted">
+      <span>{{ $t("app.pinned") }}</span>
+      <slot name="header-action" />
+    </div>
+    <div v-if="threads.length" class="space-y-1">
       <ThreadRow
         v-for="thread in threads"
         :key="pinnedThreadKey(thread)"


### PR DESCRIPTION
## Summary
- move the desktop collapse trigger into the pinned threads heading
- remove the standalone sidebar toolbar row
- keep the trigger available when the pinned list is empty

## Verification
- pnpm lint
- pnpm test:e2e -- tests/e2e/sidebar-tree.spec.ts (3 passed)