### PR TITLE
fix: stabilize expanded remote file trees

### DIFF
--- a/app/components/files/RemoteFileTree.vue
+++ b/app/components/files/RemoteFileTree.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FolderIcon, Loader2Icon, RefreshCwIcon } from "@lucide/vue";
-import { TreeRoot, TreeVirtualizer } from "reka-ui";
+import { TreeRoot } from "reka-ui";
 import { computed, ref, watch } from "vue";
 import type { RemoteDirectoryEntry } from "~~/shared/types";
 import { Button } from "@/components/ui/button";
@@ -128,6 +128,7 @@ function fileTreeNode(value: unknown) {
     </div>
     <div v-else class="min-h-0 flex-1 overflow-hidden py-2">
       <TreeRoot
+        v-slot="{ flattenItems }"
         data-testid="remote-file-tree-scroll"
         v-model="selected"
         v-model:expanded="expanded"
@@ -137,20 +138,22 @@ function fileTreeNode(value: unknown) {
         class="relative h-full w-full min-w-0 list-none overflow-x-scroll overflow-y-auto outline-none"
       >
         <!--
-          Reka virtualizes rows, so scrollWidth only reflects the currently rendered names.
-          Keep the horizontal scrollbar geometry allocated: auto overflow can otherwise toggle
-          when a long row enters/leaves the virtual range, changing clientHeight and feeding back
-          into the vertical virtualizer. The estimate must also match the h-8 row height exactly.
+          Keep this as a regular tree like the Host sidebar. Directory children arrive
+          asynchronously and rows can widen the horizontal scroll range; virtualizing that changing
+          two-axis geometry makes the vertical scrollbar repeatedly correct itself after deep
+          expansion. The normal tree has one stable scroll owner and is appropriate for the number
+          of entries loaded interactively here. Do not reintroduce TreeVirtualizer without isolating
+          horizontal sizing and proving deep expansion remains stable.
         -->
-        <TreeVirtualizer v-slot="{ item }" :estimate-size="32" :text-content="(node) => node.name">
-          <RemoteFileTreeRow
-            :node="fileTreeNode(item.value)"
-            :level="item.level"
-            @download="fileActions.downloadFile"
-            @copy-path="fileActions.copyAbsolutePath"
-            @delete="fileActions.requestDelete"
-          />
-        </TreeVirtualizer>
+        <RemoteFileTreeRow
+          v-for="item in flattenItems"
+          :key="item._id"
+          :node="fileTreeNode(item.value)"
+          :level="item.level"
+          @download="fileActions.downloadFile"
+          @copy-path="fileActions.copyAbsolutePath"
+          @delete="fileActions.requestDelete"
+        />
       </TreeRoot>
     </div>
 

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -17,6 +17,7 @@ test("the unified file workspace browses, restores, and refreshes real remote fi
   const unknownTextPath = `${projectPath}/codex-gateway-preview-${Date.now()}.customformat`;
   const binaryPath = `${projectPath}/codex-gateway-preview-${Date.now()}.bin`;
   const longFilePath = `${projectPath}/${"very-long-file-name-".repeat(8)}preview.log`;
+  const treeStressPath = `${projectPath}/tree-stability-${Date.now()}`;
   const wideTable = `| metric | sample-a | sample-b | sample-c |
 | --- | --- | --- | --- |
 | very-long-column | ${"unbroken-value-".repeat(12)}a | ${"unbroken-value-".repeat(12)}b | ${"unbroken-value-".repeat(12)}c |`;
@@ -52,6 +53,15 @@ unknown extensions still render as text
 EOF
 printf '\\000\\001\\002codex-gateway-binary' > ${shellQuote(binaryPath)}
 printf '%s\n' 'long file names stay inside the tree' > ${shellQuote(longFilePath)}
+current=${shellQuote(treeStressPath)}
+mkdir -p "$current"
+for level in $(seq -w 1 14); do
+  current="$current/level-$level"
+  mkdir -p "$current"
+  for file in $(seq -w 1 6); do
+    printf 'tree stability %s %s\n' "$level" "$file" > "$current/file-$level-$file.log"
+  done
+done
 `,
   );
 
@@ -176,6 +186,24 @@ printf '%s\n' 'long file names stay inside the tree' > ${shellQuote(longFilePath
   });
   expect(new Set(treeGeometry.map(([height]) => height)).size).toBe(1);
   expect(new Set(treeGeometry.map(([, height]) => height)).size).toBe(1);
+
+  await tree.getByText(treeStressPath.split("/").pop()!, { exact: true }).click();
+  for (let level = 1; level <= 14; level += 1) {
+    await tree.getByText(`level-${String(level).padStart(2, "0")}`, { exact: true }).click();
+  }
+  await expect.poll(() => tree.getByRole("treeitem").count()).toBeGreaterThan(90);
+  const expandedTreeGeometry = await treeScroll.evaluate(async (element) => {
+    element.scrollTop = Math.floor((element.scrollHeight - element.clientHeight) / 2);
+    const samples: Array<[number, number, number]> = [];
+    for (let index = 0; index < 30; index += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      samples.push([element.scrollTop, element.clientHeight, element.scrollHeight]);
+    }
+    return samples;
+  });
+  expect(new Set(expandedTreeGeometry.map(([top]) => top)).size).toBe(1);
+  expect(new Set(expandedTreeGeometry.map(([, height]) => height)).size).toBe(1);
+  expect(new Set(expandedTreeGeometry.map(([, , height]) => height)).size).toBe(1);
 
   const treePane = page.getByTestId("file-tree-pane");
   const separator = page.getByTestId("file-workspace-separator");


### PR DESCRIPTION
## Summary
- replace the remote file tree virtualizer with regular Reka tree rendering
- keep one stable horizontal and vertical scroll owner during asynchronous directory expansion
- add a real-SSH deep-tree regression covering more than 90 visible entries

## Validation
- pnpm lint
- pnpm test:e2e (59 passed)
- git diff --check