### PR TITLE
fix: recognize explicitly started tmux shells

### DIFF
--- a/server/utils/gateway/tmux-monitor/remote-scanner.ts
+++ b/server/utils/gateway/tmux-monitor/remote-scanner.ts
@@ -90,11 +90,10 @@ printf '%s\n' "$pane_ids" | while IFS= read -r pane_id; do
   pane_pid="$(tmux display-message -p -t "$pane_id" -F '#{pane_pid}')"
   pane_tty="$(tmux display-message -p -t "$pane_id" -F '#{pane_tty}')"
   pane_dead="$(tmux display-message -p -t "$pane_id" -F '#{pane_dead}')"
-  pane_start_command="$(tmux display-message -p -t "$pane_id" -F '#{pane_start_command}')"
   current_command="$(tmux display-message -p -t "$pane_id" -F '#{pane_current_command}')"
   running=1
   [ "$pane_dead" = "1" ] && running=0
-  if [ "$running" -eq 1 ] && [ -z "$pane_start_command" ]; then
+  if [ "$running" -eq 1 ]; then
     root_executable="$(readlink -f "/proc/$pane_pid/exe" 2>/dev/null || true)"
     root_is_login_shell=0
     if [ -n "$root_executable" ] && [ -r /etc/shells ]; then
@@ -107,7 +106,7 @@ printf '%s\n' "$pane_ids" | while IFS= read -r pane_id; do
       done < /etc/shells
     fi
     if [ "$root_is_login_shell" -eq 1 ]; then
-      # tcgetpgrp semantics are exposed by ps as tpgid. A default interactive shell is
+      # tcgetpgrp semantics are exposed by ps as tpgid. An interactive shell is
       # idle only when it owns the foreground process group and no non-zombie process is
       # still attached to the pane TTY. Unknown process state stays running by design.
       process_state="$(ps -o pgid=,tpgid= -p "$pane_pid" 2>/dev/null || true)"

--- a/tests/e2e/tmux-monitoring.spec.ts
+++ b/tests/e2e/tmux-monitoring.spec.ts
@@ -19,6 +19,7 @@ test("monitors a real tmux pane, persists it, and notifies once when it returns 
   const idleSessionName = `idle-${suffix}`;
   const backgroundSessionName = `background-${suffix}`;
   const directSessionName = `direct-${suffix}`;
+  const explicitShellSessionName = `explicit-shell-${suffix}`;
   const outputMarker = `tmux-preview-${suffix}`;
   const hostName = `tmux-monitor-host-${suffix}`;
 
@@ -32,6 +33,7 @@ tmux new-session -d -s ${shellQuote(idleSessionName)} -n shell
 tmux new-session -d -s ${shellQuote(backgroundSessionName)} -n model
 tmux send-keys -t ${shellQuote(`${backgroundSessionName}:0.0`)} ${shellQuote("sleep 300 &")} Enter
 tmux new-session -d -s ${shellQuote(directSessionName)} -n proxy ${shellQuote("sleep 300")}
+tmux new-session -d -s ${shellQuote(explicitShellSessionName)} -n shell /bin/bash
 for i in $(seq 1 50); do
   [ "$(tmux display-message -p -t ${shellQuote(`${sessionName}:0.0`)} '#{pane_current_command}')" = sleep ] && break
   sleep 0.1
@@ -61,6 +63,7 @@ done
   const idlePane = panel.getByTestId(`tmux-pane-${idleSessionName}-0-0`);
   const backgroundPane = panel.getByTestId(`tmux-pane-${backgroundSessionName}-0-0`);
   const directPane = panel.getByTestId(`tmux-pane-${directSessionName}-0-0`);
+  const explicitShellPane = panel.getByTestId(`tmux-pane-${explicitShellSessionName}-0-0`);
   await expect(runningPane).toContainText("sleep");
   await expect(idlePane.getByRole("button", { name: "已回到 Shell" })).toBeDisabled();
   // A background job leaves bash in the foreground but still owns the pane TTY. It must not
@@ -68,9 +71,13 @@ done
   await expect(backgroundPane).toContainText("bash");
   await expect(backgroundPane.getByRole("button", { name: "加入监控" })).toBeEnabled();
   // A pane can start a process directly, so its root PGID is also the foreground PGID.
-  // tmux pane_start_command distinguishes this from an idle default interactive shell.
+  // The root executable identity distinguishes it from an idle interactive shell.
   await expect(directPane).toContainText("sleep");
   await expect(directPane.getByRole("button", { name: "加入监控" })).toBeEnabled();
+  // pane_start_command is non-empty for an explicitly started shell, but the system shell
+  // registry still identifies it as a shell and allows the idle transition.
+  await expect(explicitShellPane).toContainText("bash");
+  await expect(explicitShellPane.getByRole("button", { name: "已回到 Shell" })).toBeDisabled();
 
   await runningPane.getByRole("button", { name: `查看 ${sessionName} Pane 输出` }).click();
   const paneOutput = page.getByTestId("tmux-pane-output");


### PR DESCRIPTION
## Summary
- remove pane_start_command as a proxy for whether a tmux pane root is a shell
- classify idle state from the root executable in /etc/shells plus foreground PGID and live TTY processes
- cover both explicitly started interactive shells and directly started long-running processes in real SSH E2E

## Validation
- pnpm lint
- pnpm test:e2e (58 passed)