### PR TITLE
Fix external thread monitoring RPC contention

### DIFF
--- a/server/utils/gateway/runtime/active-main-thread-monitor.ts
+++ b/server/utils/gateway/runtime/active-main-thread-monitor.ts
@@ -1,198 +1,199 @@
 import pLimit from "p-limit";
 import type { HostRecord } from "~~/shared/types";
-import { isThreadActiveStatus } from "~~/shared/thread-runtime-status";
-import type { CodexRpcClient } from "../infra/rpc";
-import { gatewayEventStore } from "../state/gateway-events";
+import { threadIdFromNotification } from "../protocol/thread-payload";
 import { currentGatewayUserId } from "../state/memory";
-import { threadMetadataStore } from "../state/thread-metadata";
-import { threadBroker } from "./broker";
-import { threadRuntimeEvents } from "./thread-runtime-events";
+import type { CodexRpcClient } from "../infra/rpc";
 import { runtimeLog } from "./runtime-log";
 
-const THREAD_READ_CONCURRENCY = 4;
-const RPC_TIMEOUT_MS = 30_000;
-type HostRpcClient = CodexRpcClient;
+const RECOVERY_CONCURRENCY = 2;
+const RECOVERY_TIMEOUT_MS = 15_000;
+const UNSUBSCRIBE_TIMEOUT_MS = 5_000;
 
