### PR TITLE
feat: surface recently running threads

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -8,6 +8,7 @@ import { useGatewayStore } from "@/stores/gateway";
 import { useGatewayRealtimeStore } from "@/stores/gateway-realtime";
 import { useGatewayTerminalStore } from "@/stores/gateway-terminal";
 import { useGatewayThreadTurnsStore } from "@/stores/gateway-thread-turns";
+import { useGatewayThreadActivityStore } from "@/stores/gateway-thread-activity";
 import { useGatewayWorkspaceLayoutStore } from "@/stores/gateway-workspace-layout";
 import { titleForThread } from "@/stores/gateway/thread-utils/identity";
 
@@ -15,6 +16,7 @@ const store = useGatewayStore();
 const realtime = useGatewayRealtimeStore();
 const terminal = useGatewayTerminalStore();
 const threadTurns = useGatewayThreadTurnsStore();
+const threadActivity = useGatewayThreadActivityStore();
 const workspaceLayout = useGatewayWorkspaceLayoutStore();
 const auth = useAuthStore();
 const device = useDevice();
@@ -79,6 +81,7 @@ function resetClientSessionState() {
   store.resetState();
   terminal.resetState();
   threadTurns.resetState();
+  threadActivity.resetState();
   workspaceLayout.resetRuntimeState();
 }
 </script>

--- a/app/components/sidebar/GatewaySidebar.vue
+++ b/app/components/sidebar/GatewaySidebar.vue
@@ -17,10 +17,12 @@ import { useGatewayStore } from "@/stores/gateway";
 import AddProjectDialog from "./AddProjectDialog.vue";
 import HostTree from "./HostTree.vue";
 import PinnedThreadList from "./PinnedThreadList.vue";
+import RecentThreadList from "./RecentThreadList.vue";
 import SidebarScrollArea from "./SidebarScrollArea.vue";
 import { SidebarFooter } from "@/components/ui/sidebar";
 import { useSidebarTree } from "./useSidebarTree";
 import { useThreadRename } from "./useThreadRename";
+import { useRecentThreadActivity } from "./useRecentThreadActivity";
 import SidebarWorkspaceToolbar from "./SidebarWorkspaceToolbar.vue";
 
 const store = useGatewayStore();
@@ -32,6 +34,7 @@ const projectEditor = ref<{ host: any; project: any | null } | null>(null);
 const { longPressTriggered, longPressContextMenuHandlers } = useLongPressContextMenu();
 const sidebarTree = useSidebarTree(store, longPressTriggered);
 const threadRename = useThreadRename(store);
