### PR TITLE
fix: check for frontend updates every five minutes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,7 @@ export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },
   experimental: {
+    checkOutdatedBuildInterval: 5 * 60_000,
     emitRouteChunkError: "automatic-immediate",
   },
   css: ["~/assets/css/tailwind.css"],


### PR DESCRIPTION
## Summary
- use Nuxt's built-in outdated build check
- poll every five minutes instead of every 30 seconds
- retain automatic immediate reload behavior for stale chunks

## Validation
- pnpm lint
- pnpm build
- git diff --check