-interface ObservedThread {
-  threadId: string;
+type ControllerLookup = (threadId: string) => boolean;
+
+interface MonitorContext {
+  host: HostRecord;
+  client: CodexRpcClient;
+  hasController: ControllerLookup;
 }
 
 /**
- * Observes main threads already loaded by the remote app-server process.
+ * Attaches Gateway to main threads created by another app-server client, such as
+ * VS Code. `thread/started` is broadcast by app-server to every connection, while
+ * turn events are delivered only after this connection resumes that specific thread.
  *
- * App-server subscriptions are connection-scoped. A thread resumed by VS Code can
- * therefore be active without Gateway receiving its events. This monitor discovers
- * only currently loaded active threads, attaches Gateway's existing Host RPC
- * connection, and releases monitor-only subscriptions once the turn becomes idle.
- *
- * The map is deliberately process-local: app-server remains the state authority,
- * while persisting observation state would turn a Gateway restart into stale
- * completion notifications for turns that ended while Gateway was offline.
+ * Do not poll `thread/loaded/list` here. It exposes only ids, so the old monitor
+ * followed every poll with `thread/read` for every loaded thread and then resumed
+ * active ones. That work shared the only Host RPC connection with foreground UI
+ * requests and could make a normal realtime request time out. Recovery scans once
+ * after a Host connection is established, solely to cover a turn that was already
+ * running while Gateway was disconnected.
  */
 class ActiveMainThreadMonitor {
-  private readonly observedByHost = new Map<string, Map<string, ObservedThread>>();
-  private readonly pendingScans = new Map<string, Promise<void>>();
+  private readonly observedByHost = new Map<string, Set<string>>();
+  private readonly pendingByThread = new Map<string, Promise<void>>();
+  private readonly pendingRecoveries = new Map<string, Promise<void>>();
   private readonly generations = new Map<string, number>();
 
-  async refreshHost(host: HostRecord) {
-    const key = this.hostKey(host.id);
-    const pending = this.pendingScans.get(key);
-    if (pending) {
-      return pending;
+  async recoverHost(context: MonitorContext) {
+    const hostKey = this.hostKey(context.host.id);
+    const pending = this.pendingRecoveries.get(hostKey);
+    if (pending) return pending;
+
+    const generation = this.generation(hostKey);
+    const recovery = this.recoverLoadedThreads(context, hostKey, generation)
+      .catch((error) => {
+        // Observation is additive. A recovery failure must not make a connected
+        // Host unavailable or surface as a browser realtime request failure.
+        runtimeLog("active main thread recovery failed", {
+          hostId: context.host.id,
+          hostName: context.host.name,
+          message: messageFromError(error),
+        });
+      })
+      .finally(() => {
+        if (this.pendingRecoveries.get(hostKey) === recovery) {
+          this.pendingRecoveries.delete(hostKey);
+        }
+      });
+    this.pendingRecoveries.set(hostKey, recovery);
+    return recovery;
+  }
+
+  handleNotification(context: MonitorContext, message: unknown) {
+    const method = (message as any)?.method;
+    const threadId = threadIdFromNotification(message);
+    if (!threadId) return;
+
+    if (method === "thread/started") {
+      if (isSubagentThread(message)) return;
+      void this.observeThread(context, threadId).catch((error) => {
+        runtimeLog("active main thread subscribe failed", {
+          hostId: context.host.id,
+          hostName: context.host.name,
+          threadId,
+          message: messageFromError(error),
+        });
+      });
+      return;
     }
 
-    const generation = this.generation(key);
-    const scan = this.performRefresh(host, key, generation).finally(() => {
-      if (this.pendingScans.get(key) === scan) {
-        this.pendingScans.delete(key);
-      }
-    });
-    this.pendingScans.set(key, scan);
-    return scan;
+    if (method === "turn/completed") {
+      void this.releaseThread(context, threadId);
+    }
   }
 
   forgetHost(userId: number, hostId: number) {
     const key = this.hostKey(hostId, userId);
     this.generations.set(key, this.generation(key) + 1);
     this.observedByHost.delete(key);
-    this.pendingScans.delete(key);
-  }
-
-  private async performRefresh(host: HostRecord, key: string, generation: number) {
-    const client = await threadBroker.getHostClient(host);
-    const observed = this.observedByHost.get(key) ?? new Map<string, ObservedThread>();
-    const activeThreadIds = await this.activeMainThreadIds(client, host.id);
-
-    if (!this.isCurrent(key, generation)) {
-      return;
-    }
-
-    for (const threadId of activeThreadIds) {
-      if (observed.has(threadId)) {
-        continue;
+    this.pendingRecoveries.delete(key);
+    for (const key of this.pendingByThread.keys()) {
+      if (key.startsWith(`${this.hostKey(hostId, userId)}:`)) {
+        this.pendingByThread.delete(key);
       }
-      try {
-        await this.subscribe(client, host, threadId);
-      } catch (error) {
-        // A turn can end after thread/read reported active but before resume reaches
-        // app-server. Treat that narrow race like a lost realtime completion instead
-        // of abandoning the notification until another user action happens.
-        runtimeLog("active main thread subscribe failed", {
-          hostId: host.id,
-          hostName: host.name,
-          threadId,
-          message: error instanceof Error ? error.message : String(error),
-        });
-        if (!this.isCurrent(key, generation)) {
-          return;
-        }
-        await this.finalizeObservedThread(client, host, { threadId });
-        continue;
-      }
-      if (!this.isCurrent(key, generation)) {
-        return;
-      }
-      observed.set(threadId, { threadId });
-    }
-
-    for (const [threadId, thread] of observed) {
-      if (activeThreadIds.has(threadId)) {
-        continue;
-      }
-      observed.delete(threadId);
-      await this.finalizeObservedThread(client, host, thread);
-      if (!this.isCurrent(key, generation)) {
-        return;
-      }
-    }
-
-    if (!this.isCurrent(key, generation)) {
-      return;
-    }
-    if (observed.size) {
-      this.observedByHost.set(key, observed);
-    } else {
-      this.observedByHost.delete(key);
     }
   }
 
-  private async activeMainThreadIds(client: HostRpcClient, hostId: number) {
-    const threadIds = await loadedThreadIds(client);
-    const limit = pLimit(THREAD_READ_CONCURRENCY);
-    const reads = await Promise.all(
-      threadIds.map((threadId) => limit(() => readActiveMainThread(client, hostId, threadId))),
+  private async recoverLoadedThreads(context: MonitorContext, hostKey: string, generation: number) {
+    const threadIds = await loadedThreadIds(context.client);
+    const limit = pLimit(RECOVERY_CONCURRENCY);
+    await Promise.all(
+      threadIds.map((threadId) =>
+        limit(async () => {
+          if (!this.isCurrent(hostKey, generation)) return;
+          await this.observeThread(context, threadId, true);
+        }),
+      ),
     );
-    return new Set(reads.filter((threadId): threadId is string => Boolean(threadId)));
   }
 
-  private async subscribe(client: HostRpcClient, host: HostRecord, threadId: string) {
-    // Do not create a ThreadController here. The monitor only needs an upstream
-    // listener; materializing a UI snapshot would grow thread caches for hidden work.
-    await client.request("thread/resume", { threadId, excludeTurns: true }, RPC_TIMEOUT_MS);
+  private async observeThread(
+    context: MonitorContext,
+    threadId: string,
+    releaseIdleThread = false,
+  ) {
+    if (context.hasController(threadId)) return;
+    const hostKey = this.hostKey(context.host.id);
+    const observed = this.observedByHost.get(hostKey);
+    if (observed?.has(threadId)) return;
+
+    const key = `${hostKey}:${threadId}`;
+    const pending = this.pendingByThread.get(key);
+    if (pending) return pending;
+
+    const generation = this.generation(hostKey);
+    const subscription = this.resumeMonitorOnlyThread(
+      context,
+      threadId,
+      releaseIdleThread,
+      generation,
+    ).finally(() => {
+      if (this.pendingByThread.get(key) === subscription) {
+        this.pendingByThread.delete(key);
+      }
+    });
+    this.pendingByThread.set(key, subscription);
+    return subscription;
+  }
+
+  private async resumeMonitorOnlyThread(
+    context: MonitorContext,
+    threadId: string,
+    releaseIdleThread: boolean,
+    generation: number,
+  ) {
+    const result = await context.client.request<any>(
+      "thread/resume",
+      { threadId, excludeTurns: true },
+      RECOVERY_TIMEOUT_MS,
+    );
+    const thread = result?.thread ?? result;
+    const hostKey = this.hostKey(context.host.id);
+    if (!this.isCurrent(hostKey, generation) || context.hasController(threadId)) return;
+
+    // A loaded list is not restricted to active main threads. Resume is the one
+    // request that both tells us its metadata and attaches the event listener, so
+    // immediately release idle/subagent results discovered during recovery.
+    if (isSubagentThread({ params: { thread } }) || (releaseIdleThread && !isActive(thread))) {
+      await this.unsubscribe(context, threadId);
+      return;
+    }
+
+    let observed = this.observedByHost.get(hostKey);
+    if (!observed) {
+      observed = new Set();
+      this.observedByHost.set(hostKey, observed);
+    }
+    observed.add(threadId);
     runtimeLog("subscribed to active main thread", {
-      hostId: host.id,
-      hostName: host.name,
+      hostId: context.host.id,
+      hostName: context.host.name,
       threadId,
     });
   }
 
-  private async finalizeObservedThread(
-    client: HostRpcClient,
-    host: HostRecord,
-    thread: ObservedThread,
-  ) {
-    try {
-      const latestTurn = await latestTerminalTurn(client, thread.threadId);
-      if (latestTurn && !hasRecordedCompletion(host.id, thread.threadId, latestTurn.id)) {
-        // The primary path is app-server's turn/completed notification. This fallback
-        // covers a transport reconnect between the remote turn ending and its event
-        // reaching Gateway. Both paths retain the same turn id, so notification-center
-        // deduplication keeps browser and Bark delivery singular.
-        threadRuntimeEvents.record(
-          host.id,
-          thread.threadId,
-          "turn/completed",
-          {
-            method: "turn/completed",
-            params: { threadId: thread.threadId, turn: latestTurn },
-          },
-          {
-            resolveGoal: () => client.request("thread/goal/get", { threadId: thread.threadId }),
-            resolveThread: () =>
-              client.request("thread/read", { threadId: thread.threadId, includeTurns: false }),
-          },
-        );
-      }
-    } catch (error) {
-      runtimeLog("active main thread completion fallback failed", {
-        hostId: host.id,
-        hostName: host.name,
-        threadId: thread.threadId,
-        message: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      await this.unsubscribeMonitorOnlyThread(client, host, thread.threadId);
+  private async releaseThread(context: MonitorContext, threadId: string) {
+    const hostKey = this.hostKey(context.host.id);
+    const observed = this.observedByHost.get(hostKey);
+    if (!observed?.delete(threadId)) return;
+    if (!observed.size) this.observedByHost.delete(hostKey);
+    if (!context.hasController(threadId)) {
+      await this.unsubscribe(context, threadId);
     }
   }
 
-  private async unsubscribeMonitorOnlyThread(
-    client: HostRpcClient,
-    host: HostRecord,
-    threadId: string,
-  ) {
-    // Controllers are shared with visible Gateway threads on this same RPC connection.
-    // Unsubscribing a thread with a controller would silently stop its UI event stream.
-    if (threadBroker.hasController(host.id, threadId)) {
-      return;
-    }
-    await client.request("thread/unsubscribe", { threadId }, 5_000).catch((error) => {
-      runtimeLog("monitor-only thread unsubscribe failed", {
-        hostId: host.id,
-        hostName: host.name,
-        threadId,
-        message: error instanceof Error ? error.message : String(error),
+  private async unsubscribe(context: MonitorContext, threadId: string) {
+    await context.client
+      .request("thread/unsubscribe", { threadId }, UNSUBSCRIBE_TIMEOUT_MS)
+      .catch((error) => {
+        runtimeLog("monitor-only thread unsubscribe failed", {
+          hostId: context.host.id,
+          hostName: context.host.name,
+          threadId,
+          message: messageFromError(error),
+        });
       });
-    });
   }
 
   private hostKey(hostId: number, userId = requiredUserId()) {
@@ -208,7 +209,7 @@ class ActiveMainThreadMonitor {
   }
 }
 
-async function loadedThreadIds(client: HostRpcClient) {
+async function loadedThreadIds(client: CodexRpcClient) {
   const threadIds: string[] = [];
   const seenCursors = new Set<string>();
   let cursor: string | null = null;
@@ -216,89 +217,38 @@ async function loadedThreadIds(client: HostRpcClient) {
     const page: { data?: unknown; nextCursor?: unknown } = await client.request(
       "thread/loaded/list",
       { cursor, limit: 100 },
-      RPC_TIMEOUT_MS,
+      RECOVERY_TIMEOUT_MS,
     );
     for (const threadId of Array.isArray(page.data) ? page.data : []) {
-      if (typeof threadId === "string" && threadId.trim()) {
-        threadIds.push(threadId);
-      }
+      if (typeof threadId === "string" && threadId.trim()) threadIds.push(threadId);
     }
-    const nextCursor: string | null = typeof page.nextCursor === "string" ? page.nextCursor : null;
-    if (!nextCursor || seenCursors.has(nextCursor)) {
-      break;
-    }
+    const nextCursor = typeof page.nextCursor === "string" ? page.nextCursor : null;
+    if (!nextCursor || seenCursors.has(nextCursor)) break;
     seenCursors.add(nextCursor);
     cursor = nextCursor;
   } while (cursor);
   return threadIds;
 }
 
-async function readActiveMainThread(client: HostRpcClient, hostId: number, threadId: string) {
-  try {
-    const result = await client.request<any>(
-      "thread/read",
-      { threadId, includeTurns: false },
-      RPC_TIMEOUT_MS,
-    );
-    const thread = result?.thread ?? result;
-    if (thread && typeof thread === "object") {
-      threadMetadataStore.record(hostId, null, thread);
-    }
-    if (!isThreadActiveStatus(thread?.status) || parentThreadId(thread) !== null) {
-      return null;
-    }
-    return threadId;
-  } catch (error) {
-    runtimeLog("active main thread inspection failed", {
-      threadId,
-      message: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
+function isActive(thread: any) {
+  const status = typeof thread?.status === "string" ? thread.status : thread?.status?.type;
+  return ["active", "inProgress", "in_progress", "running"].includes(status);
 }
 
-async function latestTerminalTurn(client: HostRpcClient, threadId: string) {
-  const result = await client.request<{ data?: unknown }>(
-    "thread/turns/list",
-    { threadId, limit: 1, sortDirection: "desc", itemsView: "summary" },
-    RPC_TIMEOUT_MS,
-  );
-  const turn = Array.isArray(result.data) ? result.data[0] : null;
-  if (!turn || typeof turn !== "object" || !isTerminalTurn(turn)) {
-    return null;
-  }
-  return turn as { id: string; status: string };
-}
-
-function hasRecordedCompletion(hostId: number, threadId: string, turnId: string) {
-  return gatewayEventStore.list(hostId, threadId, 0, 500).some((event) => {
-    if (event.method !== "turn/completed") {
-      return false;
-    }
-    const completedTurnId = (event.payload as any)?.params?.turn?.id;
-    return completedTurnId === turnId;
-  });
-}
-
-function isTerminalTurn(turn: any): turn is { id: string; status: string } {
-  return (
-    typeof turn.id === "string" &&
-    typeof turn.status === "string" &&
-    ["completed", "failed", "interrupted"].includes(turn.status)
-  );
-}
-
-function parentThreadId(thread: any) {
-  const value = thread?.parentThreadId ?? thread?.parent_thread_id;
-  return typeof value === "string" && value.trim() ? value.trim() : null;
+function isSubagentThread(message: unknown) {
+  const thread = (message as any)?.params?.thread;
+  const parentThreadId = thread?.parentThreadId ?? thread?.parent_thread_id;
+  return typeof parentThreadId === "string" && parentThreadId.trim().length > 0;
 }
 
 function requiredUserId() {
   const userId = currentGatewayUserId();
-  if (!userId) {
-    throw new Error("Active main thread monitor requires an authenticated user scope");
-  }
+  if (!userId) throw new Error("Active main thread monitor requires an authenticated user scope");
   return userId;
+}
+
+function messageFromError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export const activeMainThreadMonitor = new ActiveMainThreadMonitor();

--- a/server/utils/gateway/runtime/host-rpc-session.ts
+++ b/server/utils/gateway/runtime/host-rpc-session.ts
@@ -5,6 +5,7 @@ import { bindGatewayUser } from "../state/memory";
 import type { HostControllerLookup, HostControllersLookup } from "./types";
 import { threadIdFromNotification } from "../protocol/thread-payload";
 import { threadRuntimeEvents } from "./thread-runtime-events";
+import { activeMainThreadMonitor } from "./active-main-thread-monitor";
 
 export class HostRpcSession {
   readonly client: CodexRpcClient;
@@ -58,6 +59,14 @@ export class HostRpcSession {
   }
 
   private routeNotification(message: any) {
+    activeMainThreadMonitor.handleNotification(
+      {
+        host: this.host,
+        client: this.client,
+        hasController: (threadId) => Boolean(this.controllerForThread(this.host.id, threadId)),
+      },
+      message,
+    );
     const threadId = threadIdFromNotification(message);
     if (!threadId) {
       return;

--- a/server/utils/gateway/runtime/host-runtime-connection.ts
+++ b/server/utils/gateway/runtime/host-runtime-connection.ts
@@ -20,8 +20,12 @@ export async function connectHostRuntime(slot: HostRuntimeSlot) {
       hostName: slot.host.name,
       pinnedThreads: slot.pinnedThreads.filter((thread) => thread.hostId === slot.hostId).length,
     });
-    await threadBroker.getHostClient(slot.host);
-    await activeMainThreadMonitor.refreshHost(slot.host);
+    const client = await threadBroker.getHostClient(slot.host);
+    await activeMainThreadMonitor.recoverHost({
+      host: slot.host,
+      client,
+      hasController: (threadId) => threadBroker.hasController(slot.host.id, threadId),
+    });
     await refreshRunningThreadsForHost({
       host: slot.host,
       reason: "host-connected",

--- a/server/utils/gateway/scheduled-tasks/stale-running-thread-scanner.ts
+++ b/server/utils/gateway/scheduled-tasks/stale-running-thread-scanner.ts
@@ -1,8 +1,6 @@
 import type { HostRuntimeSlot } from "../runtime/host-runtime-slot";
 import { runWithGatewayUser } from "../state/memory";
 import { refreshRunningThreadsForHost } from "../runtime/running-thread-sync";
-import { activeMainThreadMonitor } from "../runtime/active-main-thread-monitor";
-import { runtimeLog } from "../runtime/runtime-log";
 
 export class StaleRunningThreadScanner {
   private running = false;
@@ -15,17 +13,6 @@ export class StaleRunningThreadScanner {
     try {
       for (const slot of slots) {
         await runWithGatewayUser(slot.userId, async () => {
-          try {
-            await activeMainThreadMonitor.refreshHost(slot.host);
-          } catch (error) {
-            // Discovery is additive. A temporarily unavailable Host must not keep
-            // later Hosts from refreshing their existing running-thread snapshots.
-            runtimeLog("active main thread scan failed", {
-              hostId: slot.host.id,
-              hostName: slot.host.name,
-              message: error instanceof Error ? error.message : String(error),
-            });
-          }
           await refreshRunningThreadsForHost({
             host: slot.host,
             reason: "stale-scan",


### PR DESCRIPTION
Summary: replace periodic loaded-thread discovery with app-server thread-started event handling. Subscribe only the started main thread, release after turn completion, and retain one bounded recovery scan after Host RPC connection. Verification: pnpm lint and pnpm test:e2e, 60 passed.