### PR TITLE
Fix settings tabs and tmux background process detection

### DIFF
--- a/app/components/settings/settings-dock/useSettingsDock.ts
+++ b/app/components/settings/settings-dock/useSettingsDock.ts
@@ -1,4 +1,4 @@
-import type { DockviewReadyEvent } from "dockview-vue";
+import type { DockviewReadyEvent, IDockviewPanel } from "dockview-vue";
 import { settingsPanelKinds, settingsPanelRegistry } from "./panel-registry";
 
 const DEFAULT_SETTINGS_PANEL = "config";
@@ -7,22 +7,29 @@ export function useSettingsDock() {
   const { t } = useI18n();
 
   function ready({ api }: DockviewReadyEvent) {
+    let groupAnchor: IDockviewPanel | null = null;
+    let defaultPanel: IDockviewPanel | null = null;
+
     for (const kind of settingsPanelKinds) {
       const policy = settingsPanelRegistry[kind];
-      const panel = api.addPanel({
+      const panel: IDockviewPanel = api.addPanel({
         id: kind,
         component: policy.component,
         tabComponent: "SettingsDockTab",
         title: t(policy.titleKey),
         params: { kind },
         renderer: "always",
-        inactive: kind !== DEFAULT_SETTINGS_PANEL,
-        position: api.activeGroup
-          ? { referenceGroup: api.activeGroup, direction: "within" }
-          : undefined,
+        // An inactive first panel does not establish api.activeGroup. Anchoring every later
+        // panel to the first concrete panel keeps settings as one tab group rather than
+        // accidentally creating a second column while the default tab is initialized.
+        inactive: groupAnchor !== null,
+        position: groupAnchor ? { referencePanel: groupAnchor, direction: "within" } : undefined,
       });
-      if (kind === DEFAULT_SETTINGS_PANEL) panel.api.setActive();
+      groupAnchor ??= panel;
+      if (kind === DEFAULT_SETTINGS_PANEL) defaultPanel = panel;
     }
+
+    defaultPanel?.api.setActive();
   }
 
   return { ready };

--- a/server/utils/gateway/tmux-monitor/remote-scanner.ts
+++ b/server/utils/gateway/tmux-monitor/remote-scanner.ts
@@ -88,12 +88,24 @@ printf '%s\n' "$pane_ids" | while IFS= read -r pane_id; do
   window_name="$(tmux display-message -p -t "$pane_id" -F '#{window_name}')"
   pane_index="$(tmux display-message -p -t "$pane_id" -F '#{pane_index}')"
   pane_pid="$(tmux display-message -p -t "$pane_id" -F '#{pane_pid}')"
+  pane_tty="$(tmux display-message -p -t "$pane_id" -F '#{pane_tty}')"
   current_command="$(tmux display-message -p -t "$pane_id" -F '#{pane_current_command}')"
   process_state="$(ps -o pgid=,tpgid= -p "$pane_pid" 2>/dev/null || true)"
   set -- $process_state
   [ "$#" -ge 2 ] || { echo "Unable to inspect foreground process group for $pane_id" >&2; exit 1; }
   running=1
   [ "$1" = "$2" ] && running=0
+  if [ "$running" -eq 0 ]; then
+    # pane_current_command and the foreground PGID both report the shell after a job is
+    # backgrounded. Processes still attached to the pane TTY are nevertheless live work;
+    # ignoring them makes long-running training jobs look completed while output continues.
+    for process_pid in $(ps -t "$pane_tty" -o pid= 2>/dev/null || true); do
+      if [ "$process_pid" != "$pane_pid" ]; then
+        running=1
+        break
+      fi
+    done
+  fi
   printf '${RECORD_KIND}|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
     "$(encode "$session_name")" "$(encode "$session_id")" "$session_created" "$window_index" \
     "$(encode "$window_name")" "$pane_index" "$(encode "$pane_id")" "$pane_pid" \

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -53,6 +53,9 @@ test("can revoke the current session from appearance settings", async ({ page })
 test("config JSON editor shows current config by default and scrolls", async ({ page }) => {
   await openApp(page);
   await page.getByTestId("settings-toggle").click();
+  const settingsPanel = page.getByTestId("settings-panel");
+  await expect(settingsPanel.locator(".dv-groupview")).toHaveCount(1);
+  await expect(settingsPanel.getByRole("tab")).toHaveCount(4);
   const editor = page.getByTestId("config-json-editor");
   await expect(editor).toContainText('"version"');
   await expect(editor).toContainText('"notifications"');

--- a/tests/e2e/tmux-monitoring.spec.ts
+++ b/tests/e2e/tmux-monitoring.spec.ts
@@ -17,6 +17,7 @@ test("monitors a real tmux pane, persists it, and notifies once when it returns 
   const suffix = Date.now();
   const sessionName = `train-${suffix}`;
   const idleSessionName = `idle-${suffix}`;
+  const backgroundSessionName = `background-${suffix}`;
   const outputMarker = `tmux-preview-${suffix}`;
   const hostName = `tmux-monitor-host-${suffix}`;
 
@@ -27,8 +28,17 @@ tmux kill-server >/dev/null 2>&1 || true
 tmux new-session -d -s ${shellQuote(sessionName)} -n model
 tmux send-keys -t ${shellQuote(`${sessionName}:0.0`)} ${shellQuote(`for i in $(seq 1 200); do printf 'training-line-%s\\n' "$i"; done; printf '${outputMarker}\\n'; sleep 300`)} Enter
 tmux new-session -d -s ${shellQuote(idleSessionName)} -n shell
+tmux new-session -d -s ${shellQuote(backgroundSessionName)} -n model
+tmux send-keys -t ${shellQuote(`${backgroundSessionName}:0.0`)} ${shellQuote("sleep 300 &")} Enter
 for i in $(seq 1 50); do
   [ "$(tmux display-message -p -t ${shellQuote(`${sessionName}:0.0`)} '#{pane_current_command}')" = sleep ] && break
+  sleep 0.1
+done
+for i in $(seq 1 50); do
+  pane_pid="$(tmux display-message -p -t ${shellQuote(`${backgroundSessionName}:0.0`)} '#{pane_pid}')"
+  [ "$(tmux display-message -p -t ${shellQuote(`${backgroundSessionName}:0.0`)} '#{pane_current_command}')" = bash ] \
+    && ps --ppid "$pane_pid" -o comm= | grep -qx sleep \
+    && break
   sleep 0.1
 done
 `,
@@ -45,8 +55,13 @@ done
   await expect(panel).toBeVisible();
   const runningPane = panel.getByTestId(`tmux-pane-${sessionName}-0-0`);
   const idlePane = panel.getByTestId(`tmux-pane-${idleSessionName}-0-0`);
+  const backgroundPane = panel.getByTestId(`tmux-pane-${backgroundSessionName}-0-0`);
   await expect(runningPane).toContainText("sleep");
   await expect(idlePane.getByRole("button", { name: "已回到 Shell" })).toBeDisabled();
+  // A background job leaves bash in the foreground but still owns the pane TTY. It must not
+  // be conflated with the genuinely idle shell above.
+  await expect(backgroundPane).toContainText("bash");
+  await expect(backgroundPane.getByRole("button", { name: "加入监控" })).toBeEnabled();
 
   await runningPane.getByRole("button", { name: `查看 ${sessionName} Pane 输出` }).click();
   const paneOutput = page.getByTestId("tmux-pane-output");
@@ -89,14 +104,14 @@ done
   await expect(page.getByTestId("tmux-monitor-panel").getByText("已返回 Shell")).toBeVisible();
   const toast = page.locator("[data-sonner-toast]").filter({ hasText: "Tmux 任务已结束" });
   await expect(toast).toBeVisible();
-  await expect.poll(async () => (await bark.readRequests()).length, { timeout: 30_000 }).toBe(1);
-  const completionNotification = (await bark.readRequests())[0];
+  await expect.poll(() => readTmuxNotifications(bark), { timeout: 30_000 }).toHaveLength(1);
+  const completionNotification = (await readTmuxNotifications(bark))[0];
   expect(completionNotification?.body).toContain(hostName);
   expect(completionNotification?.body).toContain(threadId.slice(0, 8));
   expect(completionNotification?.body).toContain(sessionName);
 
   await page.waitForTimeout(1_000);
-  expect(await bark.readRequests()).toHaveLength(1);
+  expect(await readTmuxNotifications(bark)).toHaveLength(1);
 
   await execRemoteSsh(
     remote,
@@ -124,11 +139,17 @@ done`,
   await execRemoteSsh(remote, `tmux kill-session -t ${shellQuote(exitSessionName)}`);
   await page.getByRole("button", { name: "立即检查" }).click();
   await expect(panel.getByText("Session 已退出")).toBeVisible();
-  await expect.poll(async () => (await bark.readRequests()).length, { timeout: 30_000 }).toBe(2);
+  await expect.poll(() => readTmuxNotifications(bark), { timeout: 30_000 }).toHaveLength(2);
 
   await execRemoteSsh(remote, "tmux kill-server >/dev/null 2>&1 || true");
 });
 
 function shellQuote(value: string) {
   return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function readTmuxNotifications(bark: Awaited<ReturnType<typeof useBarkReceiver>>) {
+  return (await bark.readRequests()).filter((request) =>
+    request.title.startsWith("Tmux 任务已结束"),
+  );
 }


### PR DESCRIPTION
## Summary
- keep all four settings views in one Dockview tab group
- treat background processes attached to a tmux pane TTY as running
- cover settings grouping, idle panes, foreground jobs, and background jobs in E2E
- scope Bark assertions to tmux notifications

## Validation
- pnpm lint
- pnpm test:e2e (58 passed)
- CUHK psypsg-arrow-full live scan: bash / running=true
- git diff --check