### PR TITLE
feat: reveal opened files in workspace tree

### DIFF
--- a/app/components/files/FileWorkspacePane.vue
+++ b/app/components/files/FileWorkspacePane.vue
@@ -141,6 +141,7 @@ function revalidateWorkspace() {
           :host-id="hostId"
           :thread-id="threadId"
           :root-path="rootPath"
+          :visible="active"
           @open="openFile"
         />
       </template>
@@ -217,6 +218,7 @@ function revalidateWorkspace() {
             :host-id="hostId"
             :thread-id="threadId"
             :root-path="rootPath"
+            :visible="mobileTreeOpen"
             @open="openFile"
           />
         </SheetContent>

--- a/app/components/files/RemoteFileTree.vue
+++ b/app/components/files/RemoteFileTree.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { FolderIcon, Loader2Icon, RefreshCwIcon } from "@lucide/vue";
 import { TreeRoot } from "reka-ui";
-import { computed, ref, watch } from "vue";
+import { computed, ref, useTemplateRef, watch } from "vue";
 import type { RemoteDirectoryEntry } from "~~/shared/types";
 import { Button } from "@/components/ui/button";
 import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
 import RemoteFileDeleteDialog from "./RemoteFileDeleteDialog.vue";
 import RemoteFileTreeRow from "./RemoteFileTreeRow.vue";
 import { useRemoteFileTreeActions } from "./useRemoteFileTreeActions";
+import { useRemoteFileTreeReveal } from "./useRemoteFileTreeReveal";
 
 interface FileTreeNode {
   name: string;
@@ -20,6 +21,7 @@ const props = defineProps<{
   hostId: number;
   threadId: string;
   rootPath: string;
+  visible: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -32,7 +34,9 @@ const fileActions = useRemoteFileTreeActions({
   threadId: () => props.threadId,
 });
 const selected = ref<FileTreeNode>();
+const treeViewport = useTemplateRef<HTMLElement>("treeViewport");
 const scope = computed(() => fileWorkspace.scopeFor(props.hostId, props.threadId));
+const activePath = computed(() => scope.value?.activePath ?? null);
 const rootDirectory = computed(() =>
   fileWorkspace.directoryFor(props.hostId, props.threadId, props.rootPath),
 );
@@ -55,6 +59,17 @@ const tree = computed<FileTreeNode[]>(() =>
     : [],
 );
 
+useRemoteFileTreeReveal({
+  hostId: () => props.hostId,
+  threadId: () => props.threadId,
+  rootPath: () => props.rootPath,
+  visible: () => props.visible,
+  activePath,
+  tree,
+  selected,
+  viewport: treeViewport,
+});
+
 watch(
   () => props.rootPath,
   (path) => {
@@ -65,11 +80,12 @@ watch(
   { immediate: true },
 );
 
-watch(selected, (node) => {
+function selectNode(node: FileTreeNode | undefined) {
+  selected.value = node;
   if (node?.type === "file") {
     emit("open", node.path);
   }
-});
+}
 
 function childrenFor(path: string): FileTreeNode[] {
   const state = fileWorkspace.directoryFor(props.hostId, props.threadId, path);
@@ -126,15 +142,16 @@ function fileTreeNode(value: unknown) {
       <Loader2Icon class="mr-2 size-4 animate-spin" />
       {{ $t("app.loadingFileTree") }}
     </div>
-    <div v-else class="min-h-0 flex-1 overflow-hidden py-2">
+    <div v-else ref="treeViewport" class="min-h-0 flex-1 overflow-hidden py-2">
       <TreeRoot
         v-slot="{ flattenItems }"
         data-testid="remote-file-tree-scroll"
-        v-model="selected"
+        :model-value="selected"
         v-model:expanded="expanded"
         :items="tree"
         :get-key="(node: FileTreeNode) => node.path"
         :get-children="(node: FileTreeNode) => node.children"
+        @update:model-value="selectNode"
         class="relative h-full w-full min-w-0 list-none overflow-x-scroll overflow-y-auto outline-none"
       >
         <!--

--- a/app/components/files/RemoteFileTreeRow.vue
+++ b/app/components/files/RemoteFileTreeRow.vue
@@ -46,6 +46,7 @@ const { longPressContextMenuHandlers } = useLongPressContextMenu({ menuWidthEsti
         v-slot="{ isExpanded }"
         v-bind="node.type === 'file' ? longPressContextMenuHandlers : {}"
         :value="node"
+        :data-file-path="node.path"
         :level="level"
         class="flex h-8 w-max min-w-full cursor-default items-center gap-1.5 rounded-md pr-2 text-sm text-ink-muted outline-none hover:bg-canvas-soft hover:text-ink focus-visible:ring-2 focus-visible:ring-primary/35 data-selected:bg-primary/10 data-selected:text-ink"
         :style="{ paddingInlineStart: `${Math.max(0, level - 1) * 1.125 + 0.5}rem` }"

--- a/app/components/files/useRemoteFileTreeReveal.ts
+++ b/app/components/files/useRemoteFileTreeReveal.ts
@@ -1,0 +1,73 @@
+import { nextTick, ref, watch, type ComputedRef, type Ref } from "vue";
+import type { RemoteDirectoryEntry } from "~~/shared/types";
+import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
+
+interface FileTreeNode {
+  path: string;
+  type: RemoteDirectoryEntry["type"];
+  children?: FileTreeNode[];
+}
+
+export function useRemoteFileTreeReveal(options: {
+  hostId: () => number;
+  threadId: () => string;
+  rootPath: () => string;
+  visible: () => boolean;
+  activePath: ComputedRef<string | null>;
+  tree: ComputedRef<FileTreeNode[]>;
+  selected: Ref<FileTreeNode | undefined>;
+  viewport: Readonly<Ref<HTMLElement | null>>;
+}) {
+  const fileWorkspace = useGatewayFileWorkspaceStore();
+  const revealSequence = ref(0);
+
+  watch(
+    () =>
+      [
+        options.hostId(),
+        options.threadId(),
+        options.rootPath(),
+        options.activePath.value,
+        options.visible(),
+      ] as const,
+    async ([hostId, threadId, rootPath, path, visible]) => {
+      const sequence = ++revealSequence.value;
+      if (!visible || !rootPath) return;
+      if (!path) {
+        options.selected.value = undefined;
+        return;
+      }
+
+      // Files outside the conversation root remain valid preview documents. They deliberately do
+      // not affect the tree because their ancestors cannot be represented beneath this TreeRoot.
+      if (!(await fileWorkspace.revealFileInTree(hostId, threadId, path))) {
+        if (sequence === revealSequence.value) options.selected.value = undefined;
+        return;
+      }
+      await nextTick();
+      if (sequence !== revealSequence.value) return;
+
+      const node = findNode(options.tree.value, path);
+      options.selected.value = node;
+      await nextTick();
+      if (!node || sequence !== revealSequence.value) return;
+
+      // scrollIntoView delegates both axes to the native tree viewport. Using nearest avoids
+      // disturbing the user's position when the selected row is already visible.
+      const row = [
+        ...(options.viewport.value?.querySelectorAll<HTMLElement>("[data-file-path]") ?? []),
+      ].find((element) => element.dataset.filePath === path);
+      row?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    },
+    { immediate: true },
+  );
+}
+
+function findNode(nodes: FileTreeNode[], path: string): FileTreeNode | undefined {
+  for (const node of nodes) {
+    if (node.path === path) return node;
+    const child = node.children ? findNode(node.children, path) : undefined;
+    if (child) return child;
+  }
+  return undefined;
+}

--- a/app/stores/file-workspace/index.ts
+++ b/app/stores/file-workspace/index.ts
@@ -14,6 +14,7 @@ import { createDirectoryState, loadDirectoryState } from "./directory-runtime";
 import {
   absolutePath,
   directoryStateKey,
+  directoryPathsToFile,
   fileDocumentKey,
   fileWorkspaceScopeKey,
   parentPath,
@@ -210,6 +211,21 @@ export const useGatewayFileWorkspaceStore = defineStore(
       await Promise.all(added.map((path) => loadDirectory(hostId, threadId, path)));
     }
 
+    async function revealFileInTree(hostId: number, threadId: string, path: string) {
+      const scope = scopeFor(hostId, threadId);
+      if (!scope) {
+        return false;
+      }
+      const ancestors = directoryPathsToFile(scope.rootPath, path);
+      if (!ancestors.length) {
+        return false;
+      }
+      await setExpandedPaths(hostId, threadId, [
+        ...new Set([...scope.expandedPaths, ...ancestors]),
+      ]);
+      return true;
+    }
+
     async function refreshExpandedDirectories(hostId: number, threadId: string, force = true) {
       const scope = scopeFor(hostId, threadId);
       if (!scope) {
@@ -322,6 +338,7 @@ export const useGatewayFileWorkspaceStore = defineStore(
       loadDirectory,
       directoryFor,
       setExpandedPaths,
+      revealFileInTree,
       refreshExpandedDirectories,
       deleteFile,
       markRemoteFilesChanged,

--- a/app/stores/file-workspace/paths.ts
+++ b/app/stores/file-workspace/paths.ts
@@ -30,6 +30,25 @@ export function parentPaths(path: string) {
   return result;
 }
 
+export function isPathWithinRoot(rootPath: string, path: string) {
+  const root = normalizeRemotePath(rootPath);
+  const candidate = normalizeRemotePath(path);
+  return root === "/" ? candidate.startsWith("/") : candidate.startsWith(`${root}/`);
+}
+
+export function directoryPathsToFile(rootPath: string, filePath: string) {
+  if (!isPathWithinRoot(rootPath, filePath)) {
+    return [];
+  }
+  return parentPaths(filePath)
+    .reverse()
+    .filter((path) => path === normalizeRemotePath(rootPath) || isPathWithinRoot(rootPath, path));
+}
+
 export function absolutePath(rootPath: string, path: string) {
   return path.startsWith("/") ? path : `${rootPath.replace(/\/$/, "")}/${path}`;
+}
+
+function normalizeRemotePath(path: string) {
+  return path.replace(/\/+$/, "") || "/";
 }

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -14,6 +14,7 @@ test("the unified file workspace browses, restores, and refreshes real remote fi
   const remotePath = `${projectPath}/codex-gateway-preview-${Date.now()}.ts`;
   const markdownPath = `${projectPath}/codex-gateway-preview-${Date.now()}.md`;
   const nestedPythonPath = `${projectPath}/deep/prefix/model_${Date.now()}.py`;
+  const outsideWorkspacePath = `/tmp/codex-gateway-outside-${Date.now()}.log`;
   const unknownTextPath = `${projectPath}/codex-gateway-preview-${Date.now()}.customformat`;
   const binaryPath = `${projectPath}/codex-gateway-preview-${Date.now()}.bin`;
   const longFilePath = `${projectPath}/${"very-long-file-name-".repeat(8)}preview.log`;
@@ -45,6 +46,9 @@ EOF
 cat > ${shellQuote(nestedPythonPath)} <<'EOF'
 def nested_preview_marker():
     return "codex-gateway-nested-python"
+EOF
+cat > ${shellQuote(outsideWorkspacePath)} <<'EOF'
+outside workspace files still open safely
 EOF
 for line in $(seq 1 120); do printf '# source line %s\n' "$line" >> ${shellQuote(nestedPythonPath)}; done
 cat > ${shellQuote(unknownTextPath)} <<'EOF'
@@ -101,7 +105,7 @@ done
               id: "file-preview-md-message",
               type: "agentMessage",
               phase: "final_answer",
-              text: `Open [markdown target](${origin}${markdownPath}), [nested python](${origin}${nestedPythonPath}:2), [unknown text](${origin}${unknownTextPath}), and [binary target](${origin}${binaryPath}).\n\nInline agent formula: \\(E = mc^2\\).\n\n${wideTable}`,
+              text: `Open [markdown target](${origin}${markdownPath}), [nested python](${origin}${nestedPythonPath}:2), [outside workspace](${origin}${outsideWorkspacePath}), [unknown text](${origin}${unknownTextPath}), and [binary target](${origin}${binaryPath}).\n\nInline agent formula: \\(E = mc^2\\).\n\n${wideTable}`,
             },
           ],
         },
@@ -287,6 +291,8 @@ done
     history: latestHistory,
   });
 
+  await tree.getByText("deep", { exact: true }).click();
+  await expect(tree.getByText("prefix", { exact: true })).toBeHidden();
   await agentWorkspaceTab(page).click();
   const renderedTable = page.locator(".markdown-content table").filter({
     hasText: "very-long-column",
@@ -317,11 +323,21 @@ done
   await expect(page.getByTestId("file-workspace-tab")).toHaveCount(3);
   await expect(panel.getByText("codex-gateway-nested-python")).toBeVisible();
   await expect(panel.getByTestId("remote-file-editor")).toBeVisible();
+  await expect(tree.getByText("prefix", { exact: true })).toBeVisible();
+  await expect(
+    tree.locator(`[data-file-path=${JSON.stringify(nestedPythonPath)}][data-selected]`),
+  ).toBeVisible();
   const nestedSourceScroller = panel.getByTestId("remote-file-editor").locator(".cm-scroller");
   await nestedSourceScroller.evaluate((element) => element.scrollTo({ top: 320, left: 0 }));
   await expect
     .poll(() => nestedSourceScroller.evaluate((element) => element.scrollTop))
     .toBeGreaterThan(250);
+
+  await agentWorkspaceTab(page).click();
+  await page.getByRole("link", { name: "outside workspace" }).click();
+  await expect(fileTab(page, outsideWorkspacePath)).toBeVisible();
+  await expect(panel.getByText("outside workspace files still open safely")).toBeVisible();
+  await expect(tree.locator("[data-selected]")).toHaveCount(0);
 
   await agentWorkspaceTab(page).click();
   await page.getByRole("link", { name: "unknown text" }).click();
@@ -408,7 +424,7 @@ done
   const restoredDockRatio =
     restoredAgentDockBox!.width / (restoredAgentDockBox!.width + restoredFilesDockBox!.width);
   expect(Math.abs(restoredDockRatio - dockWidthRatio)).toBeLessThan(0.08);
-  await expect(page.getByTestId("file-workspace-tab")).toHaveCount(5);
+  await expect(page.getByTestId("file-workspace-tab")).toHaveCount(6);
   await expect(panel.getByText("codex-gateway-nested-python")).toBeVisible();
 
   await execRemoteSsh(


### PR DESCRIPTION
## Summary
- reveal externally opened workspace files by expanding their ancestor directories
- select and scroll the file-tree row into view without affecting outside-root files
- cover deep Agent-link reveals and outside-workspace files with real SSH E2E

## Validation
- pnpm lint
- pnpm test:e2e (59 passed)
- git diff --check