### PR TITLE
fix: preview Markdown files by default

### DIFF
--- a/app/components/files/FileTextEditor.vue
+++ b/app/components/files/FileTextEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { EyeIcon, FileCodeIcon, Loader2Icon, SaveIcon } from "@lucide/vue";
 import type { FilePreviewDocument } from "~~/shared/types";
 import { isMarkdownPreviewPath } from "~~/shared/file-preview";
@@ -11,19 +11,32 @@ import { fileEditorExtensions } from "@/utils/file-editor-extensions";
 import FileMarkdownPreview from "./FileMarkdownPreview.vue";
 
 const MAX_EDITABLE_FILE_BYTES = 5 * 1024 * 1024;
+type MarkdownMode = "source" | "preview";
+
 const props = defineProps<{ document: FilePreviewDocument }>();
 const emit = defineEmits<{ conflict: [] }>();
 const fileWorkspace = useGatewayFileWorkspaceStore();
-const markdownMode = ref<"source" | "preview">("source");
 const editable = computed(() => (props.document.size ?? 0) <= MAX_EDITABLE_FILE_BYTES);
 const markdown = computed(() =>
   isMarkdownPreviewPath(props.document.path, props.document.contentType),
 );
+const markdownMode = ref<MarkdownMode>(defaultMode(props.document));
 const language = computed(() => codeEditorLanguageForPath(props.document.path));
 const draft = computed({
   get: () => props.document.draftText,
   set: (value) => fileWorkspace.updateDocumentDraft(props.document, value),
 });
+
+// Dockview keeps this editor mounted while file tabs change. Reset only when the
+// displayed document changes so Markdown opens rendered, while a user's explicit
+// source/preview choice remains stable for the current document.
+watch([() => props.document.path, () => props.document.contentType], () => {
+  markdownMode.value = defaultMode(props.document);
+});
+
+function defaultMode(document: FilePreviewDocument): MarkdownMode {
+  return isMarkdownPreviewPath(document.path, document.contentType) ? "preview" : "source";
+}
 
 function save() {
   if (editable.value) void fileWorkspace.saveDocument(props.document);

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -224,9 +224,9 @@ printf '%s\n' 'long file names stay inside the tree' > ${shellQuote(longFilePath
     .getByText(markdownPath.split("/").pop()!, { exact: true })
     .click();
   await expect(fileTab(page, markdownPath)).toBeVisible();
-  await expect(panel.getByTestId("remote-file-editor")).toContainText("Rendered Markdown Preview");
-  await panel.getByRole("button", { name: "预览" }).click();
   await expect(panel.locator(".markdown-content h1")).toHaveText("Rendered Markdown Preview");
+  await panel.getByRole("button", { name: "源码" }).click();
+  await expect(panel.getByTestId("remote-file-editor")).toContainText("Rendered Markdown Preview");
 
   await seedGatewayThread(page, {
     hostId: host.id,


### PR DESCRIPTION
## Summary
- open Markdown documents in rendered preview mode by default
- reset the default when Dockview reuses the editor for another document
- preserve manual source/preview selection for the current document

## Validation
- `pnpm lint`
- `pnpm test:e2e -- tests/e2e/thread-file-preview.spec.ts` (1 passed)