### PR TITLE
fix: detect direct tmux pane processes

### DIFF
--- a/server/utils/gateway/tmux-monitor/remote-scanner.ts
+++ b/server/utils/gateway/tmux-monitor/remote-scanner.ts
@@ -89,22 +89,41 @@ printf '%s\n' "$pane_ids" | while IFS= read -r pane_id; do
   pane_index="$(tmux display-message -p -t "$pane_id" -F '#{pane_index}')"
   pane_pid="$(tmux display-message -p -t "$pane_id" -F '#{pane_pid}')"
   pane_tty="$(tmux display-message -p -t "$pane_id" -F '#{pane_tty}')"
+  pane_dead="$(tmux display-message -p -t "$pane_id" -F '#{pane_dead}')"
+  pane_start_command="$(tmux display-message -p -t "$pane_id" -F '#{pane_start_command}')"
   current_command="$(tmux display-message -p -t "$pane_id" -F '#{pane_current_command}')"
-  process_state="$(ps -o pgid=,tpgid= -p "$pane_pid" 2>/dev/null || true)"
-  set -- $process_state
-  [ "$#" -ge 2 ] || { echo "Unable to inspect foreground process group for $pane_id" >&2; exit 1; }
   running=1
-  [ "$1" = "$2" ] && running=0
-  if [ "$running" -eq 0 ]; then
-    # pane_current_command and the foreground PGID both report the shell after a job is
-    # backgrounded. Processes still attached to the pane TTY are nevertheless live work;
-    # ignoring them makes long-running training jobs look completed while output continues.
-    for process_pid in $(ps -t "$pane_tty" -o pid= 2>/dev/null || true); do
-      if [ "$process_pid" != "$pane_pid" ]; then
-        running=1
-        break
+  [ "$pane_dead" = "1" ] && running=0
+  if [ "$running" -eq 1 ] && [ -z "$pane_start_command" ]; then
+    root_executable="$(readlink -f "/proc/$pane_pid/exe" 2>/dev/null || true)"
+    root_is_login_shell=0
+    if [ -n "$root_executable" ] && [ -r /etc/shells ]; then
+      while IFS= read -r shell_path; do
+        case "$shell_path" in ''|'#'*) continue ;; esac
+        if [ "$root_executable" -ef "$shell_path" ] 2>/dev/null; then
+          root_is_login_shell=1
+          break
+        fi
+      done < /etc/shells
+    fi
+    if [ "$root_is_login_shell" -eq 1 ]; then
+      # tcgetpgrp semantics are exposed by ps as tpgid. A default interactive shell is
+      # idle only when it owns the foreground process group and no non-zombie process is
+      # still attached to the pane TTY. Unknown process state stays running by design.
+      process_state="$(ps -o pgid=,tpgid= -p "$pane_pid" 2>/dev/null || true)"
+      set -- $process_state
+      if [ "$#" -ge 2 ] && [ "$1" = "$2" ]; then
+        running=0
+        for process_pid in $(ps -t "$pane_tty" -o pid=,stat= 2>/dev/null | while read -r pid state; do
+          case "$state" in Z*) ;; *) printf '%s\n' "$pid" ;; esac
+        done); do
+          if [ "$process_pid" != "$pane_pid" ]; then
+            running=1
+            break
+          fi
+        done
       fi
-    done
+    fi
   fi
   printf '${RECORD_KIND}|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
     "$(encode "$session_name")" "$(encode "$session_id")" "$session_created" "$window_index" \

--- a/tests/e2e/tmux-monitoring.spec.ts
+++ b/tests/e2e/tmux-monitoring.spec.ts
@@ -18,6 +18,7 @@ test("monitors a real tmux pane, persists it, and notifies once when it returns 
   const sessionName = `train-${suffix}`;
   const idleSessionName = `idle-${suffix}`;
   const backgroundSessionName = `background-${suffix}`;
+  const directSessionName = `direct-${suffix}`;
   const outputMarker = `tmux-preview-${suffix}`;
   const hostName = `tmux-monitor-host-${suffix}`;
 
@@ -30,6 +31,7 @@ tmux send-keys -t ${shellQuote(`${sessionName}:0.0`)} ${shellQuote(`for i in $(s
 tmux new-session -d -s ${shellQuote(idleSessionName)} -n shell
 tmux new-session -d -s ${shellQuote(backgroundSessionName)} -n model
 tmux send-keys -t ${shellQuote(`${backgroundSessionName}:0.0`)} ${shellQuote("sleep 300 &")} Enter
+tmux new-session -d -s ${shellQuote(directSessionName)} -n proxy ${shellQuote("sleep 300")}
 for i in $(seq 1 50); do
   [ "$(tmux display-message -p -t ${shellQuote(`${sessionName}:0.0`)} '#{pane_current_command}')" = sleep ] && break
   sleep 0.1
@@ -58,12 +60,17 @@ done
   const runningPane = panel.getByTestId(`tmux-pane-${sessionName}-0-0`);
   const idlePane = panel.getByTestId(`tmux-pane-${idleSessionName}-0-0`);
   const backgroundPane = panel.getByTestId(`tmux-pane-${backgroundSessionName}-0-0`);
+  const directPane = panel.getByTestId(`tmux-pane-${directSessionName}-0-0`);
   await expect(runningPane).toContainText("sleep");
   await expect(idlePane.getByRole("button", { name: "已回到 Shell" })).toBeDisabled();
   // A background job leaves bash in the foreground but still owns the pane TTY. It must not
   // be conflated with the genuinely idle shell above.
   await expect(backgroundPane).toContainText("bash");
   await expect(backgroundPane.getByRole("button", { name: "加入监控" })).toBeEnabled();
+  // A pane can start a process directly, so its root PGID is also the foreground PGID.
+  // tmux pane_start_command distinguishes this from an idle default interactive shell.
+  await expect(directPane).toContainText("sleep");
+  await expect(directPane.getByRole("button", { name: "加入监控" })).toBeEnabled();
 
   await runningPane.getByRole("button", { name: `查看 ${sessionName} Pane 输出` }).click();
   const paneOutput = page.getByTestId("tmux-pane-output");


### PR DESCRIPTION
## Summary
- use tmux pane_start_command and pane_dead to distinguish direct pane processes from idle default shells
- confirm default shell identity through /etc/shells before applying foreground process-group idle detection
- treat unknown process state conservatively as running and ignore zombie TTY processes
- add real SSH E2E coverage for tmux panes that directly start a long-running process

## Validation
- pnpm lint
- pnpm test:e2e (58 passed)