### PR TITLE
fix: stabilize mobile history top-up scrolling

### DIFF
--- a/app/components/common/chat-virtualizer/direct-dom-virtualizer.ts
+++ b/app/components/common/chat-virtualizer/direct-dom-virtualizer.ts
@@ -111,6 +111,7 @@ export function useDirectDomVirtualizer<
     wrapOptions(resolvedOptions.value),
   );
   const state = shallowRef(instance);
+  const containerElement = shallowRef<HTMLElement | null>(null);
   const commitVersion = shallowRef(0);
   const cleanup = instance._didMount();
 
@@ -265,6 +266,7 @@ export function useDirectDomVirtualizer<
 
   function containerRef(refValue: Element | ComponentPublicInstance | null) {
     const element = refValue instanceof HTMLElement ? refValue : null;
+    containerElement.value = element;
     directState.container = element;
     directState.lastSize = null;
     if (element) {
@@ -298,6 +300,7 @@ export function useDirectDomVirtualizer<
 
   return {
     applyDirectStyles,
+    containerElement,
     containerRef,
     measureElement,
     refresh,

--- a/app/components/common/chat-virtualizer/stick-to-bottom-state.ts
+++ b/app/components/common/chat-virtualizer/stick-to-bottom-state.ts
@@ -11,6 +11,7 @@ type StickToBottomStateOptions = {
 };
 
 const DETACH_FROM_BOTTOM_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
+const MOVE_TOWARD_BOTTOM_KEYS = new Set(["ArrowDown", "PageDown", "End"]);
 
 function resolveThreshold(source: ThresholdSource | undefined) {
   if (typeof source === "function") {
@@ -28,8 +29,8 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
   const userDetached = ref(false);
   let version = 0;
   let lastTouchY: number | null = null;
-  let lastScrollTop: number | null = null;
   let detachedByUser = false;
+  let userDirection: "backward" | "forward" | null = null;
 
   function bottomDistance(viewport = options.getViewport()) {
     if (!viewport) {
@@ -53,13 +54,10 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
     viewport.style.setProperty("overflow-anchor", "none");
   }
 
-  function markProgrammaticScroll(viewport: HTMLElement) {
-    lastScrollTop = viewport.scrollTop;
-  }
-
   function lockToBottom() {
     followLatest.value = true;
     detachedByUser = false;
+    userDirection = null;
     userDetached.value = false;
     disableNativeScrollAnchor();
     options.onLocked?.();
@@ -68,6 +66,7 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
   function detachFromBottom() {
     followLatest.value = false;
     detachedByUser = true;
+    userDirection = "backward";
     userDetached.value = true;
     disableNativeScrollAnchor();
     version += 1;
@@ -88,12 +87,13 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
     if (viewport !== options.getViewport()) {
       return false;
     }
-    const currentScrollTop = viewport.scrollTop;
-    const movedDown = lastScrollTop !== null && currentScrollTop > lastScrollTop;
-    if (isNearBottom(viewport) && (!detachedByUser || movedDown || bottomDistance(viewport) <= 2)) {
+    if (isNearBottom(viewport) && (!detachedByUser || userDirection === "forward")) {
+      // Virtual-core changes scrollTop while preserving a keyed prepend anchor.
+      // That programmatic movement can be downward, but it is not permission to
+      // resume following. Do not infer reader intent from scroll delta alone;
+      // only the wheel/touch/keyboard handlers below may mark forward intent.
       lockToBottom();
     }
-    lastScrollTop = currentScrollTop;
     options.onViewportScroll?.(viewport);
     return true;
   }
@@ -101,8 +101,9 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
   function handleWheel(event: WheelEvent) {
     if (event.deltaY < 0) {
       detachFromBottom();
-    } else if (event.deltaY > 0 && isNearBottom()) {
-      lockToBottom();
+    } else if (event.deltaY > 0) {
+      userDirection = "forward";
+      if (isNearBottom()) lockToBottom();
     }
   }
 
@@ -114,6 +115,9 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
     const nextY = event.touches[0]?.clientY ?? null;
     if (lastTouchY !== null && nextY !== null && nextY > lastTouchY) {
       detachFromBottom();
+    } else if (lastTouchY !== null && nextY !== null && nextY < lastTouchY) {
+      userDirection = "forward";
+      if (isNearBottom()) lockToBottom();
     }
     lastTouchY = nextY;
   }
@@ -121,12 +125,14 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
   function handleKeydown(event: KeyboardEvent) {
     if (DETACH_FROM_BOTTOM_KEYS.has(event.key) || (event.key === " " && event.shiftKey)) {
       detachFromBottom();
+    } else if (MOVE_TOWARD_BOTTOM_KEYS.has(event.key) || (event.key === " " && !event.shiftKey)) {
+      userDirection = "forward";
+      if (isNearBottom()) lockToBottom();
     }
   }
 
-  function setLastScrollTop(viewport: HTMLElement) {
+  function prepareViewport() {
     disableNativeScrollAnchor();
-    lastScrollTop = viewport.scrollTop;
   }
 
   return {
@@ -140,9 +146,8 @@ export function createStickToBottomState(options: StickToBottomStateOptions) {
     initialBottomAligned,
     isNearBottom,
     lockToBottom,
-    markProgrammaticScroll,
+    prepareViewport,
     reset,
-    setLastScrollTop,
     userDetached,
   };
 }

--- a/app/components/common/chat-virtualizer/stick-to-bottom.ts
+++ b/app/components/common/chat-virtualizer/stick-to-bottom.ts
@@ -22,7 +22,7 @@ export function useStickToBottom(options: StickToBottomOptions) {
   });
   const inputIntent = createViewportInputIntent({
     getViewport: options.getViewport,
-    onBound: state.setLastScrollTop,
+    onBound: state.prepareViewport,
     onKeydown: state.handleKeydown,
     onScroll: state.handleScroll,
     onTouchMove: state.handleTouchMove,
@@ -45,7 +45,6 @@ export function useStickToBottom(options: StickToBottomOptions) {
     const viewport = options.getViewport();
     if (viewport) {
       options.scrollToBottom(viewport);
-      state.markProgrammaticScroll(viewport);
     }
     state.lockToBottom();
     state.initialBottomAligned.value = true;
@@ -60,7 +59,6 @@ export function useStickToBottom(options: StickToBottomOptions) {
     const viewport = options.getViewport();
     if (viewport) {
       options.scrollToBottom(viewport);
-      state.markProgrammaticScroll(viewport);
     }
   }
 
@@ -92,7 +90,6 @@ export function useStickToBottom(options: StickToBottomOptions) {
         const viewport = options.getViewport();
         if (viewport) {
           options.scrollToBottom(viewport);
-          state.markProgrammaticScroll(viewport);
         }
       }
     }

--- a/app/components/common/chat-virtualizer/useChatVirtualizer.ts
+++ b/app/components/common/chat-virtualizer/useChatVirtualizer.ts
@@ -131,6 +131,7 @@ export function useChatVirtualizer(options: ChatVirtualizerOptions) {
 
   return {
     bindInputListeners: sticky.bindInputListeners,
+    containerElement: directVirtualizer.containerElement,
     containerRef: directVirtualizer.containerRef,
     followLatest: sticky.followLatest,
     followContentChange: sticky.followContentChange,

--- a/app/components/thread/VirtualTimelineViewport.vue
+++ b/app/components/thread/VirtualTimelineViewport.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import type { VirtualItem } from "@tanstack/virtual-core";
-import { useDocumentVisibility, useElementVisibility, useResizeObserver } from "@vueuse/core";
+import {
+  useDocumentVisibility,
+  useElementVisibility,
+  useEventListener,
+  useResizeObserver,
+} from "@vueuse/core";
 import type { ComponentPublicInstance } from "vue";
 import { computed, onMounted, ref, watch } from "vue";
 import { ChatVirtualScrollFrame, useChatVirtualizer } from "@/components/common/chat-virtualizer";
@@ -42,6 +47,13 @@ const chatVirtualizer = useChatVirtualizer({
     }
   },
   scrollToBottom: () => {
+    // Keep bottom alignment in TanStack's coordinate system. A history prepend
+    // first expands the DOM sizer with estimated rows and then replaces those
+    // estimates with mobile-width measurements. Writing viewport.scrollTop from
+    // the intermediate DOM scrollHeight loses the keyed end anchor and moves the
+    // previously visible latest row. Do not replace this with direct scrollHeight
+    // arithmetic; scrollToEnd lets virtual-core apply the prepend and measurement
+    // deltas as one end-anchored transaction.
     if (props.rows.length) {
       virtualizer.value.scrollToEnd({ behavior: "auto" });
     }
@@ -83,10 +95,53 @@ function resetFollowLatest() {
 }
 
 function reflowPreservingViewport() {
+  if (chatVirtualizer.followLatest.value) {
+    // Mobile browsers resize 100dvh as their toolbar settles. Waiting for the
+    // detached-reader two-frame reflow lets the new viewport paint off-bottom
+    // and then snap back. Pinned readers only need the synchronous chat follow
+    // path; detached readers still require the keyed anchor flow below.
+    chatVirtualizer.followContentChange();
+    return;
+  }
   void chatVirtualizer.reflow({ preserveViewport: true });
 }
 
 useResizeObserver(viewportElement, reflowPreservingViewport);
+useEventListener(
+  () => (import.meta.client ? window.visualViewport : null),
+  "resize",
+  reflowPreservingViewport,
+);
+// Do not also subscribe to window.resize. visualViewport reports mobile toolbar
+// geometry first, while the element observer owns the final layout; a third
+// duplicate source can follow an unrelated later content transaction.
+useResizeObserver(chatVirtualizer.containerElement, () => {
+  if (!chatVirtualizer.followLatest.value) return;
+
+  // TanStack updates the direct-DOM sizer only after estimated row heights
+  // become real measurements. Following that notification keeps pinned
+  // prepend/viewport reflow correction in the same pre-paint layout phase.
+  //
+  // Do not synchronously remeasure rows here: that bypasses virtual-core's
+  // keyed transaction. Detached intent is retained by the input state machine,
+  // so this callback can trust followLatest without a second transaction flag.
+  // Do not defer with RAF; the stale bottom would already have painted.
+  chatVirtualizer.followContentChange();
+});
+
+watch(
+  () => props.rows.map((row) => row.key).join("\0"),
+  () => {
+    if (chatVirtualizer.followLatest.value) {
+      // Prepending measured history is not an append, so followOnAppend does
+      // not own this transaction. Run one post-flush follow after Vue has
+      // mounted and measured the new rows; this prevents narrow mobile rows
+      // from painting at estimated offsets before TanStack's later correction.
+      chatVirtualizer.followContentChange();
+    }
+  },
+  { flush: "post" },
+);
 
 watch(viewportVisible, (visible, previous) => {
   if (visible && previous === false) reflowPreservingViewport();
@@ -142,9 +197,10 @@ defineExpose({ resetFollowLatest });
       <slot name="overlay" :visible="startControlsVisible" />
     </div>
     <!--
-      Keep vertical spacing inside measured rows. Padding around TanStack's
-      sizer is invisible to virtual-core and creates a false scroll range when
-      a short, bottom-aligned chat grows past one viewport during prepend.
+      Keep trailing spacing inside every measured row. Do not put top spacing
+      on `first:*`: after a prepend the old anchor row stops being first, so its
+      content moves inside an otherwise stable keyed row. Padding around the
+      sizer is also invisible to virtual-core and creates a false scroll range.
     -->
     <div class="mx-auto flex min-h-full w-full max-w-4xl flex-col px-[clamp(0.875rem,4vw,2rem)]">
       <div :ref="chatVirtualizer.containerRef" class="relative mt-auto shrink-0">
@@ -154,7 +210,7 @@ defineExpose({ resetFollowLatest });
           :ref="setRowRef"
           :data-index="virtualRow.index"
           :data-row-key="rows[virtualRow.index]?.key"
-          class="pb-5 first:pt-4 md:pb-8 md:first:pt-8"
+          class="pb-5 md:pb-8"
           :style="rowStyle(virtualRow)"
         >
           <slot :row="rows[virtualRow.index]" :index="virtualRow.index" />

--- a/tests/e2e/helpers/history-top-up.ts
+++ b/tests/e2e/helpers/history-top-up.ts
@@ -1,0 +1,156 @@
+import type { Locator, Page } from "@playwright/test";
+
+export function buildTextTurns(start: number, end: number, prefix: string, lineCount = 1) {
+  return Array.from({ length: end - start + 1 }, (_, index) => {
+    const number = start + index;
+    const label = String(number).padStart(3, "0");
+    return {
+      id: `turn-${label}`,
+      status: "completed",
+      items: [
+        {
+          id: `agent-${label}`,
+          type: "agentMessage",
+          phase: "final_answer",
+          status: "completed",
+          text:
+            lineCount === 1
+              ? `${prefix} ${label}`
+              : [
+                  `${prefix} ${label}`,
+                  ...Array.from(
+                    { length: lineCount - 1 },
+                    (_, lineIndex) => `${prefix} ${label} detail ${lineIndex + 1}`,
+                  ),
+                ].join("\n"),
+        },
+      ],
+    };
+  });
+}
+
+export async function threadTurnCount(page: Page) {
+  return await page.evaluate(() => {
+    const app = (document.querySelector("#__nuxt") as any)?.__vue_app__;
+    const store = app?.config?.globalProperties?.$pinia?._s?.get("gateway");
+    if (!store) throw new Error("Unable to locate gateway Pinia store");
+    return store.history?.thread?.turns?.length ?? 0;
+  });
+}
+
+export async function installDeferredThreadTurnsLoadStub(page: Page, response: unknown) {
+  await installThreadTurnsLoadStub(page, response, true);
+}
+
+export async function installThreadTurnsLoadStub(page: Page, response: unknown, deferred: boolean) {
+  await page.evaluate(
+    ({ response, deferred }) => {
+      const app = (document.querySelector("#__nuxt") as any)?.__vue_app__;
+      const realtime = app?.config?.globalProperties?.$pinia?._s?.get("gateway-realtime");
+      if (!realtime) throw new Error("Unable to locate gateway realtime Pinia store");
+      const original = realtime.request.bind(realtime);
+      (window as any).__threadTurnsLoadRequests = [];
+      if (deferred) {
+        (window as any).__threadTurnsLoadResponse = response;
+        (window as any).__threadTurnsLoadPromise = new Promise((resolve) => {
+          (window as any).__releaseThreadTurnsLoad = () =>
+            resolve((window as any).__threadTurnsLoadResponse);
+        });
+      }
+      let requestSequence = 0;
+      realtime.request = async (buildMessage: (requestId: string) => any, timeoutMs?: number) => {
+        requestSequence += 1;
+        const requestId = `e2e-thread-turns-${requestSequence}`;
+        const request = buildMessage(requestId);
+        if (request?.type !== "thread.turns.load") {
+          return original(buildMessage, timeoutMs);
+        }
+        (window as any).__threadTurnsLoadRequests.push(request);
+        return deferred ? await (window as any).__threadTurnsLoadPromise : response;
+      };
+    },
+    { response, deferred },
+  );
+}
+
+export async function releaseDeferredThreadTurnsLoad(page: Page) {
+  await page.evaluate(() => {
+    const release = (window as any).__releaseThreadTurnsLoad;
+    if (typeof release !== "function") {
+      throw new Error("Missing deferred thread turns release callback");
+    }
+    release();
+  });
+}
+
+export async function threadTurnsLoadRequests(page: Page) {
+  return await page.evaluate(() => (window as any).__threadTurnsLoadRequests ?? []);
+}
+
+export async function startElementTopTracking(page: Page, text: string) {
+  await startLocatorTopTracking(page.getByText(text, { exact: true }));
+}
+
+export async function startLocatorTopTracking(locator: Locator) {
+  await locator.evaluate((element) => {
+    const samples: number[] = [element.getBoundingClientRect().top];
+    const track = () => {
+      (window as any).__frameTrackerId = requestAnimationFrame(() => {
+        (window as any).__frameTrackerTimerId = window.setTimeout(() => {
+          samples.push(element.getBoundingClientRect().top);
+          track();
+        }, 0);
+      });
+    };
+    (window as any).__frameTrackerSamples = samples;
+    (window as any).__frameTrackerId = requestAnimationFrame(track);
+  });
+}
+
+export async function startBottomDistanceTracking(page: Page) {
+  await page.getByTestId("chat-scroll-area").evaluate((root) => {
+    const viewport = root.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    if (!viewport) throw new Error("Missing chat viewport");
+    const distance = () => viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    const samples: number[] = [distance()];
+    const track = () => {
+      (window as any).__frameTrackerId = requestAnimationFrame(() => {
+        (window as any).__frameTrackerTimerId = window.setTimeout(() => {
+          samples.push(distance());
+          track();
+        }, 0);
+      });
+    };
+    (window as any).__frameTrackerSamples = samples;
+    (window as any).__frameTrackerId = requestAnimationFrame(track);
+  });
+}
+
+export async function stopFrameTracking(page: Page) {
+  return await page.evaluate(() => {
+    cancelAnimationFrame((window as any).__frameTrackerId);
+    clearTimeout((window as any).__frameTrackerTimerId);
+    return ((window as any).__frameTrackerSamples ?? []) as number[];
+  });
+}
+
+export async function waitForAnimationFrames(page: Page, count: number) {
+  await page.evaluate(
+    (frameCount) =>
+      new Promise<void>((resolve) => {
+        const wait = (remaining: number) => {
+          if (remaining <= 0) {
+            resolve();
+            return;
+          }
+          requestAnimationFrame(() => wait(remaining - 1));
+        };
+        wait(frameCount);
+      }),
+    count,
+  );
+}
+
+export function frameSpread(samples: number[]) {
+  return Math.max(...samples) - Math.min(...samples);
+}

--- a/tests/e2e/helpers/scroll.ts
+++ b/tests/e2e/helpers/scroll.ts
@@ -110,6 +110,10 @@ export async function scrollChatViewportToBottom(page: Page) {
   await page.getByTestId(chatScrollAreaTestId).evaluate((root: HTMLElement) => {
     const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
     if (!viewport) throw new Error("Missing chat viewport");
+    // Production intentionally ignores programmatic scroll deltas when deciding
+    // whether a detached reader returned to the latest content. Model the real
+    // downward user intent before moving the test viewport to the bottom.
+    viewport.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: 240 }));
     viewport.scrollTop = viewport.scrollHeight;
     viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
   });

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -2,6 +2,18 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 import type { HostRecord, ProjectRecord } from "../../shared/types";
 import { authenticatedFetch, openApp, reloadApp } from "./helpers/app";
 import { seedGatewayThread } from "./helpers/gateway-store";
+import {
+  buildTextTurns,
+  frameSpread,
+  installDeferredThreadTurnsLoadStub,
+  releaseDeferredThreadTurnsLoad,
+  startBottomDistanceTracking,
+  startLocatorTopTracking,
+  stopFrameTracking,
+  threadTurnCount,
+  threadTurnsLoadRequests,
+  waitForAnimationFrames,
+} from "./helpers/history-top-up";
 import { execRemoteSsh, readRemoteEnv, waitForSelectedThreadId } from "./helpers/remote-codex";
 
 test("uses the mobile layout with hidden sidebar and usable composer shell", async ({ page }) => {
@@ -18,6 +30,85 @@ test("uses the mobile layout with hidden sidebar and usable composer shell", asy
 
   await expect(page.getByTestId("chat-scroll-area")).toBeVisible();
   await expect(page.getByText("先选择一个项目")).toBeVisible();
+});
+
+test("background history top-up keeps the mobile timeline visually stable", async ({ page }) => {
+  await openApp(page);
+  const threadId = "mobile-background-turn-top-up";
+  await installDeferredThreadTurnsLoadStub(page, {
+    type: "thread.turns.page",
+    requestId: "mobile-thread-turns-page",
+    hostId: 1,
+    threadId,
+    history: {
+      thread: { id: threadId, turns: buildTextTurns(1, 3, "mobile top-up turn", 14) },
+    },
+    turnsPage: { nextCursor: null, backwardsCursor: null },
+  });
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Mobile Top Up" },
+    olderTurnsCursor: JSON.stringify({ turnId: "turn-004", includeAnchor: false }),
+    history: {
+      thread: { id: threadId, turns: buildTextTurns(4, 5, "mobile top-up turn", 14) },
+    },
+  });
+
+  const latestRow = page.locator('[data-row-key$=":turn-turn-005"]');
+  await expect(latestRow).toBeVisible();
+  await expect
+    .poll(() => threadTurnsLoadRequests(page).then((requests) => requests.length))
+    .toBe(1);
+  await startLocatorTopTracking(latestRow);
+  await releaseDeferredThreadTurnsLoad(page);
+  await expect.poll(() => threadTurnCount(page)).toBe(5);
+  await waitForAnimationFrames(page, 8);
+  const samples = await stopFrameTracking(page);
+  expect(frameSpread(samples), JSON.stringify(samples)).toBeLessThanOrEqual(2);
+});
+
+test("mobile viewport resize during history top-up stays bottom pinned", async ({ page }) => {
+  await openApp(page);
+  const threadId = "mobile-resizing-turn-top-up";
+  await installDeferredThreadTurnsLoadStub(page, {
+    type: "thread.turns.page",
+    requestId: "mobile-resizing-turns-page",
+    hostId: 1,
+    threadId,
+    history: {
+      thread: { id: threadId, turns: buildTextTurns(1, 3, "mobile resize turn", 14) },
+    },
+    turnsPage: { nextCursor: null, backwardsCursor: null },
+  });
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Mobile Resize Top Up" },
+    olderTurnsCursor: JSON.stringify({ turnId: "turn-004", includeAnchor: false }),
+    history: {
+      thread: { id: threadId, turns: buildTextTurns(4, 5, "mobile resize turn", 14) },
+    },
+  });
+
+  await expect
+    .poll(() => threadTurnsLoadRequests(page).then((requests) => requests.length))
+    .toBe(1);
+  await startBottomDistanceTracking(page);
+  await releaseDeferredThreadTurnsLoad(page);
+  await page.setViewportSize({ width: 393, height: 820 });
+  await expect.poll(() => threadTurnCount(page)).toBe(5);
+  await waitForAnimationFrames(page, 8);
+  const samples = await stopFrameTracking(page);
+  // Chromium can expose one frame of the new external viewport geometry before
+  // visualViewport/ResizeObserver callbacks run. The application contract is
+  // that this does not become a multi-frame correction cascade and remains
+  // pinned after that unavoidable browser-owned frame.
+  expect(
+    samples.filter((distance) => distance > 2).length,
+    JSON.stringify(samples),
+  ).toBeLessThanOrEqual(1);
+  expect(Math.max(...samples.slice(-4)), JSON.stringify(samples)).toBeLessThanOrEqual(2);
 });
 
 test("opens sidebar context actions with long press on mobile", async ({ page }) => {

--- a/tests/e2e/thread-scroll-behavior.spec.ts
+++ b/tests/e2e/thread-scroll-behavior.spec.ts
@@ -24,6 +24,18 @@ import {
   visibleAgentLineTop,
   visibleTextTop,
 } from "./helpers/scroll";
+import {
+  buildTextTurns,
+  frameSpread,
+  installDeferredThreadTurnsLoadStub,
+  releaseDeferredThreadTurnsLoad,
+  startBottomDistanceTracking,
+  startElementTopTracking,
+  stopFrameTracking,
+  threadTurnCount,
+  threadTurnsLoadRequests,
+  waitForAnimationFrames,
+} from "./helpers/history-top-up";
 
 test("opened threads render two turns first and then top up to five turns", async ({ page }) => {
   await openApp(page);
@@ -701,6 +713,7 @@ test("loading older turns prepends history without moving the current viewport a
   });
 
   await scrollChatViewportToTop(page);
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "false");
   await expect
     .poll(() => threadTurnsLoadRequests(page).then((requests) => requests.length))
     .toBe(1);
@@ -714,37 +727,6 @@ test("loading older turns prepends history without moving the current viewport a
   expect(httpTurnsRequests()).toBe(0);
 });
 
-function buildTextTurns(start: number, end: number, prefix: string) {
-  return Array.from({ length: end - start + 1 }, (_, index) => {
-    const number = start + index;
-    const label = String(number).padStart(3, "0");
-    return {
-      id: `turn-${label}`,
-      status: "completed",
-      items: [
-        {
-          id: `agent-${label}`,
-          type: "agentMessage",
-          phase: "final_answer",
-          status: "completed",
-          text: `${prefix} ${label}`,
-        },
-      ],
-    };
-  });
-}
-
-async function threadTurnCount(page: import("@playwright/test").Page) {
-  return await page.evaluate(() => {
-    const app = (document.querySelector("#__nuxt") as any)?.__vue_app__;
-    const store = app?.config?.globalProperties?.$pinia?._s?.get("gateway");
-    if (!store) {
-      throw new Error("Unable to locate gateway Pinia store");
-    }
-    return store.history?.thread?.turns?.length ?? 0;
-  });
-}
-
 function trackThreadTurnsHttpRequests(page: Page) {
   let count = 0;
   page.on("request", (request) => {
@@ -753,117 +735,6 @@ function trackThreadTurnsHttpRequests(page: Page) {
     }
   });
   return () => count;
-}
-
-async function installDeferredThreadTurnsLoadStub(page: Page, response: unknown) {
-  await installThreadTurnsLoadStub(page, response, true);
-}
-
-async function installThreadTurnsLoadStub(page: Page, response: unknown, deferred: boolean) {
-  await page.evaluate(
-    ({ response, deferred }) => {
-      const app = (document.querySelector("#__nuxt") as any)?.__vue_app__;
-      const realtime = app?.config?.globalProperties?.$pinia?._s?.get("gateway-realtime");
-      if (!realtime) {
-        throw new Error("Unable to locate gateway realtime Pinia store");
-      }
-      const original = realtime.request.bind(realtime);
-      (window as any).__threadTurnsLoadRequests = [];
-      if (deferred) {
-        (window as any).__threadTurnsLoadResponse = response;
-        (window as any).__threadTurnsLoadPromise = new Promise((resolve) => {
-          (window as any).__releaseThreadTurnsLoad = () =>
-            resolve((window as any).__threadTurnsLoadResponse);
-        });
-      }
-      let requestSequence = 0;
-      realtime.request = async (buildMessage: (requestId: string) => any, timeoutMs?: number) => {
-        requestSequence += 1;
-        const requestId = `e2e-thread-turns-${requestSequence}`;
-        const request = buildMessage(requestId);
-        if (request?.type !== "thread.turns.load") {
-          return original(buildMessage, timeoutMs);
-        }
-        (window as any).__threadTurnsLoadRequests.push(request);
-        return deferred ? await (window as any).__threadTurnsLoadPromise : response;
-      };
-    },
-    { response, deferred },
-  );
-}
-
-async function releaseDeferredThreadTurnsLoad(page: Page) {
-  await page.evaluate(() => {
-    const release = (window as any).__releaseThreadTurnsLoad;
-    if (typeof release !== "function") {
-      throw new Error("Missing deferred thread turns release callback");
-    }
-    release();
-  });
-}
-
-async function threadTurnsLoadRequests(page: Page) {
-  return await page.evaluate(() => (window as any).__threadTurnsLoadRequests ?? []);
-}
-
-async function startElementTopTracking(page: Page, text: string) {
-  await page.getByText(text, { exact: true }).evaluate((element) => {
-    const samples: number[] = [element.getBoundingClientRect().top];
-    const track = () => {
-      (window as any).__frameTrackerId = requestAnimationFrame(() => {
-        (window as any).__frameTrackerTimerId = window.setTimeout(() => {
-          samples.push(element.getBoundingClientRect().top);
-          track();
-        }, 0);
-      });
-    };
-    (window as any).__frameTrackerSamples = samples;
-    (window as any).__frameTrackerId = requestAnimationFrame(track);
-  });
-}
-
-async function startBottomDistanceTracking(page: Page) {
-  await page.getByTestId("chat-scroll-area").evaluate((root) => {
-    const viewport = root.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
-    if (!viewport) throw new Error("Missing chat viewport");
-    const distance = () => viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-    const samples: number[] = [distance()];
-    const track = () => {
-      (window as any).__frameTrackerId = requestAnimationFrame(() => {
-        (window as any).__frameTrackerTimerId = window.setTimeout(() => {
-          samples.push(distance());
-          track();
-        }, 0);
-      });
-    };
-    (window as any).__frameTrackerSamples = samples;
-    (window as any).__frameTrackerId = requestAnimationFrame(track);
-  });
-}
-
-async function stopFrameTracking(page: Page) {
-  return await page.evaluate(() => {
-    cancelAnimationFrame((window as any).__frameTrackerId);
-    clearTimeout((window as any).__frameTrackerTimerId);
-    return ((window as any).__frameTrackerSamples ?? []) as number[];
-  });
-}
-
-async function waitForAnimationFrames(page: Page, count: number) {
-  await page.evaluate(
-    (frameCount) =>
-      new Promise<void>((resolve) => {
-        const wait = (remaining: number) => {
-          if (remaining <= 0) {
-            resolve();
-            return;
-          }
-          requestAnimationFrame(() => wait(remaining - 1));
-        };
-        wait(frameCount);
-      }),
-    count,
-  );
 }
 
 async function startTimelineRowCountTracking(page: Page) {
@@ -882,8 +753,4 @@ async function stopTimelineRowCountTracking(page: Page) {
     (window as any).__timelineRowCountObserver?.disconnect();
     return ((window as any).__timelineRowCountSamples ?? []) as number[];
   });
-}
-
-function frameSpread(samples: number[]) {
-  return Math.max(...samples) - Math.min(...samples);
 }


### PR DESCRIPTION
## Summary
- preserve mobile timeline position while history expands from the initial two turns to five
- separate pinned reflow from detached reading and keep nested diff/command scrollers independent
- consolidate history top-up E2E helpers and add strict mobile regressions

## Validation
- `pnpm lint`
- `pnpm build`
- strict mobile history top-up regressions passed repeatedly
- desktop detached prepend regression passed repeatedly
- full E2E reached 55/56 before a test-only scroll helper correction; the sole failed case passed when rerun after that correction