+const recentActivity = useRecentThreadActivity(store);
 const workspaceActions = useWorkspaceLaunchActions();
 
 defineOptions({
@@ -71,13 +74,28 @@ function openEditProject(project: any) {
             :hosts="sidebarTree.hosts.value"
             :selected-host-id="sidebarTree.selectedHostId.value"
             :selected-thread-id="sidebarTree.selectedThreadId.value"
-            :renaming-thread-id="threadRename.renamingThreadId.value"
+            :renaming-thread-key="threadRename.renamingThreadKey.value"
             :rename-value="threadRename.renameValue.value"
             :long-press-handlers="longPressContextMenuHandlers"
             :runtime-status="sidebarTree.pinnedRuntimeStatus"
             :completion-attention="sidebarTree.pinnedCompletionAttention"
             @open="sidebarTree.openPinnedThread"
             @unpin="store.setPinnedThread($event, false)"
+            @rename="threadRename.startInlineRename"
+            @submit-rename="threadRename.submitRename"
+            @rename-keydown="threadRename.handleRenameKeydown"
+            @update:rename-value="threadRename.renameValue.value = $event"
+          />
+
+          <RecentThreadList
+            :threads="recentActivity.recentThreads.value"
+            :selected-host-id="sidebarTree.selectedHostId.value"
+            :selected-thread-id="sidebarTree.selectedThreadId.value"
+            :renaming-thread-key="threadRename.renamingThreadKey.value"
+            :rename-value="threadRename.renameValue.value"
+            :long-press-handlers="longPressContextMenuHandlers"
+            @open="recentActivity.openRecentThread"
+            @pin="recentActivity.pinRecentThread"
             @rename="threadRename.startInlineRename"
             @submit-rename="threadRename.submitRename"
             @rename-keydown="threadRename.handleRenameKeydown"
@@ -96,7 +114,7 @@ function openEditProject(project: any) {
             :selected-project-id="sidebarTree.selectedProjectId.value"
             :selected-thread-id="sidebarTree.selectedThreadId.value"
             :host-connection-statuses="sidebarTree.hostConnectionStatuses.value"
-            :renaming-thread-id="threadRename.renamingThreadId.value"
+            :renaming-thread-key="threadRename.renamingThreadKey.value"
             :rename-value="threadRename.renameValue.value"
             :long-press-handlers="longPressContextMenuHandlers"
             :thread-runtime-status="sidebarTree.threadRuntimeStatus"

--- a/app/components/sidebar/HostTree.vue
+++ b/app/components/sidebar/HostTree.vue
@@ -33,7 +33,7 @@ const props = defineProps<{
   selectedProjectId: number | null;
   selectedThreadId: string | null;
   hostConnectionStatuses: Record<number, { status: string; message?: string | null }>;
-  renamingThreadId: string | null;
+  renamingThreadKey: string | null;
   renameValue: string;
   longPressHandlers?: Record<string, unknown>;
   threadRuntimeStatus: (hostId: number, threadId: string) => ThreadRuntimeStatus;
@@ -144,7 +144,7 @@ function hostConnectionStatus(hostId: number) {
                     threadCompletionAttention(project.hostId, String(thread.id))
                   "
                   :subtitle="formatRelative(thread.updatedAt)"
-                  :rename-active="renamingThreadId === String(thread.id)"
+                  :rename-active="renamingThreadKey === `${project.hostId}:${thread.id}`"
                   :rename-value="renameValue"
                   :pin-label="thread.pinned ? $t('app.unpinThread') : $t('app.pinThread')"
                   :long-press-handlers="longPressHandlers"
@@ -156,7 +156,7 @@ function hostConnectionStatus(hostId: number) {
                     })
                   "
                   @toggle-pin="emit('toggleThreadPin', String(thread.id), !thread.pinned)"
-                  @rename="emit('rename', thread)"
+                  @rename="emit('rename', { ...thread, hostId: project.hostId })"
                   @submit-rename="emit('submitRename')"
                   @rename-keydown="emit('renameKeydown', $event)"
                   @update:rename-value="emit('update:renameValue', $event)"

--- a/app/components/sidebar/PinnedThreadList.vue
+++ b/app/components/sidebar/PinnedThreadList.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
   hosts: any[];
   selectedHostId: number | null;
   selectedThreadId: string | null;
-  renamingThreadId: string | null;
+  renamingThreadKey: string | null;
   renameValue: string;
   longPressHandlers?: Record<string, unknown>;
   runtimeStatus: (thread: any) => any;
@@ -52,7 +52,7 @@ function isSelectedPinnedThread(thread: any) {
         :status="runtimeStatus(thread)"
         :completion-attention="completionAttention(thread)"
         :subtitle="subtitleForPinnedThread(thread) || formatRelative(thread.updatedAt)"
-        :rename-active="renamingThreadId === pinnedThreadId(thread)"
+        :rename-active="renamingThreadKey === pinnedThreadKey(thread)"
         :rename-value="renameValue"
         :pin-label="$t('app.unpinThread')"
         :long-press-handlers="longPressHandlers"

--- a/app/components/sidebar/RecentThreadList.vue
+++ b/app/components/sidebar/RecentThreadList.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import ThreadRow from "./ThreadRow.vue";
+import { formatRelative, threadKey } from "./sidebar-utils";
+import type { ThreadActivitySummary } from "@/stores/gateway-thread-activity";
+import type { ThreadRuntimeStatus } from "@/stores/gateway";
+
+type RecentThread = ThreadActivitySummary & {
+  id: string;
+  hostName: string | null;
+  status: ThreadRuntimeStatus;
+  completionAttention: boolean;
+};
+
+defineProps<{
+  threads: RecentThread[];
+  selectedHostId: number | null;
+  selectedThreadId: string | null;
+  renamingThreadKey: string | null;
+  renameValue: string;
+  longPressHandlers?: Record<string, unknown>;
+}>();
+
+const emit = defineEmits<{
+  open: [thread: RecentThread];
+  pin: [thread: RecentThread];
+  rename: [thread: RecentThread];
+  submitRename: [];
+  renameKeydown: [event: KeyboardEvent];
+  "update:renameValue": [value: string];
+}>();
+
+function subtitle(thread: RecentThread) {
+  return (
+    [thread.hostName, thread.projectName].filter(Boolean).join(" / ") ||
+    formatRelative(thread.updatedAt)
+  );
+}
+</script>
+
+<template>
+  <section v-if="threads.length" class="flex min-w-0 max-w-full flex-col overflow-hidden">
+    <div class="flex h-8 items-center px-2 pb-2 text-sm text-ink-muted">
+      {{ $t("app.recentlyRunning") }}
+    </div>
+    <div class="space-y-1">
+      <ThreadRow
+        v-for="thread in threads"
+        :key="threadKey(thread.hostId, thread.threadId)"
+        :thread="thread"
+        :test-id="`recent-thread-button-${thread.threadId}`"
+        :selected="thread.hostId === selectedHostId && thread.threadId === selectedThreadId"
+        :status="thread.status"
+        :completion-attention="thread.completionAttention"
+        :subtitle="subtitle(thread)"
+        :rename-active="renamingThreadKey === threadKey(thread.hostId, thread.threadId)"
+        :rename-value="renameValue"
+        :pin-label="$t('app.pinThread')"
+        :long-press-handlers="longPressHandlers"
+        @open="emit('open', thread)"
+        @toggle-pin="emit('pin', thread)"
+        @rename="emit('rename', thread)"
+        @submit-rename="emit('submitRename')"
+        @rename-keydown="emit('renameKeydown', $event)"
+        @update:rename-value="emit('update:renameValue', $event)"
+      />
+    </div>
+  </section>
+</template>

--- a/app/components/sidebar/useRecentThreadActivity.ts
+++ b/app/components/sidebar/useRecentThreadActivity.ts
@@ -1,0 +1,77 @@
+import { storeToRefs } from "pinia";
+import { computed } from "vue";
+import type { PinnedThreadRecord } from "~~/shared/types";
+import type { useGatewayStore } from "@/stores/gateway";
+import {
+  type ThreadActivitySummary,
+  useGatewayThreadActivityStore,
+} from "@/stores/gateway-thread-activity";
+import { pinnedKey } from "@/stores/gateway/thread-utils/identity";
+
+type GatewayStore = ReturnType<typeof useGatewayStore>;
+
+export function useRecentThreadActivity(gateway: GatewayStore) {
+  const activity = useGatewayThreadActivityStore();
+  const { summariesByKey, observedRunningThreadKeys } = storeToRefs(activity);
+  const { hosts, pinnedThreads, threadStatuses, unviewedCompletedThreadKeys } =
+    storeToRefs(gateway);
+
+  const recentThreads = computed(() => {
+    const pinnedKeys = new Set(
+      pinnedThreads.value.map((thread) => pinnedKey(thread.hostId, thread.threadId)),
+    );
+    const unviewedKeys = new Set(unviewedCompletedThreadKeys.value);
+    return observedRunningThreadKeys.value
+      .map((key) => summariesByKey.value[key])
+      .filter(
+        (thread): thread is ThreadActivitySummary =>
+          // app-server parentThreadId is the authoritative sub-agent marker.
+          // Sub-agents stay in their parent workspace rather than flooding this list.
+          thread !== undefined && !thread.parentThreadId && !pinnedKeys.has(keyFor(thread)),
+      )
+      .map((thread) => ({
+        ...thread,
+        id: thread.threadId,
+        hostName: hosts.value.find((host) => host.id === thread.hostId)?.name ?? null,
+        status: threadStatuses.value[keyFor(thread)] ?? "idle",
+        completionAttention: unviewedKeys.has(keyFor(thread)),
+      }))
+      .sort((left, right) => {
+        const runningOrder = Number(right.status === "running") - Number(left.status === "running");
+        return runningOrder || right.updatedAt - left.updatedAt;
+      });
+  });
+
+  function openRecentThread(thread: ThreadActivitySummary) {
+    void gateway.openThread(thread.threadId, {
+      hostId: thread.hostId,
+      projectId: thread.projectId,
+    });
+  }
+
+  function pinRecentThread(thread: ThreadActivitySummary) {
+    void gateway.setPinnedThread(toPinnedThread(thread), true);
+  }
+
+  return {
+    recentThreads,
+    openRecentThread,
+    pinRecentThread,
+  };
+}
+
+function keyFor(thread: ThreadActivitySummary) {
+  return pinnedKey(thread.hostId, thread.threadId);
+}
+
+function toPinnedThread(thread: ThreadActivitySummary): PinnedThreadRecord {
+  return {
+    hostId: thread.hostId,
+    projectId: thread.projectId,
+    threadId: thread.threadId,
+    title: thread.title,
+    subtitle: thread.cwd,
+    projectName: thread.projectName,
+    updatedAt: thread.updatedAt,
+  };
+}

--- a/app/components/sidebar/useThreadRename.ts
+++ b/app/components/sidebar/useThreadRename.ts
@@ -1,5 +1,5 @@
 import { storeToRefs } from "pinia";
-import { nextTick, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 import type { useGatewayStore } from "@/stores/gateway";
 import { titleForThread } from "@/stores/gateway/thread-utils/identity";
 
@@ -7,8 +7,12 @@ type GatewayStore = ReturnType<typeof useGatewayStore>;
 
 export function useThreadRename(store: GatewayStore) {
   const { threads, pinnedThreads } = storeToRefs(store);
-  const renamingThreadId = ref<string | null>(null);
+  const renameTarget = ref<{ hostId: number; threadId: string } | null>(null);
   const renameValue = ref("");
+  const renamingThreadKey = computed(() => {
+    const target = renameTarget.value;
+    return target ? `${target.hostId}:${target.threadId}` : null;
+  });
   const renameKeyHandlers: Record<string, (event: KeyboardEvent) => void> = {
     Escape: (event) => {
       event.preventDefault();
@@ -17,7 +21,10 @@ export function useThreadRename(store: GatewayStore) {
   };
 
   function startInlineRename(thread: any) {
-    renamingThreadId.value = String(thread.threadId || thread.id);
+    const hostId = Number(thread.hostId);
+    const threadId = String(thread.threadId || thread.id || "");
+    if (!hostId || !threadId) return;
+    renameTarget.value = { hostId, threadId };
     renameValue.value = titleForThread(thread);
     void nextTick(() => {
       document.querySelector<HTMLInputElement>('[data-testid="rename-thread-input"]')?.focus();
@@ -25,26 +32,32 @@ export function useThreadRename(store: GatewayStore) {
   }
 
   async function submitRename() {
-    const threadId = renamingThreadId.value ?? "";
+    const target = renameTarget.value;
     const name = renameValue.value.trim();
-    if (!threadId || !name) {
+    if (!target || !name) {
       cancelRename();
       return;
     }
     const thread =
-      threads.value.find((candidate) => String(candidate.id) === threadId) ||
-      pinnedThreads.value.find((candidate) => String(candidate.threadId) === threadId);
+      threads.value.find(
+        (candidate) =>
+          store.selectedHostId === target.hostId && String(candidate.id) === target.threadId,
+      ) ||
+      pinnedThreads.value.find(
+        (candidate) =>
+          candidate.hostId === target.hostId && String(candidate.threadId) === target.threadId,
+      );
     if (thread && titleForThread(thread) === name) {
       cancelRename();
       return;
     }
-    await store.renameThread(threadId, name);
-    renamingThreadId.value = null;
+    await store.renameThread(target.hostId, target.threadId, name);
+    renameTarget.value = null;
     renameValue.value = "";
   }
 
   function cancelRename() {
-    renamingThreadId.value = null;
+    renameTarget.value = null;
     renameValue.value = "";
   }
 
@@ -53,7 +66,7 @@ export function useThreadRename(store: GatewayStore) {
   }
 
   return {
-    renamingThreadId,
+    renamingThreadKey,
     renameValue,
     startInlineRename,
     submitRename,

--- a/app/stores/gateway-thread-activity.ts
+++ b/app/stores/gateway-thread-activity.ts
@@ -1,0 +1,119 @@
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+import type { ProjectRecord, ThreadRuntimeStatus } from "~~/shared/types";
+import { pinnedKey } from "./gateway/thread-utils/identity";
+
+export interface ThreadActivitySummary {
+  hostId: number;
+  projectId: number | null;
+  threadId: string;
+  title: string;
+  cwd: string | null;
+  projectName: string | null;
+  parentThreadId: string | null;
+  updatedAt: number;
+}
+
+export const useGatewayThreadActivityStore = defineStore("gateway-thread-activity", () => {
+  const summariesByKey = ref<Record<string, ThreadActivitySummary>>({});
+  const observedRunningThreadKeys = ref<string[]>([]);
+  const observedRunningThreadKeySet = computed(() => new Set(observedRunningThreadKeys.value));
+
+  function ingestThreads(hostId: number, threads: any[], projects: ProjectRecord[]) {
+    for (const thread of threads) {
+      upsertThread(hostId, thread, projects);
+    }
+  }
+
+  function upsertThread(hostId: number, thread: any, projects: ProjectRecord[]) {
+    const threadId = String(thread?.threadId ?? thread?.id ?? "");
+    if (!threadId) return;
+
+    const key = pinnedKey(hostId, threadId);
+    const existing = summariesByKey.value[key];
+    const project = resolveProject(hostId, thread, projects);
+    summariesByKey.value = {
+      ...summariesByKey.value,
+      [key]: {
+        hostId,
+        projectId: numberOrNull(thread?.projectId) ?? project?.id ?? existing?.projectId ?? null,
+        threadId,
+        title: activityTitle(thread, existing?.title ?? threadId),
+        cwd: stringOrNull(thread?.cwd) ?? existing?.cwd ?? null,
+        projectName: project?.name ?? existing?.projectName ?? null,
+        parentThreadId:
+          stringOrNull(thread?.parentThreadId ?? thread?.parent_thread_id) ??
+          existing?.parentThreadId ??
+          null,
+        updatedAt: timestamp(thread) ?? existing?.updatedAt ?? Math.floor(Date.now() / 1000),
+      },
+    };
+  }
+
+  function recordRuntimeStatus(hostId: number, threadId: string, status: ThreadRuntimeStatus) {
+    if (status !== "running") return;
+    const key = pinnedKey(hostId, threadId);
+    if (observedRunningThreadKeySet.value.has(key)) return;
+    // This key set is intentionally sticky for the browser page lifetime. The
+    // authoritative status may later complete, but the row remains discoverable
+    // until a real page/session reset clears this store.
+    observedRunningThreadKeys.value = [...observedRunningThreadKeys.value, key];
+  }
+
+  function updateTitle(hostId: number, threadId: string, title: string) {
+    const key = pinnedKey(hostId, threadId);
+    const existing = summariesByKey.value[key];
+    if (!existing) return;
+    summariesByKey.value = {
+      ...summariesByKey.value,
+      [key]: { ...existing, title },
+    };
+  }
+
+  function resetState() {
+    summariesByKey.value = {};
+    observedRunningThreadKeys.value = [];
+  }
+
+  return {
+    summariesByKey,
+    observedRunningThreadKeys,
+    ingestThreads,
+    upsertThread,
+    recordRuntimeStatus,
+    updateTitle,
+    resetState,
+  };
+});
+
+function resolveProject(hostId: number, thread: any, projects: ProjectRecord[]) {
+  const projectId = numberOrNull(thread?.projectId);
+  if (projectId !== null) {
+    return projects.find((project) => project.id === projectId && project.hostId === hostId);
+  }
+  const cwd = stringOrNull(thread?.cwd);
+  return cwd
+    ? projects.find((project) => project.hostId === hostId && project.remotePath === cwd)
+    : undefined;
+}
+
+function timestamp(thread: any) {
+  const raw = thread?.recencyAt ?? thread?.updatedAt ?? thread?.createdAt;
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric) && numeric > 0) return numeric;
+  const parsed = typeof raw === "string" ? Date.parse(raw) / 1000 : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function activityTitle(thread: any, fallback: string) {
+  return thread?.title || thread?.name || thread?.preview || fallback;
+}
+
+function numberOrNull(value: unknown) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function stringOrNull(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/app/stores/gateway/actions/thread-list.ts
+++ b/app/stores/gateway/actions/thread-list.ts
@@ -1,5 +1,6 @@
 import type { GatewayStoreContext, ThreadListResponse } from "../types";
 import { gatewayApi } from "@/utils/gateway-api";
+import { useGatewayThreadActivityStore } from "@/stores/gateway-thread-activity";
 import { messageFromError, pinnedKey, sortThreads } from "../thread-utils/identity";
 import { runtimeStatusFromAppThreadStatus } from "../thread-utils/status";
 
@@ -12,6 +13,7 @@ export function createThreadListActions(ctx: GatewayStoreContext) {
       ctx.mergeProjects(response.projects);
     }
     applyProjectDirectoryAvailability(ctx, response);
+    useGatewayThreadActivityStore().ingestThreads(hostId, response.data ?? [], ctx.state.projects);
     syncThreadStatusesFromList(ctx, hostId, response.data ?? []);
   }
 
@@ -85,6 +87,11 @@ export function createThreadListActions(ctx: GatewayStoreContext) {
           ctx.mergeProjects(response.projects);
         }
         applyProjectDirectoryAvailability(ctx, response);
+        useGatewayThreadActivityStore().ingestThreads(
+          hostId,
+          response.data ?? [],
+          ctx.state.projects,
+        );
         ctx.state.hostConnectionStatuses = {
           ...ctx.state.hostConnectionStatuses,
           [hostId]: { status: "connected", updatedAt: Date.now() },

--- a/app/stores/gateway/actions/thread-pinning.ts
+++ b/app/stores/gateway/actions/thread-pinning.ts
@@ -1,5 +1,6 @@
 import type { PinnedThreadRecord, ProjectRecord } from "~~/shared/types";
 import { gatewayApi } from "@/utils/gateway-api";
+import { useGatewayThreadActivityStore } from "@/stores/gateway-thread-activity";
 import type { GatewayStoreContext } from "../types";
 import { pinnedKey, sortThreads, titleForThread } from "../thread-utils/identity";
 
@@ -107,35 +108,38 @@ export function createThreadPinningActions(ctx: GatewayStoreContext) {
       });
     },
 
-    async renameThread(threadId: string, name: string) {
-      if (!ctx.state.selectedHostId) {
-        return;
-      }
+    async renameThread(hostId: number, threadId: string, name: string) {
       await gatewayApi("/api/threads/rename", {
         method: "POST",
         body: {
-          hostId: ctx.state.selectedHostId,
+          hostId,
           threadId,
           name,
         },
       });
-      ctx.state.threads = ctx.state.threads.map((thread) =>
-        String(thread.id) === threadId ? { ...thread, name } : thread,
-      );
-      const key = pinnedKey(ctx.state.selectedHostId, threadId);
+      if (hostId === ctx.state.selectedHostId) {
+        ctx.state.threads = ctx.state.threads.map((thread) =>
+          String(thread.id) === threadId ? { ...thread, name } : thread,
+        );
+      }
+      const key = pinnedKey(hostId, threadId);
       ctx.state.gatewayConfig.pinnedThreads = ctx.state.gatewayConfig.pinnedThreads.map((thread) =>
         pinnedKey(thread.hostId, thread.threadId) === key ? { ...thread, title: name } : thread,
       );
+      useGatewayThreadActivityStore().updateTitle(hostId, threadId, name);
       ctx.persistConfig();
       await ctx.syncConfigToServer();
       if (
+        hostId === ctx.state.selectedHostId &&
         ctx.state.selectedThreadId === threadId &&
         ctx.state.currentThread &&
         typeof ctx.state.currentThread === "object"
       ) {
         ctx.state.currentThread = { ...(ctx.state.currentThread as Record<string, unknown>), name };
       }
-      await ctx.listThreads();
+      if (hostId === ctx.state.selectedHostId) {
+        await ctx.listThreads();
+      }
     },
   };
 }

--- a/app/stores/gateway/domain-events.ts
+++ b/app/stores/gateway/domain-events.ts
@@ -2,6 +2,10 @@ import type { ThreadSettingsState, ThreadTokenUsageState } from "~~/shared/types
 import type { ThreadRuntimeStatus } from "./types";
 
 export type GatewayDomainEventMap = {
+  "thread-summary-detected": {
+    hostId: number;
+    thread: any;
+  };
   "thread-status-detected": {
     hostId: number;
     threadId: string;

--- a/app/stores/gateway/domain-subscribers.ts
+++ b/app/stores/gateway/domain-subscribers.ts
@@ -17,8 +17,12 @@ import {
   clearActiveTerminalProcess,
 } from "./thread-turns/terminal-processes";
 import { useGatewayFileWorkspaceStore } from "@/stores/gateway-file-workspace";
+import { useGatewayThreadActivityStore } from "@/stores/gateway-thread-activity";
 
 export function registerGatewayDomainSubscribers(ctx: GatewayStoreContext) {
+  ctx.events.on("thread-summary-detected", (event) => {
+    useGatewayThreadActivityStore().upsertThread(event.hostId, event.thread, ctx.state.projects);
+  });
   ctx.events.on("remote-files-changed", (event) => {
     useGatewayFileWorkspaceStore().markRemoteFilesChanged(
       event.hostId,

--- a/app/stores/gateway/event-handlers/thread-events.ts
+++ b/app/stores/gateway/event-handlers/thread-events.ts
@@ -4,6 +4,14 @@ import { runtimeStatusFromAppThreadStatus } from "../thread-utils/status";
 import type { GatewayEventHandlerRegistry } from "./types";
 
 export const threadEventHandlers: GatewayEventHandlerRegistry = {
+  "thread/started": (ctx, event, params) => {
+    if (params.thread?.id) {
+      ctx.events.emit("thread-summary-detected", {
+        hostId: event.hostId,
+        thread: params.thread,
+      });
+    }
+  },
   "thread/status/changed": (ctx, event, params) => {
     const threadId = threadIdFromParams(params);
     if (threadId) {

--- a/app/stores/gateway/thread-open/hydration.ts
+++ b/app/stores/gateway/thread-open/hydration.ts
@@ -1,6 +1,7 @@
 import type { ThreadOpenResult } from "~~/shared/types";
 import { normalizeTokenUsage } from "~~/shared/token-usage";
 import { useGatewayRealtimeStore } from "@/stores/gateway-realtime";
+import { useGatewayThreadActivityStore } from "@/stores/gateway-thread-activity";
 import { threadIdFromParams } from "../thread-utils/identity";
 import { runtimeStatusFromThreadState } from "../thread-utils/status";
 import type { GatewayStoreContext } from "../types";
@@ -70,16 +71,18 @@ function applyCommonThreadResult(
   result: ThreadOpenResult,
   options: { lastEventId?: number } = {},
 ) {
-  if (!ctx.state.selectedHostId) {
+  const hostId = result.hostId || ctx.state.selectedHostId;
+  if (!hostId) {
     return;
   }
+  useGatewayThreadActivityStore().upsertThread(hostId, result.thread, ctx.state.projects);
   ctx.state.events = result.recentEvents;
   ctx.state.olderTurnsCursor = result.turnsPage.nextCursor;
   ctx.state.newerTurnsCursor = result.turnsPage.backwardsCursor;
   ctx.state.lastEventId = options.lastEventId ?? result.recentEvents.at(-1)?.id ?? 0;
-  ctx.setThreadSettings(ctx.state.selectedHostId, threadId, result.threadSettings);
+  ctx.setThreadSettings(hostId, threadId, result.threadSettings);
   if (result.tokenUsage) {
-    ctx.setThreadTokenUsage(ctx.state.selectedHostId, threadId, result.tokenUsage);
+    ctx.setThreadTokenUsage(hostId, threadId, result.tokenUsage);
   } else {
     syncTokenUsageFromRecentEvents(ctx, result.recentEvents);
   }

--- a/app/stores/gateway/thread-runtime/projector.ts
+++ b/app/stores/gateway/thread-runtime/projector.ts
@@ -1,4 +1,5 @@
 import type { ThreadRuntimeStatus } from "~~/shared/types";
+import { useGatewayThreadActivityStore } from "@/stores/gateway-thread-activity";
 import { activeRemoteTurnId } from "../thread-turns/active-turn";
 import { pinnedKey } from "../thread-utils/identity";
 import type { GatewayStoreContext, GatewayStoreState } from "../types";
@@ -90,6 +91,7 @@ export function applyThreadRuntimeStatus(
     ...ctx.state.threadStatuses,
     [key]: nextStatus,
   };
+  useGatewayThreadActivityStore().recordRuntimeStatus(hostId, threadId, nextStatus);
   syncThreadCompletionAttention(ctx, hostId, threadId, previousStatus, nextStatus);
 
   if (nextStatus === "running") {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "plugins": "Plugins",
     "automations": "Automations",
     "pinned": "Pinned",
+    "recentlyRunning": "Recently running",
     "noThreads": "No threads",
     "noProjects": "No projects",
     "missingProjects": "Missing directories",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -17,6 +17,7 @@
     "plugins": "插件",
     "automations": "自动化",
     "pinned": "已固定",
+    "recentlyRunning": "最近运行",
     "noThreads": "暂无会话",
     "noProjects": "暂无项目",
     "missingProjects": "目录已删除",

--- a/server/utils/gateway/state/memory.ts
+++ b/server/utils/gateway/state/memory.ts
@@ -14,6 +14,7 @@ export interface ThreadMetadataRecord {
   hostId: number;
   projectId: number | null;
   threadId: string;
+  parentThreadId: string | null;
   title: string | null;
   name: string | null;
   preview: string | null;

--- a/server/utils/gateway/state/thread-metadata.ts
+++ b/server/utils/gateway/state/thread-metadata.ts
@@ -1,5 +1,5 @@
 import { gatewayMemoryState, toTimestamp } from "./memory";
-import { subAgentThreadStore } from "./sub-agent-threads";
+import { parentThreadIdFromMetadata, subAgentThreadStore } from "./sub-agent-threads";
 
 export const threadMetadataStore = {
   pruneToHosts(hostIds: Set<number>) {
@@ -30,6 +30,7 @@ export const threadMetadataStore = {
       hostId,
       projectId,
       threadId,
+      parentThreadId: parentThreadIdFromMetadata(thread),
       title: thread.title ?? thread.name ?? null,
       name: thread.name ?? null,
       preview: thread.preview ?? thread.name ?? null,
@@ -50,6 +51,7 @@ export const threadMetadataStore = {
         ...existing,
         ...metadata,
         projectId: projectId ?? existing.projectId,
+        parentThreadId: metadata.parentThreadId ?? existing.parentThreadId,
         cwd: metadata.cwd ?? existing.cwd,
         preview: metadata.preview ?? existing.preview,
         title: metadata.title ?? existing.title,
@@ -77,6 +79,8 @@ export const threadMetadataStore = {
       })
       .map((thread) => ({
         id: thread.threadId,
+        projectId: thread.projectId,
+        parentThreadId: thread.parentThreadId,
         title: thread.title,
         name: thread.name,
         preview: thread.preview,

--- a/tests/e2e/remote-host-project.spec.ts
+++ b/tests/e2e/remote-host-project.spec.ts
@@ -132,12 +132,17 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
 
   const marker = `E2E 置顶恢复 ${Date.now()}`;
   await sendTextTurn(page, marker);
+  const recentThread = page.getByTestId(`recent-thread-button-${threadId}`);
+  await expect(recentThread).toBeVisible({ timeout: 30_000 });
   await expect(page.getByTestId("chat-scroll-area").getByText(marker)).toBeVisible({
     timeout: 120_000,
   });
   await expect(page.getByTestId("send-turn-button")).toHaveAttribute("aria-label", "已完成", {
     timeout: 120_000,
   });
+  // This list is page-session activity, not merely a projection of the current
+  // running keys. A completed thread remains discoverable until the page reloads.
+  await expect(recentThread).toBeVisible();
 
   const staleTurnsResponse = await sendRealtimeRawRequest(page, {
     type: "thread.turns.load",
@@ -155,6 +160,7 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
   expect(staleTurnsResponse.code).toBe(STALE_THREAD_CURSOR_ERROR_CODE);
 
   await reloadApp(page);
+  await expect(page.getByTestId(`recent-thread-button-${threadId}`)).toBeHidden();
   await expect(page.getByTestId(`thread-button-${threadId}`)).toHaveAttribute(
     "data-selected",
     "true",

--- a/tests/e2e/sidebar-tree.spec.ts
+++ b/tests/e2e/sidebar-tree.spec.ts
@@ -111,6 +111,82 @@ test("marks completed threads as needing review until they are opened", async ({
   ).toBeHidden();
 });
 
+test("keeps non-pinned main threads in recent activity for the page session", async ({ page }) => {
+  await openApp(page);
+  await page.evaluate(() => {
+    const app = (document.querySelector("#__nuxt") as any)?.__vue_app__;
+    const pinia = app?.config?.globalProperties?.$pinia;
+    const gateway = pinia?._s?.get("gateway");
+    const activity = pinia?._s?.get("gateway-thread-activity");
+    if (!gateway || !activity) throw new Error("Unable to locate sidebar activity stores");
+
+    const host = {
+      id: 104,
+      name: "Activity Host",
+      sshHost: "activity.example.internal",
+      username: "codex",
+    };
+    const project = {
+      id: 204,
+      hostId: host.id,
+      name: "Activity Project",
+      remotePath: "/workspace/activity",
+    };
+    gateway.hosts = [host];
+    gateway.projects = [project];
+    gateway.gatewayConfig.pinnedThreads = [
+      {
+        hostId: host.id,
+        projectId: project.id,
+        threadId: "already-pinned",
+        title: "Already pinned",
+      },
+    ];
+    activity.ingestThreads(
+      host.id,
+      [
+        {
+          id: "recent-main",
+          title: "Recent main thread",
+          projectId: project.id,
+          cwd: project.remotePath,
+          updatedAt: 3,
+        },
+        {
+          id: "already-pinned",
+          title: "Already pinned",
+          projectId: project.id,
+          updatedAt: 2,
+        },
+        {
+          id: "spawned-child",
+          title: "Spawned child",
+          projectId: project.id,
+          parentThreadId: "recent-main",
+          updatedAt: 1,
+        },
+      ],
+      [project],
+    );
+    gateway.setThreadStatus(host.id, "recent-main", "running");
+    gateway.setThreadStatus(host.id, "already-pinned", "running");
+    gateway.setThreadStatus(host.id, "spawned-child", "running");
+    gateway.setThreadStatus(host.id, "recent-main", "completed");
+  });
+
+  await expect(page.getByText("最近运行", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("recent-thread-button-recent-main")).toBeVisible();
+  await expect(page.getByTestId("recent-thread-button-already-pinned")).toBeHidden();
+  await expect(page.getByTestId("recent-thread-button-spawned-child")).toBeHidden();
+
+  const sectionOrder = await page.getByTestId("sidebar-scroll-area").evaluate((root) => {
+    const text = root.textContent ?? "";
+    return [text.indexOf("已固定"), text.indexOf("最近运行"), text.indexOf("主机")];
+  });
+  expect(sectionOrder[0]).toBeLessThan(sectionOrder[1]!);
+  expect(sectionOrder[1]).toBeLessThan(sectionOrder[2]!);
+});
+
 test("long expanded tree labels truncate without displacing trailing statuses", async ({
   page,
 }) => {
@@ -167,25 +243,35 @@ test("long expanded tree labels truncate without displacing trailing statuses", 
   await expect(page.getByTestId(`host-button-${hostId}`).getByLabel("已连接")).toBeVisible();
   await expect(page.getByTestId(`thread-button-${threadId}`).getByLabel("运行中")).toBeVisible();
 
-  const metrics = await page.getByTestId("sidebar-scroll-area").evaluate((root, longTitle) => {
-    const viewport = root.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
-    const title = root.querySelector<HTMLElement>(`[title="${CSS.escape(longTitle)}"]`);
-    const statuses = Array.from(
-      root.querySelectorAll<HTMLElement>('[aria-label="已连接"], [aria-label="运行中"]'),
-    );
-    if (!viewport || !title || statuses.length !== 2)
-      throw new Error("Missing sidebar layout nodes");
-    const viewportRect = viewport.getBoundingClientRect();
-    return {
-      overflow: viewport.scrollWidth - viewport.clientWidth,
-      titleClipped: title.scrollWidth > title.clientWidth,
-      titleOverflow: getComputedStyle(title).textOverflow,
-      statusesInside: statuses.every((status) => {
-        const rect = status.getBoundingClientRect();
-        return rect.left >= viewportRect.left && rect.right <= viewportRect.right;
-      }),
-    };
-  }, longTitle);
+  const metrics = await page.getByTestId("sidebar-scroll-area").evaluate(
+    (root, { hostId, threadId, longTitle }) => {
+      const viewport = root.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+      const threadButton = root.querySelector<HTMLElement>(
+        `[data-testid="thread-button-${CSS.escape(threadId)}"]`,
+      );
+      const title = threadButton?.querySelector<HTMLElement>(`[title="${CSS.escape(longTitle)}"]`);
+      const hostStatus = root.querySelector<HTMLElement>(
+        `[data-testid="host-button-${hostId}"] [aria-label="已连接"]`,
+      );
+      const threadStatus = threadButton?.querySelector<HTMLElement>('[aria-label="运行中"]');
+      const statuses = [hostStatus, threadStatus];
+      if (!viewport || !title || statuses.some((status) => !status)) {
+        throw new Error("Missing sidebar layout nodes");
+      }
+      const viewportRect = viewport.getBoundingClientRect();
+      return {
+        overflow: viewport.scrollWidth - viewport.clientWidth,
+        titleClipped: title.scrollWidth > title.clientWidth,
+        titleOverflow: getComputedStyle(title).textOverflow,
+        statusesInside: statuses.every((status) => {
+          if (!status) return false;
+          const rect = status.getBoundingClientRect();
+          return rect.left >= viewportRect.left && rect.right <= viewportRect.right;
+        }),
+      };
+    },
+    { hostId, threadId, longTitle },
+  );
   expect(metrics).toEqual({
     overflow: 0,
     titleClipped: true,


### PR DESCRIPTION
## Summary
- add a page-session Recently running sidebar section between pinned threads and hosts
- retain completed non-pinned main threads until reload while excluding spawned sub-agents
- make sidebar thread rename operations host-scoped and preserve activity metadata

## Validation
- pnpm lint
- pnpm build
- pnpm test:e2e -- tests/e2e/sidebar-tree.spec.ts (5 passed)
- pnpm test:e2e (54 passed)