### PR TITLE
fix: keep sidebar statuses visible

### DIFF
--- a/app/components/sidebar/GatewaySidebar.vue
+++ b/app/components/sidebar/GatewaySidebar.vue
@@ -65,7 +65,7 @@ function openEditProject(project: any) {
     />
     <div class="flex min-h-0 flex-1 overflow-hidden px-3 py-3">
       <SidebarScrollArea>
-        <div class="space-y-4 pr-1">
+        <div class="min-w-0 max-w-full space-y-4 overflow-hidden pr-1">
           <PinnedThreadList
             :threads="sidebarTree.pinnedThreads.value"
             :hosts="sidebarTree.hosts.value"

--- a/app/components/sidebar/HostStatusIndicator.vue
+++ b/app/components/sidebar/HostStatusIndicator.vue
@@ -27,7 +27,7 @@ const iconClass = computed(() => ({
 
 <template>
   <span
-    class="ml-auto inline-flex size-4 shrink-0 items-center justify-center"
+    class="inline-flex size-4 shrink-0 items-center justify-center"
     :class="hostConnectionClass(status)"
     :title="label"
     :aria-label="label"

--- a/app/components/sidebar/HostTree.vue
+++ b/app/components/sidebar/HostTree.vue
@@ -63,17 +63,17 @@ function hostConnectionStatus(hostId: number) {
 </script>
 
 <template>
-  <section class="flex flex-col">
+  <section class="flex min-w-0 max-w-full flex-col overflow-hidden">
     <div class="px-2 pb-2 text-sm text-ink-muted">{{ $t("app.hosts") }}</div>
-    <div class="space-y-1">
-      <div v-for="host in hosts" :key="host.id" class="rounded-lg">
+    <div class="min-w-0 space-y-1 overflow-hidden">
+      <div v-for="host in hosts" :key="host.id" class="min-w-0 overflow-hidden rounded-lg">
         <ContextMenu>
           <ContextMenuTrigger as-child>
             <Button
               :data-testid="`host-button-${host.id}`"
               v-bind="longPressHandlers"
               variant="ghost"
-              class="h-11 w-full justify-start gap-2 rounded-lg px-3 text-left text-[0.9375rem] font-normal hover:bg-surface"
+              class="h-11 w-full min-w-0 justify-start gap-2 overflow-hidden rounded-lg px-3 text-left text-[0.9375rem] font-normal hover:bg-surface"
               :class="selectedRowClass(host.id === selectedHostId)"
               @click="emit('selectHost', host.id)"
             >
@@ -83,11 +83,14 @@ function hostConnectionStatus(hostId: number) {
               />
               <ChevronRightIcon v-else class="size-3.5 shrink-0 text-ink-muted" />
               <ServerIcon class="size-4 shrink-0" />
-              <SidebarRowLabel :title="host.name" :subtitle="host.sshHost" />
-              <HostStatusIndicator
-                :status="hostConnectionStatus(host.id).status"
-                :label="hostConnectionStatus(host.id).message"
-              />
+              <SidebarRowLabel :title="host.name" :subtitle="host.sshHost">
+                <template #trailing>
+                  <HostStatusIndicator
+                    :status="hostConnectionStatus(host.id).status"
+                    :label="hostConnectionStatus(host.id).message"
+                  />
+                </template>
+              </SidebarRowLabel>
             </Button>
           </ContextMenuTrigger>
           <ContextMenuContent :collision-padding="12" prioritize-position class="w-44">
@@ -105,11 +108,14 @@ function hostConnectionStatus(hostId: number) {
           </ContextMenuContent>
         </ContextMenu>
 
-        <div v-if="expandedHostIds.has(host.id)" class="mt-1 space-y-1 pl-5">
+        <div
+          v-if="expandedHostIds.has(host.id)"
+          class="mt-1 min-w-0 space-y-1 overflow-hidden pl-5"
+        >
           <div
             v-for="project in availableProjectsByHost.get(host.id) ?? []"
             :key="project.id"
-            class="space-y-1"
+            class="min-w-0 space-y-1 overflow-hidden"
           >
             <SidebarProjectRow
               :project="project"
@@ -122,7 +128,10 @@ function hostConnectionStatus(hostId: number) {
               @start-thread="emit('startThreadInProject', project)"
             />
 
-            <div v-if="expandedProjectIds.has(project.id)" class="space-y-1 pl-7">
+            <div
+              v-if="expandedProjectIds.has(project.id)"
+              class="min-w-0 space-y-1 overflow-hidden pl-7"
+            >
               <template v-if="project.id === selectedProjectId && projectThreads.length">
                 <ThreadRow
                   v-for="thread in projectThreads"

--- a/app/components/sidebar/PinnedThreadList.vue
+++ b/app/components/sidebar/PinnedThreadList.vue
@@ -37,7 +37,7 @@ function isSelectedPinnedThread(thread: any) {
 </script>
 
 <template>
-  <section class="flex flex-col">
+  <section class="flex min-w-0 max-w-full flex-col overflow-hidden">
     <div class="flex h-8 items-center justify-between gap-2 px-2 pb-2 text-sm text-ink-muted">
       <span>{{ $t("app.pinned") }}</span>
       <slot name="header-action" />

--- a/app/components/sidebar/SidebarProjectRow.vue
+++ b/app/components/sidebar/SidebarProjectRow.vue
@@ -48,7 +48,7 @@ function selectProject(event: MouseEvent) {
         :data-testid="`project-button-${project.id}`"
         v-bind="longPressHandlers"
         variant="ghost"
-        class="h-10 w-full justify-start gap-2 rounded-lg px-3 text-[0.9375rem] font-normal hover:bg-surface"
+        class="h-10 w-full min-w-0 justify-start gap-2 overflow-hidden rounded-lg px-3 text-[0.9375rem] font-normal hover:bg-surface"
         :class="[selectedRowClass(selected), missing ? 'text-ink-faint' : '']"
         :data-project-missing="missing ? 'true' : 'false'"
         @click="selectProject"
@@ -63,8 +63,11 @@ function selectProject(event: MouseEvent) {
         <SidebarRowLabel
           :title="project.name"
           :subtitle="missing ? $t('app.projectDirectoryMissing') : undefined"
-        />
-        <span v-if="!missing" class="ml-auto size-2 shrink-0 rounded-full bg-accent-green" />
+        >
+          <template v-if="!missing" #trailing>
+            <span class="size-2 shrink-0 rounded-full bg-accent-green" />
+          </template>
+        </SidebarRowLabel>
       </Button>
     </ContextMenuTrigger>
     <ContextMenuContent :collision-padding="12" prioritize-position class="w-44">

--- a/app/components/sidebar/SidebarRowLabel.vue
+++ b/app/components/sidebar/SidebarRowLabel.vue
@@ -6,13 +6,18 @@ defineProps<{
 </script>
 
 <template>
-  <span class="min-w-0 flex-1 pr-2 text-left">
-    <span class="flex w-full min-w-0 items-center gap-1.5">
-      <slot name="title-prefix" />
-      <span class="block min-w-0 flex-1 truncate">{{ title }}</span>
+  <span class="flex min-w-0 flex-1 items-center overflow-hidden text-left">
+    <span class="min-w-0 flex-1 overflow-hidden pr-2">
+      <span class="flex w-full min-w-0 items-center gap-1.5">
+        <slot name="title-prefix" />
+        <span class="block min-w-0 flex-1 truncate" :title="title">{{ title }}</span>
+      </span>
+      <span v-if="subtitle" class="block min-w-0 truncate text-xs text-ink-muted">
+        {{ subtitle }}
+      </span>
     </span>
-    <span v-if="subtitle" class="block min-w-0 truncate text-xs text-ink-muted">
-      {{ subtitle }}
+    <span v-if="$slots.trailing" class="inline-flex size-4 shrink-0 items-center justify-center">
+      <slot name="trailing" />
     </span>
   </span>
 </template>

--- a/app/components/sidebar/SidebarScrollArea.vue
+++ b/app/components/sidebar/SidebarScrollArea.vue
@@ -3,8 +3,19 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 </script>
 
 <template>
-  <ScrollArea class="sidebar-scroll-area min-h-0 flex-1">
-    <slot />
+  <ScrollArea
+    data-testid="sidebar-scroll-area"
+    class="sidebar-scroll-area min-h-0 min-w-0 flex-1"
+    viewport-class="overflow-x-hidden"
+  >
+    <!--
+      Reka's viewport uses an intrinsic-size content wrapper. Keep a bounded
+      application wrapper inside it so an expanded tree's unbroken filename or
+      thread title cannot widen every row and push trailing statuses offscreen.
+    -->
+    <div class="w-full min-w-0 max-w-full overflow-hidden">
+      <slot />
+    </div>
   </ScrollArea>
 </template>
 

--- a/app/components/sidebar/ThreadRow.vue
+++ b/app/components/sidebar/ThreadRow.vue
@@ -1,12 +1,5 @@
 <script setup lang="ts">
-import {
-  BellDotIcon,
-  CheckCircle2Icon,
-  CircleAlertIcon,
-  CirclePauseIcon,
-  Loader2Icon,
-  StarIcon,
-} from "@lucide/vue";
+import { StarIcon } from "@lucide/vue";
 import { computed } from "vue";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,8 +11,9 @@ import {
 import { Input } from "@/components/ui/input";
 import type { ThreadRuntimeStatus } from "@/stores/gateway";
 import { titleForThread } from "@/stores/gateway/thread-utils/identity";
-import { selectedRowClass, statusClass, statusLabelKey } from "./sidebar-utils";
+import { selectedRowClass } from "./sidebar-utils";
 import SidebarRowLabel from "./SidebarRowLabel.vue";
+import ThreadStatusIndicator from "./ThreadStatusIndicator.vue";
 
 const props = defineProps<{
   thread: any;
@@ -45,26 +39,6 @@ const emit = defineEmits<{
 }>();
 
 const pressHandlers = computed(() => props.longPressHandlers ?? {});
-const { t } = useI18n();
-
-const statusIconByStatus = {
-  running: Loader2Icon,
-  completedUnviewed: BellDotIcon,
-  completed: CheckCircle2Icon,
-  failed: CircleAlertIcon,
-  interrupted: CirclePauseIcon,
-} as const;
-
-const displayStatus = computed(() =>
-  props.completionAttention ? "completedUnviewed" : props.status,
-);
-const statusLabel = computed(() => t(statusLabelKey(displayStatus.value)));
-const statusIcon = computed(
-  () => statusIconByStatus[displayStatus.value as keyof typeof statusIconByStatus] ?? null,
-);
-const statusIconClass = computed(() => ({
-  "animate-spin": props.status === "running",
-}));
 </script>
 
 <template>
@@ -86,7 +60,7 @@ const statusIconClass = computed(() => ({
         v-bind="pressHandlers"
         :data-selected="selected ? 'true' : 'false'"
         variant="ghost"
-        class="h-auto min-h-9 w-full justify-between rounded-lg px-3 py-2 text-sm font-normal hover:bg-surface"
+        class="h-auto min-h-9 w-full min-w-0 justify-start overflow-hidden rounded-lg px-3 py-2 text-sm font-normal hover:bg-surface"
         :class="selectedRowClass(selected)"
         @click="emit('open')"
       >
@@ -97,15 +71,10 @@ const statusIconClass = computed(() => ({
               class="size-3.5 shrink-0 fill-current text-accent-orange"
             />
           </template>
+          <template #trailing>
+            <ThreadStatusIndicator :status="status" :completion-attention="completionAttention" />
+          </template>
         </SidebarRowLabel>
-        <span
-          class="ml-2 inline-flex size-4 shrink-0 items-center justify-center"
-          :class="statusClass(displayStatus)"
-          :aria-label="statusLabel"
-        >
-          <component :is="statusIcon" v-if="statusIcon" class="size-3.5" :class="statusIconClass" />
-          <span v-else class="size-2 rounded-full bg-current opacity-50" />
-        </span>
       </Button>
     </ContextMenuTrigger>
     <ContextMenuContent :collision-padding="12" prioritize-position class="w-40">

--- a/app/components/sidebar/ThreadStatusIndicator.vue
+++ b/app/components/sidebar/ThreadStatusIndicator.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import {
+  BellDotIcon,
+  CheckCircle2Icon,
+  CircleAlertIcon,
+  CirclePauseIcon,
+  Loader2Icon,
+} from "@lucide/vue";
+import { computed } from "vue";
+import type { ThreadRuntimeStatus } from "@/stores/gateway";
+import { statusClass, statusLabelKey } from "./sidebar-utils";
+
+const props = defineProps<{
+  status: ThreadRuntimeStatus;
+  completionAttention?: boolean;
+}>();
+
+const { t } = useI18n();
+const statusIconByStatus = {
+  running: Loader2Icon,
+  completedUnviewed: BellDotIcon,
+  completed: CheckCircle2Icon,
+  failed: CircleAlertIcon,
+  interrupted: CirclePauseIcon,
+} as const;
+const displayStatus = computed(() =>
+  props.completionAttention ? "completedUnviewed" : props.status,
+);
+const label = computed(() => t(statusLabelKey(displayStatus.value)));
+const icon = computed(
+  () => statusIconByStatus[displayStatus.value as keyof typeof statusIconByStatus] ?? null,
+);
+</script>
+
+<template>
+  <span
+    class="inline-flex size-4 shrink-0 items-center justify-center"
+    :class="statusClass(displayStatus)"
+    :aria-label="label"
+    :title="label"
+  >
+    <component
+      :is="icon"
+      v-if="icon"
+      class="size-3.5"
+      :class="{ 'animate-spin': status === 'running' }"
+    />
+    <span v-else class="size-2 rounded-full bg-current opacity-50" />
+  </span>
+</template>

--- a/tests/e2e/sidebar-tree.spec.ts
+++ b/tests/e2e/sidebar-tree.spec.ts
@@ -110,3 +110,86 @@ test("marks completed threads as needing review until they are opened", async ({
     page.getByTestId("thread-button-review-thread").getByLabel("已完成，待查看", { exact: true }),
   ).toBeHidden();
 });
+
+test("long expanded tree labels truncate without displacing trailing statuses", async ({
+  page,
+}) => {
+  await openApp(page);
+  const hostId = 103;
+  const projectId = 203;
+  const threadId = "long-sidebar-thread";
+  const longTitle = `Long thread ${"unbroken-segment-".repeat(18)}`;
+  await seedGatewayThread(page, {
+    hostId,
+    projectId,
+    threadId: null,
+    host: {
+      id: hostId,
+      name: `Long host ${"host-segment-".repeat(12)}`,
+      sshHost: "very-long-hostname.example.internal",
+      sshUser: "codex",
+    },
+    project: {
+      id: projectId,
+      hostId,
+      name: `Long project ${"project-segment-".repeat(12)}`,
+      remotePath: "/workspace/sidebar-layout",
+    },
+    threads: [{ id: threadId, name: longTitle, pinned: false, updatedAt: 1 }],
+  });
+  await installRealtimeThreadSnapshotMock(page, {
+    hostId,
+    snapshots: {
+      [threadId]: {
+        thread: { id: threadId, name: longTitle },
+        history: { thread: { id: threadId, turns: [] } },
+        projectId,
+        runtimeStatus: "running",
+      },
+    },
+  });
+  await page.evaluate(
+    ({ hostId, threadId }) => {
+      const app = (document.querySelector("#__nuxt") as any)?.__vue_app__;
+      const store = app?.config?.globalProperties?.$pinia?._s?.get("gateway");
+      store.hostConnectionStatuses = { [hostId]: { status: "connected" } };
+      store.setThreadStatus(hostId, threadId, "running");
+    },
+    { hostId, threadId },
+  );
+
+  await expect(page.getByTestId(`thread-button-${threadId}`)).toBeVisible();
+  await page.getByTestId(`thread-button-${threadId}`).click();
+  await expect(page.getByTestId(`thread-button-${threadId}`)).toHaveAttribute(
+    "data-selected",
+    "true",
+  );
+  await expect(page.getByTestId(`host-button-${hostId}`).getByLabel("已连接")).toBeVisible();
+  await expect(page.getByTestId(`thread-button-${threadId}`).getByLabel("运行中")).toBeVisible();
+
+  const metrics = await page.getByTestId("sidebar-scroll-area").evaluate((root, longTitle) => {
+    const viewport = root.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    const title = root.querySelector<HTMLElement>(`[title="${CSS.escape(longTitle)}"]`);
+    const statuses = Array.from(
+      root.querySelectorAll<HTMLElement>('[aria-label="已连接"], [aria-label="运行中"]'),
+    );
+    if (!viewport || !title || statuses.length !== 2)
+      throw new Error("Missing sidebar layout nodes");
+    const viewportRect = viewport.getBoundingClientRect();
+    return {
+      overflow: viewport.scrollWidth - viewport.clientWidth,
+      titleClipped: title.scrollWidth > title.clientWidth,
+      titleOverflow: getComputedStyle(title).textOverflow,
+      statusesInside: statuses.every((status) => {
+        const rect = status.getBoundingClientRect();
+        return rect.left >= viewportRect.left && rect.right <= viewportRect.right;
+      }),
+    };
+  }, longTitle);
+  expect(metrics).toEqual({
+    overflow: 0,
+    titleClipped: true,
+    titleOverflow: "ellipsis",
+    statusesInside: true,
+  });
+});


### PR DESCRIPTION
## Summary
- prevent expanded Host/Project/Thread trees from widening the vertical sidebar viewport
- centralize truncating labels and fixed trailing status slots across sidebar rows
- extract thread status rendering and preserve status visibility for long selected thread titles

## Validation
- `pnpm lint`
- `pnpm test:e2e -- tests/e2e/sidebar-tree.spec.ts` (4 passed)
- `pnpm test:e2e` (53 passed)
- `git diff --check`