### PR TITLE
fix: preserve cached thread history depth

### DIFF
--- a/app/components/chat/chat-workspace-state.ts
+++ b/app/components/chat/chat-workspace-state.ts
@@ -1,5 +1,6 @@
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
+import { threadTurnsFromHistory } from "~~/shared/thread-history/shape";
 import type { useGatewayStore } from "@/stores/gateway";
 
 export function useChatWorkspaceState(store: ReturnType<typeof useGatewayStore>) {
@@ -11,7 +12,7 @@ export function useChatWorkspaceState(store: ReturnType<typeof useGatewayStore>)
       history: refs.history.value,
     }),
   );
-  const historyTurns = computed(() => turnsFromHistory(refs.history.value));
+  const historyTurns = computed(() => threadTurnsFromHistory(refs.history.value));
   const threadItems = computed(() => historyTurns.value.flatMap((turn: any) => turn.items || []));
   const openingThread = computed(
     () =>
@@ -41,11 +42,6 @@ export function useChatWorkspaceState(store: ReturnType<typeof useGatewayStore>)
     followKey,
     canOpenTerminal: computed(() => Boolean(refs.selectedHostId.value)),
   };
-}
-
-function turnsFromHistory(history: unknown) {
-  const value = history as any;
-  return value?.thread?.turns || value?.turns || [];
 }
 
 function isSelectedThreadViewReady(input: {

--- a/app/components/thread/ThreadVirtualTimeline.vue
+++ b/app/components/thread/ThreadVirtualTimeline.vue
@@ -80,8 +80,8 @@ watch(
     @reach-start="handleReachStart"
     @user-detached-change="handleUserDetachedChange"
   >
-    <template #overlay>
-      <div v-if="olderTurnsCursor" class="pointer-events-auto flex justify-center pt-2">
+    <template #overlay="{ visible }">
+      <div v-if="olderTurnsCursor && visible" class="pointer-events-auto flex justify-center pt-2">
         <Button
           data-testid="load-older-turns-button"
           variant="outline"

--- a/app/components/thread/VirtualTimelineViewport.vue
+++ b/app/components/thread/VirtualTimelineViewport.vue
@@ -22,6 +22,7 @@ const emit = defineEmits<{
 
 const scrollFrameRef = ref<InstanceType<typeof ChatVirtualScrollFrame> | null>(null);
 const threshold = 80;
+const startControlsVisible = ref(false);
 
 const chatVirtualizer = useChatVirtualizer({
   count: () => props.rows.length,
@@ -34,7 +35,9 @@ const chatVirtualizer = useChatVirtualizer({
     // A short chat is simultaneously at the top and bottom. Only interpret
     // top proximity as history intent after explicit upward input detached the
     // outer timeline; otherwise initial bottom alignment races background top-up.
-    if (chatVirtualizer.userDetached.value && viewport.scrollTop <= 80) {
+    const reachedStart = chatVirtualizer.userDetached.value && viewport.scrollTop <= threshold;
+    startControlsVisible.value = reachedStart;
+    if (reachedStart) {
       emit("reachStart");
     }
   },
@@ -96,6 +99,7 @@ watch(documentVisibility, (visibility, previous) => {
 watch(
   () => props.followKey,
   () => {
+    startControlsVisible.value = false;
     chatVirtualizer.followContentChange();
   },
   { flush: "post" },
@@ -104,6 +108,7 @@ watch(
 watch(
   () => chatVirtualizer.userDetached.value,
   (detached) => {
+    if (!detached) startControlsVisible.value = false;
     emit("userDetachedChange", detached);
   },
   { immediate: true },
@@ -134,7 +139,7 @@ defineExpose({ resetFollowLatest });
     @viewport-ready="handleViewportReady"
   >
     <div class="pointer-events-none sticky top-0 z-10 h-0">
-      <slot name="overlay" />
+      <slot name="overlay" :visible="startControlsVisible" />
     </div>
     <!--
       Keep vertical spacing inside measured rows. Padding around TanStack's

--- a/app/stores/gateway/actions/thread-open.ts
+++ b/app/stores/gateway/actions/thread-open.ts
@@ -1,5 +1,6 @@
 import type { ComposerTurnOptions } from "~~/shared/types";
 import { INITIAL_TURN_PAGE_LIMIT } from "~~/shared/config";
+import { threadTurnsFromHistory } from "~~/shared/thread-history/shape";
 import { useGatewayNavigationStore } from "@/stores/gateway-navigation";
 import { useGatewayRealtimeStore } from "@/stores/gateway-realtime";
 import type { GatewayStoreContext } from "../types";
@@ -91,6 +92,10 @@ export function createThreadOpenActions(ctx: GatewayStoreContext) {
       activatePendingThreadView(ctx, targetHostId, targetProjectId, threadId);
       void ctx.ensureSelectedHostModels();
       if (ctx.restoreThreadView(targetHostId, threadId)) {
+        const cachedTurnLimit = Math.max(
+          INITIAL_TURN_PAGE_LIMIT,
+          threadTurnsFromHistory(ctx.state.history).length,
+        );
         ctx.rememberOpenThread(threadId);
         ctx.syncSelectedRoute({ replace: context?.replaceRoute });
         useGatewayRealtimeStore().connectThreadEvents();
@@ -104,6 +109,7 @@ export function createThreadOpenActions(ctx: GatewayStoreContext) {
           replaceRoute: context?.replaceRoute,
           showLoading: false,
           scrollToLatest: false,
+          limit: cachedTurnLimit,
         });
         return;
       }
@@ -277,6 +283,7 @@ async function syncOpenThreadFromServer(
     replaceRoute?: boolean;
     showLoading: boolean;
     scrollToLatest?: boolean;
+    limit?: number;
   },
 ) {
   if (input.showLoading) {
@@ -288,6 +295,7 @@ async function syncOpenThreadFromServer(
       hostId: input.hostId,
       projectId: input.projectId,
       threadId: input.threadId,
+      limit: input.limit,
     });
     if (!ctx.isCurrentViewTransition(input.viewEpoch) || isOlderSnapshot(ctx, result.lastEventId)) {
       return;

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -1,5 +1,6 @@
 import type { HostRecord } from "~~/shared/types";
 import { INITIAL_TURN_PAGE_LIMIT } from "~~/shared/config";
+import { threadTurnsFromHistory } from "~~/shared/thread-history/shape";
 import {
   runtimeStatusFromSnapshotState,
   runtimeStatusFromThreadState,
@@ -17,7 +18,10 @@ import type { ThreadOpenSnapshot } from "./types";
 import { currentGatewayUserId } from "../state/memory";
 
 export class ThreadOpenService {
-  private readonly pendingRefreshes = new Map<string, Promise<ReturnTypeResult>>();
+  private readonly pendingRefreshes = new Map<
+    string,
+    { limit: number; promise: Promise<ReturnTypeResult> }
+  >();
 
   constructor(private readonly registry: ControllerRegistry) {}
 
@@ -43,13 +47,25 @@ export class ThreadOpenService {
         });
         return this.refreshThreadState(host, threadId, projectId, limit);
       }
-      return this.snapshotResult(host, threadId, projectId, cachedSnapshot);
+      if (snapshotSatisfiesTurnLimit(cachedSnapshot, limit)) {
+        return this.snapshotResult(host, threadId, projectId, cachedSnapshot);
+      }
+      runtimeLog("thread cache depth refresh", {
+        hostId: host.id,
+        threadId,
+        cachedTurns: threadTurnsFromHistory(cachedSnapshot.history).length,
+        requestedTurns: limit,
+      });
+      return this.refreshThreadState(host, threadId, projectId, limit);
     }
 
     const controller = await this.registry.getController(host, threadId);
     const connectedSnapshot = controller.getOpenSnapshot();
     if (connectedSnapshot) {
-      return this.snapshotResult(host, threadId, projectId, connectedSnapshot);
+      if (snapshotSatisfiesTurnLimit(connectedSnapshot, limit)) {
+        return this.snapshotResult(host, threadId, projectId, connectedSnapshot);
+      }
+      return this.refreshThreadState(host, threadId, projectId, limit);
     }
 
     runtimeLog("thread cache miss", {
@@ -110,18 +126,28 @@ export class ThreadOpenService {
     threadId: string,
     projectId: number | null,
     limit = INITIAL_TURN_PAGE_LIMIT,
-  ) {
+  ): Promise<ReturnTypeResult> {
     const key = refreshKey(host.id, threadId);
-    let pending = this.pendingRefreshes.get(key);
-    if (!pending) {
-      pending = this.performThreadStateRefresh(host, threadId, projectId, limit).finally(() => {
-        if (this.pendingRefreshes.get(key) === pending) {
-          this.pendingRefreshes.delete(key);
-        }
-      });
-      this.pendingRefreshes.set(key, pending);
+    const pending = this.pendingRefreshes.get(key);
+    if (pending) {
+      // A wider resume may reuse an equal/wider in-flight request, but it must
+      // never inherit a narrower one. Wait for the narrow refresh to settle,
+      // then retry so the server cache monotonically expands to the requested
+      // page depth instead of racing two snapshots into the same store entry.
+      if (pending.limit >= limit) return pending.promise;
+      await pending.promise;
+      return this.refreshThreadState(host, threadId, projectId, limit);
     }
-    return pending;
+
+    const promise = this.performThreadStateRefresh(host, threadId, projectId, limit);
+    this.pendingRefreshes.set(key, { limit, promise });
+    try {
+      return await promise;
+    } finally {
+      if (this.pendingRefreshes.get(key)?.promise === promise) {
+        this.pendingRefreshes.delete(key);
+      }
+    }
   }
 
   private async performThreadStateRefresh(
@@ -219,6 +245,13 @@ export class ThreadOpenService {
 }
 
 type ReturnTypeResult = Awaited<ReturnType<ThreadOpenService["performThreadStateRefresh"]>>;
+
+function snapshotSatisfiesTurnLimit(snapshot: ThreadOpenSnapshot, limit: number) {
+  return (
+    threadTurnsFromHistory(snapshot.history).length >= limit ||
+    snapshot.turnsPage.nextCursor === null
+  );
+}
 
 function refreshKey(hostId: number, threadId: string) {
   const userId = currentGatewayUserId();

--- a/shared/thread-history/shape.ts
+++ b/shared/thread-history/shape.ts
@@ -1,5 +1,15 @@
 import type { ThreadHistoryState, ThreadHistoryTurn } from "./types";
 
+export function threadTurnsFromHistory(history: unknown): ThreadHistoryTurn[] {
+  if (!history || typeof history !== "object") return [];
+  const record = history as Record<string, unknown>;
+  const thread =
+    record.thread && typeof record.thread === "object"
+      ? (record.thread as Record<string, unknown>)
+      : record;
+  return Array.isArray(thread.turns) ? (thread.turns as ThreadHistoryTurn[]) : [];
+}
+
 export function ensureHistoryThread(history: unknown, currentThread: unknown, threadId: string) {
   const historyRecord =
     history && typeof history === "object" ? (history as Record<string, unknown>) : null;

--- a/tests/e2e/helpers/gateway-store.ts
+++ b/tests/e2e/helpers/gateway-store.ts
@@ -26,6 +26,7 @@ interface SeedGatewayThreadInput {
 
 interface MockThreadSnapshotInput {
   hostId?: number;
+  responseDelayMs?: number;
   snapshots: Record<
     string,
     {
@@ -105,6 +106,7 @@ export async function installRealtimeThreadSnapshotMock(
       throw new Error("Unable to locate gateway realtime Pinia store");
     }
     realtime.connected = true;
+    (window as any).__threadActivateRequests = [];
     realtime.socket = {
       readyState: WebSocket.OPEN,
       send(raw: string) {
@@ -112,6 +114,7 @@ export async function installRealtimeThreadSnapshotMock(
         if (message.type !== "thread.activate") {
           return;
         }
+        (window as any).__threadActivateRequests.push(message);
         const snapshot = input.snapshots[String(message.threadId)];
         if (!snapshot) {
           throw new Error(`Missing mocked thread snapshot for ${message.threadId}`);
@@ -133,10 +136,14 @@ export async function installRealtimeThreadSnapshotMock(
             recentEvents: snapshot.recentEvents ?? [],
             lastEventId: snapshot.lastEventId ?? 0,
           });
-        }, 0);
+        }, input.responseDelayMs ?? 0);
       },
     };
   }, input);
+}
+
+export async function threadActivateRequests(page: Page) {
+  return page.evaluate(() => (window as any).__threadActivateRequests ?? []);
 }
 
 export async function appendAgentStreamLines(

--- a/tests/e2e/thread-scroll-behavior.spec.ts
+++ b/tests/e2e/thread-scroll-behavior.spec.ts
@@ -5,7 +5,9 @@ import {
   appendCommandOutputLines,
   appendFileDiffLines,
   completeTurnWithFinalAgentMessage,
+  installRealtimeThreadSnapshotMock,
   seedGatewayThread,
+  threadActivateRequests,
 } from "./helpers/gateway-store";
 import {
   captureTextAnchor,
@@ -51,6 +53,7 @@ test("opened threads render two turns first and then top up to five turns", asyn
 
   await expect(page.getByText("background turn 004")).toBeVisible();
   await expect(page.getByText("background turn 005")).toBeVisible();
+  await expect(page.getByTestId("load-older-turns-button")).toHaveCount(0);
   await expect
     .poll(() => threadTurnsLoadRequests(page).then((requests) => requests.length))
     .toBe(1);
@@ -64,6 +67,62 @@ test("opened threads render two turns first and then top up to five turns", asyn
   expect(requests).toHaveLength(1);
   expect(requests[0]).toMatchObject({ type: "thread.turns.load", limit: 3 });
   expect(httpTurnsRequests()).toBe(0);
+});
+
+test("same-page thread switches retain the loaded history depth", async ({ page }) => {
+  await openApp(page);
+  const firstThreadId = "e2e-cached-depth-first";
+  const secondThreadId = "e2e-cached-depth-second";
+  const firstHistory = {
+    thread: { id: firstThreadId, turns: buildTextTurns(1, 5, "cached first turn") },
+  };
+  const secondHistory = {
+    thread: { id: secondThreadId, turns: buildTextTurns(1, 5, "cached second turn") },
+  };
+  await installRealtimeThreadSnapshotMock(page, {
+    responseDelayMs: 120,
+    snapshots: {
+      [firstThreadId]: {
+        thread: { id: firstThreadId, name: "Cached First" },
+        history: firstHistory,
+        projectId: 1,
+      },
+      [secondThreadId]: {
+        thread: { id: secondThreadId, name: "Cached Second" },
+        history: secondHistory,
+        projectId: 1,
+      },
+    },
+  });
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId: firstThreadId,
+    currentThread: { id: firstThreadId, name: "Cached First" },
+    history: firstHistory,
+    threads: [
+      { id: firstThreadId, name: "Cached First", updatedAt: 2 },
+      { id: secondThreadId, name: "Cached Second", updatedAt: 1 },
+    ],
+    threadViews: {
+      [`1:${firstThreadId}`]: cachedThreadView(firstThreadId, firstHistory),
+      [`1:${secondThreadId}`]: cachedThreadView(secondThreadId, secondHistory),
+    },
+  });
+
+  await page.getByTestId(`thread-button-${secondThreadId}`).click();
+  await expect(page.getByText("cached second turn 005")).toBeVisible();
+  await page.getByTestId(`thread-button-${firstThreadId}`).click();
+  await expect(page.getByText("cached first turn 005")).toBeVisible();
+  await startTimelineRowCountTracking(page);
+
+  await expect.poll(() => threadActivateRequests(page).then((requests) => requests.length)).toBe(2);
+  await page.waitForTimeout(180);
+  const rowCounts = await stopTimelineRowCountTracking(page);
+  expect(Math.min(...rowCounts), JSON.stringify(rowCounts)).toBe(5);
+  expect(await threadActivateRequests(page)).toEqual([
+    expect.objectContaining({ type: "thread.activate", threadId: secondThreadId, limit: 5 }),
+    expect.objectContaining({ type: "thread.activate", threadId: firstThreadId, limit: 5 }),
+  ]);
 });
 
 test("streaming output stays pinned when the user is already at the latest content", async ({
@@ -256,6 +315,22 @@ function buildMeasuredTurns(threadId: string, lineCount: number) {
       ],
     },
   ];
+}
+
+function cachedThreadView(threadId: string, history: unknown) {
+  return {
+    hostId: 1,
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId },
+    history,
+    events: [],
+    olderTurnsCursor: null,
+    newerTurnsCursor: null,
+    lastEventId: 0,
+    loading: false,
+    error: null,
+  };
 }
 
 async function visibleTimelineRowsDoNotOverlap(page: Page) {
@@ -789,6 +864,24 @@ async function waitForAnimationFrames(page: Page, count: number) {
       }),
     count,
   );
+}
+
+async function startTimelineRowCountTracking(page: Page) {
+  await page.getByTestId("chat-scroll-area").evaluate((root) => {
+    const count = () => root.querySelectorAll('[data-row-key*=":turn-"]').length;
+    const samples = [count()];
+    const observer = new MutationObserver(() => samples.push(count()));
+    observer.observe(root, { childList: true, subtree: true });
+    (window as any).__timelineRowCountSamples = samples;
+    (window as any).__timelineRowCountObserver = observer;
+  });
+}
+
+async function stopTimelineRowCountTracking(page: Page) {
+  return page.evaluate(() => {
+    (window as any).__timelineRowCountObserver?.disconnect();
+    return ((window as any).__timelineRowCountSamples ?? []) as number[];
+  });
 }
 
 function frameSpread(samples: number[]) {


### PR DESCRIPTION
## Summary
- retain the loaded Pinia thread history depth when switching threads in the same page
- make backend thread snapshots depth-aware and serialize wider refresh requests behind narrower in-flight work
- show the load-older control only after explicit upward detachment at the history start

## Validation
- `pnpm lint`
- `pnpm test:e2e -- tests/e2e/thread-scroll-behavior.spec.ts` (10 passed)
- `pnpm test:e2e` (52 passed)
- `git diff --check`