### PR TITLE
fix: keep tmux output preview at latest

### DIFF
--- a/app/components/tmux/TmuxPaneOutputDialog.vue
+++ b/app/components/tmux/TmuxPaneOutputDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RefreshCwIcon } from "@lucide/vue";
 import { useAsyncState } from "@vueuse/core";
-import { computed, watch } from "vue";
+import { computed, nextTick, useTemplateRef, watch } from "vue";
 import type { TmuxPaneSnapshot } from "~~/shared/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,6 +22,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ "update:open": [open: boolean] }>();
 const { t } = useI18n();
+const outputViewport = useTemplateRef<HTMLPreElement>("outputViewport");
 
 const request = useAsyncState(
   async () => {
@@ -40,6 +41,16 @@ const errorMessage = computed(() =>
 watch([() => props.open, () => props.hostId, () => props.pane?.paneId], ([open]) => {
   if (open && props.pane) void request.execute();
 });
+
+watch(
+  () => request.state.value?.capturedAt,
+  async (capturedAt) => {
+    if (!capturedAt) return;
+    await nextTick();
+    const viewport = outputViewport.value;
+    if (viewport) viewport.scrollTop = viewport.scrollHeight;
+  },
+);
 </script>
 
 <template>
@@ -89,6 +100,7 @@ watch([() => props.open, () => props.hostId, () => props.pane?.paneId], ([open])
         </div>
         <pre
           v-else
+          ref="outputViewport"
           data-testid="tmux-pane-output"
           class="h-full overflow-auto rounded-lg border border-hairline bg-canvas-soft p-4 font-mono text-xs leading-relaxed text-ink"
         ><code>{{ request.state.value?.output || $t("app.tmuxEmptyPaneOutput") }}</code></pre>

--- a/app/components/tmux/TmuxSessionList.vue
+++ b/app/components/tmux/TmuxSessionList.vue
@@ -69,9 +69,18 @@ function paneKey(pane: TmuxPaneSnapshot) {
               </div>
             </div>
           </button>
-          <Badge v-if="monitoredPaneKeys.has(paneKey(pane))" variant="secondary">
-            {{ $t("app.tmuxActiveMonitors") }}
-          </Badge>
+          <button
+            v-if="monitoredPaneKeys.has(paneKey(pane))"
+            type="button"
+            class="shrink-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            :aria-label="$t('app.tmuxViewPaneOutput', { session: session.name })"
+            :data-testid="`view-monitored-tmux-pane-${session.name}-${pane.windowIndex}-${pane.paneIndex}`"
+            @click="emit('preview', pane)"
+          >
+            <Badge variant="secondary" class="cursor-pointer">
+              {{ $t("app.tmuxActiveMonitors") }}
+            </Badge>
+          </button>
           <Button
             v-else
             size="sm"

--- a/tests/e2e/tmux-monitoring.spec.ts
+++ b/tests/e2e/tmux-monitoring.spec.ts
@@ -25,7 +25,7 @@ test("monitors a real tmux pane, persists it, and notifies once when it returns 
     `
 tmux kill-server >/dev/null 2>&1 || true
 tmux new-session -d -s ${shellQuote(sessionName)} -n model
-tmux send-keys -t ${shellQuote(`${sessionName}:0.0`)} ${shellQuote(`printf '${outputMarker}\\n'; sleep 300`)} Enter
+tmux send-keys -t ${shellQuote(`${sessionName}:0.0`)} ${shellQuote(`for i in $(seq 1 200); do printf 'training-line-%s\\n' "$i"; done; printf '${outputMarker}\\n'; sleep 300`)} Enter
 tmux new-session -d -s ${shellQuote(idleSessionName)} -n shell
 for i in $(seq 1 50); do
   [ "$(tmux display-message -p -t ${shellQuote(`${sessionName}:0.0`)} '#{pane_current_command}')" = sleep ] && break
@@ -49,12 +49,23 @@ done
   await expect(idlePane.getByRole("button", { name: "已回到 Shell" })).toBeDisabled();
 
   await runningPane.getByRole("button", { name: `查看 ${sessionName} Pane 输出` }).click();
-  await expect(page.getByTestId("tmux-pane-output")).toContainText(outputMarker);
+  const paneOutput = page.getByTestId("tmux-pane-output");
+  await expect(paneOutput).toContainText(outputMarker);
+  await expect
+    .poll(() =>
+      paneOutput.evaluate(
+        (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+      ),
+    )
+    .toBeLessThanOrEqual(1);
   await page.keyboard.press("Escape");
 
   await runningPane.getByRole("button", { name: "加入监控" }).click();
   await expect(panel.getByText("监控中 · 1")).toBeVisible();
   await expect(page.getByTestId("open-tmux-button")).toContainText("1");
+  await runningPane.getByTestId(`view-monitored-tmux-pane-${sessionName}-0-0`).click();
+  await expect(page.getByTestId("tmux-pane-output")).toContainText(outputMarker);
+  await page.keyboard.press("Escape");
 
   await reloadApp(page);
   await expect(page.getByTestId("tmux-monitor-panel")).toBeVisible();


### PR DESCRIPTION
## Summary
- scroll tmux pane output to the latest line after load and refresh
- make the active monitor badge an explicit pane output entry point
- verify both behaviors against a real remote tmux pane

## Validation
- pnpm lint
- pnpm test:e2e (58 passed)