### PR TITLE
fix: harden remote files and Codex upgrades

### DIFF
--- a/app/components/files/RemoteFileTree.vue
+++ b/app/components/files/RemoteFileTree.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { FolderIcon, Loader2Icon, RefreshCwIcon } from "@lucide/vue";
 import { TreeRoot } from "reka-ui";
-import { computed, ref, useTemplateRef, watch } from "vue";
+import { computed, nextTick, ref, useTemplateRef } from "vue";
 import type { RemoteDirectoryEntry } from "~~/shared/types";
 import { Button } from "@/components/ui/button";
 import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
@@ -70,21 +70,25 @@ useRemoteFileTreeReveal({
   viewport: treeViewport,
 });
 
-watch(
-  () => props.rootPath,
-  (path) => {
-    if (path) {
-      void fileWorkspace.loadDirectory(props.hostId, props.threadId, path);
-    }
-  },
-  { immediate: true },
-);
-
 function selectNode(node: FileTreeNode | undefined) {
   selected.value = node;
   if (node?.type === "file") {
     emit("open", node.path);
+  } else if (node?.type === "directory") {
+    void expandUnloadedDirectory(node.path);
   }
+}
+
+async function expandUnloadedDirectory(path: string) {
+  // Reka cannot infer that a lazy directory has children before its first request, so its initial
+  // click may only select the row. Wait for Reka's own update first, then fill in the one missing
+  // transition. Do not toggle loaded directories here: Reka remains the sole owner of collapse.
+  await nextTick();
+  const state = fileWorkspace.directoryFor(props.hostId, props.threadId, path);
+  if (state?.loaded || expanded.value.includes(path)) return;
+  await fileWorkspace.setExpandedPaths(props.hostId, props.threadId, [
+    ...new Set([...expanded.value, path]),
+  ]);
 }
 
 function childrenFor(path: string): FileTreeNode[] {

--- a/app/stores/file-workspace/directory-loader.ts
+++ b/app/stores/file-workspace/directory-loader.ts
@@ -1,6 +1,7 @@
 import pLimit from "p-limit";
 import { reactive } from "vue";
 import { listRemoteDirectory } from "@/utils/remote-file-transport";
+import { gatewayErrorMessage, gatewayErrorPayload } from "@/utils/gateway-error";
 import type { RemoteDirectoryState } from "./types";
 
 const DIRECTORY_LOAD_CONCURRENCY = 3;
@@ -22,6 +23,7 @@ export class RemoteDirectoryLoader {
       loaded: false,
       loadedAt: 0,
       error: null,
+      errorCode: null,
       stale: true,
     });
   }
@@ -36,6 +38,7 @@ export class RemoteDirectoryLoader {
       if (!force && !isDirectoryStale(state)) return state;
       state.loading = true;
       state.error = null;
+      state.errorCode = null;
       try {
         const result = await listRemoteDirectory(hostId, path);
         state.path = result.path;
@@ -44,7 +47,18 @@ export class RemoteDirectoryLoader {
         state.loadedAt = Date.now();
         state.stale = false;
       } catch (error) {
-        state.error = error instanceof Error ? error.message : String(error);
+        const payload = gatewayErrorPayload(error);
+        state.error = gatewayErrorMessage(error, "Failed to read remote directory");
+        state.errorCode = payload.code ?? null;
+        if (isPermanentDirectoryError(payload.statusCode, payload.code)) {
+          // A deleted or inaccessible path does not become healthy with time. Mark it loaded so
+          // panel activation and visibility recovery do not retry it forever. Explicit refresh or
+          // expanding the path again still passes force=true and performs a new SFTP read.
+          state.entries = [];
+          state.loaded = true;
+          state.loadedAt = Date.now();
+          state.stale = false;
+        }
       } finally {
         state.loading = false;
       }
@@ -67,7 +81,20 @@ export class RemoteDirectoryLoader {
   }
 }
 
+export function isPermanentDirectoryError(statusCode?: number, code?: string) {
+  return (
+    statusCode === 403 ||
+    statusCode === 404 ||
+    code === "remoteDirectoryNotFound" ||
+    code === "remoteDirectoryAccessDenied"
+  );
+}
+
 function isDirectoryStale(state: RemoteDirectoryState) {
+  // Time-based revalidation is for previously successful and transiently failed reads. A stable
+  // 404/403 must stay quiet until an explicit user action forces a retry; otherwise every panel
+  // activation resumes the same SFTP/log storm after DIRECTORY_STALE_AFTER_MS.
+  if (isPermanentDirectoryError(undefined, state.errorCode ?? undefined)) return false;
   return (
     state.loading ||
     state.stale ||

--- a/app/stores/file-workspace/index.ts
+++ b/app/stores/file-workspace/index.ts
@@ -7,7 +7,7 @@ import {
   updateFileDocumentDraft,
 } from "./document-runtime";
 import { createFileDocumentActions } from "./document-actions";
-import { RemoteDirectoryLoader } from "./directory-loader";
+import { isPermanentDirectoryError, RemoteDirectoryLoader } from "./directory-loader";
 import { createFileWorkspaceScopeState } from "./scope-state";
 import {
   absolutePath,
@@ -15,6 +15,7 @@ import {
   directoryPathsToFile,
   parentPath,
   parentPaths,
+  withoutPathAndDescendants,
 } from "./paths";
 import type { RemoteDirectoryState } from "./types";
 
@@ -51,7 +52,11 @@ export const useGatewayFileWorkspaceStore = defineStore(
       }
       const key = directoryStateKey(hostId, threadId, path);
       const state = ensureDirectoryState(key, path);
-      return directoryLoader.load(state, scope.hostId, path, force);
+      const result = await directoryLoader.load(state, scope.hostId, path, force);
+      if (isPermanentDirectoryError(undefined, result.errorCode ?? undefined)) {
+        scope.expandedPaths = withoutPathAndDescendants(scope.expandedPaths, path);
+      }
+      return result;
     }
 
     function directoryFor(hostId: number, threadId: string, path: string) {
@@ -65,7 +70,17 @@ export const useGatewayFileWorkspaceStore = defineStore(
       }
       const added = paths.filter((path) => !scope.expandedPaths.includes(path));
       scope.expandedPaths = paths;
-      await Promise.all(added.map((path) => loadDirectory(hostId, threadId, path)));
+      await Promise.all(
+        added.map((path) => {
+          const state = directoryFor(hostId, threadId, path);
+          return loadDirectory(
+            hostId,
+            threadId,
+            path,
+            isPermanentDirectoryError(undefined, state?.errorCode ?? undefined),
+          );
+        }),
+      );
     }
 
     async function revealFileInTree(hostId: number, threadId: string, path: string) {

--- a/app/stores/file-workspace/paths.ts
+++ b/app/stores/file-workspace/paths.ts
@@ -49,6 +49,12 @@ export function absolutePath(rootPath: string, path: string) {
   return path.startsWith("/") ? path : `${rootPath.replace(/\/$/, "")}/${path}`;
 }
 
+export function withoutPathAndDescendants(paths: string[], removedPath: string) {
+  return paths.filter(
+    (path) => path !== removedPath && !path.startsWith(`${removedPath.replace(/\/$/, "")}/`),
+  );
+}
+
 function normalizeRemotePath(path: string) {
   return path.replace(/\/+$/, "") || "/";
 }

--- a/app/stores/file-workspace/types.ts
+++ b/app/stores/file-workspace/types.ts
@@ -15,6 +15,7 @@ export interface RemoteDirectoryState extends RemoteDirectoryResult {
   loaded: boolean;
   loadedAt: number;
   error: string | null;
+  errorCode: string | null;
   stale: boolean;
 }
 

--- a/server/utils/gateway/infra/codex-artifacts.ts
+++ b/server/utils/gateway/infra/codex-artifacts.ts
@@ -1,14 +1,17 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
-import { createReadStream } from "node:fs";
+import { createReadStream, createWriteStream } from "node:fs";
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import type { CodexRemotePlatform } from "./codex-platform";
 
 const execFileAsync = promisify(execFile);
 const NPM_COMMAND_TIMEOUT_MS = 10 * 60_000;
+const ARTIFACT_IDLE_TTL_MS = 30_000;
 
 export interface CodexArtifactBundle {
   cacheArchive: {
@@ -17,11 +20,21 @@ export interface CodexArtifactBundle {
     size: number;
     sha512: string;
   };
+  nodeArchive: NodeArtifact | null;
+}
+
+interface NodeArtifact {
+  localPath: string;
+  fileName: string;
+  directoryName: string;
+  version: string;
+  sha256: string;
 }
 
 interface SharedBundle {
   promise: Promise<PreparedBundle>;
   users: number;
+  cleanupTimer: NodeJS.Timeout | null;
 }
 
 interface PreparedBundle {
@@ -35,33 +48,49 @@ export class CodexArtifactProvider {
   async withArtifacts<T>(
     version: string,
     platform: CodexRemotePlatform,
+    options: { includeNode: boolean },
     callback: (artifacts: CodexArtifactBundle) => Promise<T>,
   ) {
-    const key = `${version}:${platform.packageName}`;
+    const key = `${version}:${platform.packageName}:${options.includeNode}`;
     let entry = this.shared.get(key);
     if (!entry) {
-      entry = { promise: prepareBundle(version, platform), users: 0 };
+      const promise = prepareBundle(version, platform, options).catch((error) => {
+        this.shared.delete(key);
+        throw error;
+      });
+      entry = { promise, users: 0, cleanupTimer: null };
       this.shared.set(key, entry);
     }
+    if (entry.cleanupTimer) {
+      clearTimeout(entry.cleanupTimer);
+      entry.cleanupTimer = null;
+    }
     entry.users += 1;
-
     try {
       const prepared = await entry.promise;
       return await callback(prepared.artifacts);
     } finally {
       entry.users -= 1;
-      if (entry.users === 0 && this.shared.get(key) === entry) {
-        this.shared.delete(key);
-        const prepared = await entry.promise.catch(() => null);
-        if (prepared) await rm(prepared.directory, { recursive: true, force: true });
-      }
+      if (entry.users === 0) this.scheduleCleanup(key, entry);
     }
+  }
+
+  private scheduleCleanup(key: string, entry: SharedBundle) {
+    entry.cleanupTimer = setTimeout(() => {
+      if (entry.users || this.shared.get(key) !== entry) return;
+      this.shared.delete(key);
+      void entry.promise.then(({ directory }) =>
+        rm(directory, { recursive: true, force: true }).catch(() => undefined),
+      );
+    }, ARTIFACT_IDLE_TTL_MS);
+    entry.cleanupTimer.unref();
   }
 }
 
 async function prepareBundle(
   version: string,
   platform: CodexRemotePlatform,
+  options: { includeNode: boolean },
 ): Promise<PreparedBundle> {
   const directory = await mkdtemp(join(tmpdir(), "codex-gateway-artifacts-"));
   const cacheDirectory = join(directory, "npm-cache");
@@ -74,6 +103,7 @@ async function prepareBundle(
     await npm(["cache", "add", "--cache", cacheDirectory, platformSpec]);
     await run("tar", ["-czf", archivePath, "-C", cacheDirectory, "."]);
     const file = await stat(archivePath);
+    const nodeArchive = options.includeNode ? await prepareNodeArtifact(directory, platform) : null;
     return {
       directory,
       artifacts: {
@@ -83,12 +113,47 @@ async function prepareBundle(
           size: file.size,
           sha512: await hashFile(archivePath),
         },
+        nodeArchive,
       },
     };
   } catch (error) {
     await rm(directory, { recursive: true, force: true });
     throw error;
   }
+}
+
+async function prepareNodeArtifact(
+  directory: string,
+  platform: CodexRemotePlatform,
+): Promise<NodeArtifact> {
+  const version = process.versions.node;
+  const directoryName = `node-v${version}-${platform.nodeTarget}`;
+  const fileName = `${directoryName}.tar.gz`;
+  const releaseRoot = `https://nodejs.org/dist/v${version}`;
+  const checksumsResponse = await fetch(`${releaseRoot}/SHASUMS256.txt`);
+  if (!checksumsResponse.ok) {
+    throw new Error(
+      `Failed to download official Node.js checksums: HTTP ${checksumsResponse.status}`,
+    );
+  }
+  const checksums = await checksumsResponse.text();
+  const checksumLine = checksums.split("\n").find((line) => line.trim().endsWith(`  ${fileName}`));
+  const sha256 = checksumLine?.trim().split(/\s+/, 1)[0];
+  if (!sha256 || !/^[a-f0-9]{64}$/.test(sha256)) {
+    throw new Error(`Official Node.js checksums do not contain ${fileName}`);
+  }
+
+  const response = await fetch(`${releaseRoot}/${fileName}`);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download official Node.js ${fileName}: HTTP ${response.status}`);
+  }
+  const localPath = join(directory, fileName);
+  await pipeline(Readable.fromWeb(response.body as any), createWriteStream(localPath));
+  const downloadedHash = await hashFile(localPath, "sha256");
+  if (downloadedHash !== sha256) {
+    throw new Error(`Official Node.js archive checksum mismatch for ${fileName}`);
+  }
+  return { localPath, fileName, directoryName, version, sha256 };
 }
 
 async function readOfficialPlatformSpec(version: string, packageName: string) {
@@ -123,8 +188,8 @@ async function run(command: string, args: string[]) {
   });
 }
 
-async function hashFile(path: string) {
-  const hash = createHash("sha512");
+async function hashFile(path: string, algorithm = "sha512") {
+  const hash = createHash(algorithm);
   await new Promise<void>((resolve, reject) => {
     const stream = createReadStream(path);
     stream.on("data", (chunk) => hash.update(chunk));

--- a/server/utils/gateway/infra/codex-platform.ts
+++ b/server/utils/gateway/infra/codex-platform.ts
@@ -6,6 +6,7 @@ export interface CodexRemotePlatform {
     | "@openai/codex-darwin-x64"
     | "@openai/codex-linux-arm64"
     | "@openai/codex-linux-x64";
+  nodeTarget: "darwin-arm64" | "darwin-x64" | "linux-arm64" | "linux-x64";
 }
 
 const PLATFORM_PACKAGES = {
@@ -28,5 +29,6 @@ export function parseCodexRemotePlatform(output: string): CodexRemotePlatform {
     platform: platform as CodexRemotePlatform["platform"],
     arch: arch as CodexRemotePlatform["arch"],
     packageName,
+    nodeTarget: key.replace(":", "-") as CodexRemotePlatform["nodeTarget"],
   };
 }

--- a/server/utils/gateway/infra/codex-runtime.ts
+++ b/server/utils/gateway/infra/codex-runtime.ts
@@ -9,11 +9,14 @@ import { currentGatewayUserId } from "../state/memory";
 import type { SshConnectionPool } from "./ssh-connection";
 import { AppServerRuntimeProbe } from "./app-server-runtime-probe";
 import { CodexUpgrader } from "./codex-upgrader";
+import { CodexUpgradeWorkflow } from "./codex-upgrade-workflow";
 import { CodexVersionChecker } from "./codex-version-checker";
 import { HostVerifyService } from "./host-verify-service";
 
 export class CodexRuntimeService {
   private readonly versionChecks = new Map<string, Promise<RemoteCodexVersionState>>();
+  private readonly deferredUpgradeChecks = new Map<string, Promise<boolean>>();
+  private readonly upgradeWorkflow: CodexUpgradeWorkflow;
   private readonly appServerRuntime: AppServerRuntimeProbe;
   private readonly upgrader: CodexUpgrader;
   private readonly versionChecker: CodexVersionChecker;
@@ -23,6 +26,11 @@ export class CodexRuntimeService {
     this.appServerRuntime = new AppServerRuntimeProbe(ssh);
     this.upgrader = new CodexUpgrader(ssh);
     this.versionChecker = new CodexVersionChecker(ssh);
+    this.upgradeWorkflow = new CodexUpgradeWorkflow(
+      this.appServerRuntime,
+      this.upgrader,
+      this.versionChecker,
+    );
     this.verifier = new HostVerifyService(ssh, (host) => this.ensureCodexVersion(host));
   }
 
@@ -95,49 +103,24 @@ export class CodexRuntimeService {
 
       if (runtimeState.running) {
         if (await this.appServerRuntime.hasActiveLoadedThread(host)) {
-          throw new Error(
-            `Remote Codex runtime ${currentRuntimeVersion} is below supported ${supportedVersion}, but a loaded thread is active`,
-          );
+          hostLifecycleBus.emit({
+            hostId: host.id,
+            status: "connecting",
+            message: `${hostDisplayName(host)} 仍有活动对话，Codex ${currentRuntimeVersion} -> ${supportedVersion} 升级已延后`,
+          });
+          return {
+            version: beforeVersion,
+            appServerVersion,
+            supportedVersion,
+            beforeVersion,
+            upgraded: false,
+            deferredUpgrade: true,
+          };
         }
       }
 
       if (!cliVersionSupported) {
-        hostLifecycleBus.emit({
-          hostId: host.id,
-          status: "upgrading",
-          message: `正在为 ${hostDisplayName(host)} 准备 Codex ${supportedVersion} 官方 npm 安装包`,
-        });
-        const version = await this.upgrader.withPreparedUpgrade(
-          host,
-          supportedVersion,
-          async (install) => {
-            if (runtimeState.running) await this.appServerRuntime.terminateUnmanaged(host);
-            hostLifecycleBus.emit({
-              hostId: host.id,
-              status: "upgrading",
-              message: `正在离线升级 ${hostDisplayName(host)} 的远端 Codex ${beforeVersion} -> ${supportedVersion}`,
-            });
-            return await install();
-          },
-        );
-        await this.appServerRuntime.ensureStoppedAfterUpgrade(host);
-        if (!isCodexVersionAtLeast(version, supportedVersion)) {
-          throw new Error(
-            `Remote Codex upgraded to ${version}, still below supported ${supportedVersion}`,
-          );
-        }
-        hostLifecycleBus.emit({
-          hostId: host.id,
-          status: "restarting",
-          message: `${hostDisplayName(host)} 的远端 Codex 已升级到 ${version}，正在重启 app-server`,
-        });
-        return {
-          version,
-          appServerVersion: null,
-          supportedVersion,
-          beforeVersion,
-          upgraded: true,
-        };
+        return await this.upgradeWorkflow.upgradeOutdatedCli(host, supportedVersion, beforeVersion);
       }
 
       if (runtimeState.running) await this.appServerRuntime.terminateUnmanaged(host);
@@ -167,6 +150,20 @@ export class CodexRuntimeService {
     this.versionChecks.delete(this.hostKey(hostId));
   }
 
+  completeDeferredUpgrade(host: HostWithSecret) {
+    const key = this.hostKey(host.id);
+    const pending = this.deferredUpgradeChecks.get(key);
+    if (pending) return pending;
+
+    const check = this.stopIdleOutdatedRuntime(host).finally(() => {
+      if (this.deferredUpgradeChecks.get(key) === check) {
+        this.deferredUpgradeChecks.delete(key);
+      }
+    });
+    this.deferredUpgradeChecks.set(key, check);
+    return check;
+  }
+
   async repairAfterProxyFailure(
     host: HostWithSecret,
     error: unknown,
@@ -181,37 +178,23 @@ export class CodexRuntimeService {
       message: `${hostDisplayName(host)} 的远端 Codex app-server 启动失败，正在重新安装 ${SUPPORTED_CODEX_VERSION}：${messageFromError(error)}`,
     });
 
-    const beforeVersion = await this.readVersionForRepair(host);
-    await this.stopRuntimeIfPresent(host);
-    const version = await this.upgrader.upgrade(host, SUPPORTED_CODEX_VERSION);
-    await this.appServerRuntime.ensureStoppedAfterUpgrade(host);
+    return await this.upgradeWorkflow.repair(host);
+  }
 
-    return {
-      version,
-      appServerVersion: null,
-      supportedVersion: SUPPORTED_CODEX_VERSION,
-      beforeVersion,
-      upgraded: true,
-    };
+  private async stopIdleOutdatedRuntime(host: HostWithSecret) {
+    if (await this.appServerRuntime.hasActiveLoadedThread(host)) return false;
+    hostLifecycleBus.emit({
+      hostId: host.id,
+      status: "restarting",
+      message: `${hostDisplayName(host)} 的活动对话已结束，正在执行延后的 Codex 升级`,
+    });
+    await this.appServerRuntime.terminateUnmanaged(host);
+    this.clearVersionCheck(host.id);
+    return true;
   }
 
   private hostKey(hostId: number) {
     return `${currentGatewayUserId() ?? "anonymous"}:${hostId}`;
-  }
-
-  private async readVersionForRepair(host: HostWithSecret) {
-    try {
-      return await this.versionChecker.readVersionOrRecoverableMissing(host);
-    } catch {
-      return "0.0.0";
-    }
-  }
-
-  private async stopRuntimeIfPresent(host: HostWithSecret) {
-    const runtimeState = await this.appServerRuntime.readState(host);
-    if (runtimeState.running) {
-      await this.appServerRuntime.terminateUnmanaged(host);
-    }
   }
 }
 

--- a/server/utils/gateway/infra/codex-upgrade-queue.ts
+++ b/server/utils/gateway/infra/codex-upgrade-queue.ts
@@ -1,0 +1,19 @@
+import pLimit from "p-limit";
+import { currentGatewayUserId, runWithGatewayUser } from "../state/memory";
+
+/**
+ * Remote installs share the Gateway's outbound bandwidth, so only artifact preparation, transfer,
+ * and installation are serialized. Version probes and normal Host traffic stay concurrent.
+ */
+export class CodexUpgradeQueue {
+  private readonly limit = pLimit(1);
+
+  get busy() {
+    return this.limit.activeCount > 0 || this.limit.pendingCount > 0;
+  }
+
+  async run<T>(work: () => Promise<T>) {
+    const userId = currentGatewayUserId();
+    return await this.limit(() => (userId ? runWithGatewayUser(userId, work) : work()));
+  }
+}

--- a/server/utils/gateway/infra/codex-upgrade-remote.ts
+++ b/server/utils/gateway/infra/codex-upgrade-remote.ts
@@ -6,11 +6,23 @@ export function codexRemotePlatformProbePayload() {
   return codexRemoteBootstrapPayload(
     `
 set -eu
-if ! command -v node >/dev/null 2>&1; then
-  echo "Node.js is required to manage the official npm Codex installation" >&2
-  exit 127
-fi
-node -p 'process.platform + " " + process.arch'
+case "$(uname -s)" in Linux) platform=linux ;; Darwin) platform=darwin ;; *) echo "Unsupported remote OS: $(uname -s)" >&2; exit 1 ;; esac
+case "$(uname -m)" in x86_64|amd64) arch=x64 ;; arm64|aarch64) arch=arm64 ;; *) echo "Unsupported remote architecture: $(uname -m)" >&2; exit 1 ;; esac
+printf '%s %s\n' "$platform" "$arch"
+`,
+    { requireCodex: false },
+  );
+}
+
+export function codexRemoteNodeRuntimeProbePayload() {
+  return codexRemoteBootstrapPayload(
+    `
+set -eu
+node_major="$(node -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null || true)"
+case "$node_major" in ""|*[!0-9]*) exit 1 ;; esac
+[ "$node_major" -ge 16 ]
+command -v npm >/dev/null 2>&1
+printf '%s %s\n' "$(node --version)" "$(command -v node)"
 `,
     { requireCodex: false },
   );
@@ -41,6 +53,7 @@ export function codexRemoteOfflineInstallPayload(input: {
   artifacts: CodexArtifactBundle;
 }) {
   const archiveFile = `${input.stagePath}/${input.artifacts.cacheArchive.fileName}`;
+  const nodeArchive = input.artifacts.nodeArchive;
   return codexRemoteBootstrapPayload(
     `
 set -eu
@@ -54,6 +67,48 @@ trap cleanup EXIT HUP INT TERM
 archive_file=${shellQuote(archiveFile)}
 expected_archive_sha=${shellQuote(input.artifacts.cacheArchive.sha512)}
 npm_cache="$stage/npm-cache"
+
+verify_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$2" "$1" | sha256sum -c - >/dev/null
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$1" | awk '{print $1}')"
+    [ "$actual" = "$2" ]
+    return
+  fi
+  echo "sha256sum or shasum is required to verify the official Node.js archive" >&2
+  return 1
+}
+
+${
+  nodeArchive
+    ? `
+node_archive=${shellQuote(`${input.stagePath}/${nodeArchive.fileName}`)}
+verify_sha256 "$node_archive" ${shellQuote(nodeArchive.sha256)}
+managed_node_dir="$HOME/.nvm/versions/node/v${nodeArchive.version}"
+managed_node_tmp="$managed_node_dir.codex-gateway.$$"
+rm -rf "$managed_node_tmp"
+mkdir -p "$(dirname "$managed_node_dir")" "$stage/node-extract"
+tar -xzf "$node_archive" -C "$stage/node-extract"
+mv "$stage/node-extract/${nodeArchive.directoryName}" "$managed_node_tmp"
+rm -rf "$managed_node_dir"
+mv "$managed_node_tmp" "$managed_node_dir"
+PATH="$managed_node_dir/bin:$PATH"
+export PATH
+hash -r
+`
+    : ""
+}
+
+node_major="$(node -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null || true)"
+case "$node_major" in ""|*[!0-9]*|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15)
+  echo "Node.js >=16 with npm is required after bootstrap; selected $(node --version 2>/dev/null || echo missing)" >&2
+  exit 127
+  ;;
+esac
+command -v npm >/dev/null 2>&1 || { echo "npm is required after Node.js bootstrap" >&2; exit 127; }
 
 verify_sha512() {
   node -e '

--- a/server/utils/gateway/infra/codex-upgrade-workflow.ts
+++ b/server/utils/gateway/infra/codex-upgrade-workflow.ts
@@ -1,0 +1,160 @@
+import { SUPPORTED_CODEX_VERSION, isCodexVersionAtLeast } from "./codex-version";
+import { hostLifecycleBus } from "../state/host-events";
+import type { HostWithSecret, RemoteCodexVersionState } from "./ssh-types";
+import type { AppServerRuntimeProbe } from "./app-server-runtime-probe";
+import type { CodexUpgrader } from "./codex-upgrader";
+import { CodexUpgradeQueue } from "./codex-upgrade-queue";
+import type { CodexVersionChecker } from "./codex-version-checker";
+
+export class CodexUpgradeWorkflow {
+  private readonly queue = new CodexUpgradeQueue();
+
+  constructor(
+    private readonly runtime: AppServerRuntimeProbe,
+    private readonly upgrader: CodexUpgrader,
+    private readonly versionChecker: CodexVersionChecker,
+  ) {}
+
+  async repair(host: HostWithSecret): Promise<RemoteCodexVersionState> {
+    return await this.runExclusive(host, async () => {
+      const beforeVersion = await this.readVersionForRepair(host);
+      await this.stopRuntimeIfPresent(host);
+      const version = await this.upgrader.upgrade(host, SUPPORTED_CODEX_VERSION);
+      await this.runtime.ensureStoppedAfterUpgrade(host);
+
+      return {
+        version,
+        appServerVersion: null,
+        supportedVersion: SUPPORTED_CODEX_VERSION,
+        beforeVersion,
+        upgraded: true,
+      };
+    });
+  }
+
+  async upgradeOutdatedCli(
+    host: HostWithSecret,
+    supportedVersion: string,
+    observedBeforeVersion: string,
+  ): Promise<RemoteCodexVersionState> {
+    return await this.runExclusive(host, async () => {
+      // Hosts can wait in this queue for several minutes. Re-read both CLI and app-server state
+      // when this Host reaches the front so a newly started thread is never interrupted and an
+      // externally completed upgrade is not repeated.
+      const beforeVersion = await this.versionChecker.readVersionOrRecoverableMissing(host);
+      const runtimeState = await this.runtime.readState(host);
+      const currentRuntimeVersion = runtimeState.appServerVersion ?? beforeVersion;
+      const cliVersionSupported = isCodexVersionAtLeast(beforeVersion, supportedVersion);
+      const runtimeVersionSupported = isCodexVersionAtLeast(
+        currentRuntimeVersion,
+        supportedVersion,
+      );
+
+      if (runtimeState.running && !runtimeVersionSupported) {
+        if (await this.runtime.hasActiveLoadedThread(host)) {
+          throw new Error(
+            `Remote Codex runtime ${currentRuntimeVersion} is below supported ${supportedVersion}, but a loaded thread is active`,
+          );
+        }
+      }
+
+      if (cliVersionSupported) {
+        if (runtimeState.running && !runtimeVersionSupported) {
+          await this.runtime.terminateUnmanaged(host);
+        }
+        hostLifecycleBus.emit({
+          hostId: host.id,
+          status: runtimeVersionSupported ? "connecting" : "restarting",
+          message: runtimeVersionSupported
+            ? `${hostDisplayName(host)} 的远端 Codex 已是最新版本 ${beforeVersion}`
+            : `${hostDisplayName(host)} 的远端 Codex CLI 已是 ${beforeVersion}，正在重启旧 app-server ${currentRuntimeVersion}`,
+        });
+        return {
+          version: beforeVersion,
+          appServerVersion: runtimeVersionSupported ? runtimeState.appServerVersion : null,
+          supportedVersion,
+          beforeVersion: observedBeforeVersion,
+          upgraded: false,
+        };
+      }
+
+      const version = await this.install(host, supportedVersion, beforeVersion);
+      return {
+        version,
+        appServerVersion: null,
+        supportedVersion,
+        beforeVersion,
+        upgraded: true,
+      };
+    });
+  }
+
+  private async install(host: HostWithSecret, supportedVersion: string, beforeVersion: string) {
+    hostLifecycleBus.emit({
+      hostId: host.id,
+      status: "upgrading",
+      message: `正在为 ${hostDisplayName(host)} 准备 Codex ${supportedVersion} 官方 npm 安装包`,
+    });
+    const version = await this.upgrader.withPreparedUpgrade(
+      host,
+      supportedVersion,
+      async (install) => {
+        const latestRuntimeState = await this.runtime.readState(host);
+        if (latestRuntimeState.running) {
+          if (await this.runtime.hasActiveLoadedThread(host)) {
+            throw new Error(
+              `Remote Codex runtime is below supported ${supportedVersion}, but a loaded thread became active while waiting to upgrade`,
+            );
+          }
+          await this.runtime.terminateUnmanaged(host);
+        }
+        hostLifecycleBus.emit({
+          hostId: host.id,
+          status: "upgrading",
+          message: `正在离线升级 ${hostDisplayName(host)} 的远端 Codex ${beforeVersion} -> ${supportedVersion}`,
+        });
+        return await install();
+      },
+    );
+    await this.runtime.ensureStoppedAfterUpgrade(host);
+    if (!isCodexVersionAtLeast(version, supportedVersion)) {
+      throw new Error(
+        `Remote Codex upgraded to ${version}, still below supported ${supportedVersion}`,
+      );
+    }
+    hostLifecycleBus.emit({
+      hostId: host.id,
+      status: "restarting",
+      message: `${hostDisplayName(host)} 的远端 Codex 已升级到 ${version}，正在重启 app-server`,
+    });
+    return version;
+  }
+
+  private async runExclusive<T>(host: HostWithSecret, work: () => Promise<T>) {
+    if (this.queue.busy) {
+      hostLifecycleBus.emit({
+        hostId: host.id,
+        status: "upgrading",
+        message: `${hostDisplayName(host)} 正在等待 Codex 升级队列`,
+      });
+    }
+    return await this.queue.run(work);
+  }
+
+  private async readVersionForRepair(host: HostWithSecret) {
+    try {
+      return await this.versionChecker.readVersionOrRecoverableMissing(host);
+    } catch {
+      return "0.0.0";
+    }
+  }
+
+  private async stopRuntimeIfPresent(host: HostWithSecret) {
+    const runtimeState = await this.runtime.readState(host);
+    if (runtimeState.running) await this.runtime.terminateUnmanaged(host);
+  }
+}
+
+function hostDisplayName(host: HostWithSecret) {
+  return host.name || host.sshHost;
+}

--- a/server/utils/gateway/infra/codex-upgrader.ts
+++ b/server/utils/gateway/infra/codex-upgrader.ts
@@ -5,6 +5,7 @@ import {
   codexRemoteCleanupUpgradeStagePayload,
   codexRemoteCreateUpgradeStagePayload,
   codexRemoteOfflineInstallPayload,
+  codexRemoteNodeRuntimeProbePayload,
   codexRemotePlatformProbePayload,
 } from "./codex-upgrade-remote";
 import { parseCodexVersion } from "./codex-version";
@@ -37,9 +38,21 @@ export class CodexUpgrader {
     callback: (install: () => Promise<string>) => Promise<T>,
   ) {
     const platform = await this.readRemotePlatform(host);
-    return await artifactProvider.withArtifacts(version, platform, async (artifacts) =>
-      callback(() => this.installWithRetries(host, version, artifacts)),
+    const includeNode = await this.requiresNodeBootstrap(host);
+    return await artifactProvider.withArtifacts(
+      version,
+      platform,
+      { includeNode },
+      async (artifacts) => callback(() => this.installWithRetries(host, version, artifacts)),
     );
+  }
+
+  private async requiresNodeBootstrap(host: HostWithSecret) {
+    const result = await this.ssh.exec(
+      host,
+      remoteLoginShellCommand(codexRemoteNodeRuntimeProbePayload()),
+    );
+    return result.code !== 0;
   }
 
   private async readRemotePlatform(host: HostWithSecret) {
@@ -78,6 +91,13 @@ export class CodexUpgrader {
   private async installOnce(host: HostWithSecret, version: string, artifacts: CodexArtifactBundle) {
     const stagePath = await this.createRemoteStage(host);
     try {
+      if (artifacts.nodeArchive) {
+        await this.ssh.uploadFileResumable(
+          host,
+          artifacts.nodeArchive.localPath,
+          `${stagePath}/${artifacts.nodeArchive.fileName}`,
+        );
+      }
       await this.ssh.uploadFileResumable(
         host,
         artifacts.cacheArchive.localPath,

--- a/server/utils/gateway/infra/remote-command.ts
+++ b/server/utils/gateway/infra/remote-command.ts
@@ -16,6 +16,7 @@ function codexPathBootstrap(options: { requireCodex: boolean }) {
   return [
     'codex_gateway_path_add() { if [ -d "$1" ]; then case ":$PATH:" in *":$1:"*) ;; *) PATH="$PATH:$1" ;; esac; fi; };',
     'for dir in "${CODEX_INSTALL_DIR:-$HOME/.local/bin}" "$HOME/.local/bin" "$HOME/.npm-global/bin" "$HOME/.bun/bin" "$HOME/.nvm/current/bin" "$HOME/.nvm/versions/node"/*/bin /opt/homebrew/bin /opt/node/bin /usr/local/bin /usr/bin; do codex_gateway_path_add "$dir"; done; export PATH;',
+    modernNodePathBootstrap(),
     'CODEX_BIN="$(command -v codex 2>/dev/null || true)";',
     'if [ -z "$CODEX_BIN" ] && [ -x "${CODEX_INSTALL_DIR:-$HOME/.local/bin}/codex" ]; then CODEX_BIN="${CODEX_INSTALL_DIR:-$HOME/.local/bin}/codex"; fi;',
     'if [ -z "$CODEX_BIN" ] && command -v npm >/dev/null 2>&1; then NPM_PREFIX="$(npm prefix -g 2>/dev/null || true)"; if [ -n "$NPM_PREFIX" ] && [ -x "$NPM_PREFIX/bin/codex" ]; then CODEX_BIN="$NPM_PREFIX/bin/codex"; fi; fi;',
@@ -25,6 +26,27 @@ function codexPathBootstrap(options: { requireCodex: boolean }) {
       : "",
     "export CODEX_BIN;",
   ].join(" ");
+}
+
+function modernNodePathBootstrap() {
+  return `
+CODEX_GATEWAY_NODE_DIR=""
+CODEX_GATEWAY_NODE_MAJOR=0
+for node_bin in "$(command -v node 2>/dev/null || true)" "$HOME/.nvm/current/bin/node" "$HOME/.nvm/versions/node"/*/bin/node "$HOME/.local/share/fnm/node-versions"/*/installation/bin/node "$HOME/.volta/bin/node" /opt/homebrew/bin/node /opt/node/bin/node /usr/local/bin/node /usr/bin/node; do
+  [ -x "$node_bin" ] || continue
+  node_major="$("$node_bin" -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null || true)"
+  case "$node_major" in ""|*[!0-9]*) continue ;; esac
+  node_dir="$(dirname "$node_bin")"
+  if [ "$node_major" -ge 16 ] && [ "$node_major" -gt "$CODEX_GATEWAY_NODE_MAJOR" ] && [ -x "$node_dir/npm" ]; then
+    CODEX_GATEWAY_NODE_DIR="$node_dir"
+    CODEX_GATEWAY_NODE_MAJOR="$node_major"
+  fi
+done
+if [ -n "$CODEX_GATEWAY_NODE_DIR" ]; then
+  PATH="$CODEX_GATEWAY_NODE_DIR:$PATH"
+  export PATH
+fi
+`;
 }
 
 export function codexRemoteAppServerStartPayload() {

--- a/server/utils/gateway/infra/remote-files.ts
+++ b/server/utils/gateway/infra/remote-files.ts
@@ -22,6 +22,21 @@ export class RemoteDirectoryNotFoundError extends Error {
   }
 }
 
+export class RemoteDirectoryAccessDeniedError extends Error {
+  readonly statusCode = 403;
+  readonly code = "remoteDirectoryAccessDenied";
+
+  constructor(
+    readonly inputPath: string,
+    readonly resolvedPath: string,
+  ) {
+    super(
+      `Permission denied while reading remote directory: ${inputPath} (resolved to ${resolvedPath})`,
+    );
+    this.name = "RemoteDirectoryAccessDeniedError";
+  }
+}
+
 export class RemoteFileService {
   constructor(private readonly ssh: SshConnectionPool) {}
 
@@ -31,7 +46,7 @@ export class RemoteFileService {
     return new Promise<ReturnType<typeof directoryResult>>((resolve, reject) => {
       sftp.readdir(resolvedPath, (readError, entries) => {
         if (readError) {
-          reject(readError);
+          reject(directoryReadError(readError, path, resolvedPath));
           return;
         }
         resolve(directoryResult(resolvedPath, entries));
@@ -264,6 +279,21 @@ async function inspectDirectory(
 function isMissingSftpPath(error: unknown) {
   const code = (error as { code?: unknown })?.code;
   return code === 2 || code === "ENOENT";
+}
+
+function isDeniedSftpPath(error: unknown) {
+  const code = (error as { code?: unknown })?.code;
+  return code === 3 || code === "EACCES" || code === "EPERM";
+}
+
+function directoryReadError(error: unknown, inputPath: string, resolvedPath: string) {
+  if (isMissingSftpPath(error)) {
+    return new RemoteDirectoryNotFoundError(inputPath, resolvedPath);
+  }
+  if (isDeniedSftpPath(error)) {
+    return new RemoteDirectoryAccessDeniedError(inputPath, resolvedPath);
+  }
+  return error;
 }
 
 function directoryResult(path: string, source: FileEntryWithStats[]) {

--- a/server/utils/gateway/infra/rpc.ts
+++ b/server/utils/gateway/infra/rpc.ts
@@ -25,6 +25,7 @@ export class CodexRpcClient extends EventEmitter {
   private connectPromise: Promise<void> | null = null;
   private readonly requests = new RpcRequestBroker();
   private transport: CodexRpcTransport | null = null;
+  private deferredUpgrade = false;
 
   constructor(
     private readonly host: HostRecord,
@@ -55,6 +56,7 @@ export class CodexRpcClient extends EventEmitter {
     let versionState = this.options.skipVersionCheck
       ? null
       : await codexRuntime.ensureCodexVersion(this.host);
+    this.deferredUpgrade = Boolean(versionState?.deferredUpgrade);
 
     try {
       await this.connectRemoteProxyWebSocket();
@@ -145,6 +147,14 @@ export class CodexRpcClient extends EventEmitter {
     this.requests.rejectAll(new Error("Codex RPC client closed"));
     this.transport?.close();
     this.transport = null;
+  }
+
+  hasDeferredUpgrade() {
+    return this.deferredUpgrade;
+  }
+
+  resolveDeferredUpgrade() {
+    this.deferredUpgrade = false;
   }
 
   private async connectRemoteProxyWebSocket() {

--- a/server/utils/gateway/infra/ssh-types.ts
+++ b/server/utils/gateway/infra/ssh-types.ts
@@ -39,4 +39,5 @@ export interface RemoteCodexVersionState {
   supportedVersion: string;
   beforeVersion: string;
   upgraded: boolean;
+  deferredUpgrade?: boolean;
 }

--- a/server/utils/gateway/runtime/host-rpc-session.ts
+++ b/server/utils/gateway/runtime/host-rpc-session.ts
@@ -6,6 +6,8 @@ import type { HostControllerLookup, HostControllersLookup } from "./types";
 import { threadIdFromNotification } from "../protocol/thread-payload";
 import { threadRuntimeEvents } from "./thread-runtime-events";
 import { activeMainThreadMonitor } from "./active-main-thread-monitor";
+import { codexRuntime } from "../infra/host-services";
+import { runtimeLog } from "./runtime-log";
 
 export class HostRpcSession {
   readonly client: CodexRpcClient;
@@ -67,6 +69,20 @@ export class HostRpcSession {
       },
       message,
     );
+    if (message?.method === "turn/completed" && this.client.hasDeferredUpgrade()) {
+      void codexRuntime
+        .completeDeferredUpgrade(this.host)
+        .then((stopped) => {
+          if (stopped) this.client.resolveDeferredUpgrade();
+        })
+        .catch((error) => {
+          runtimeLog("deferred Codex upgrade check failed", {
+            hostId: this.host.id,
+            hostName: this.host.name,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        });
+    }
     const threadId = threadIdFromNotification(message);
     if (!threadId) {
       return;

--- a/tests/e2e/00-codex-upgrade.spec.ts
+++ b/tests/e2e/00-codex-upgrade.spec.ts
@@ -1,16 +1,19 @@
 import { expect, test } from "@playwright/test";
+import type { HostRecord } from "../../shared/types";
 import { parseCodexVersion } from "../../server/utils/gateway/infra/codex-version";
-import { openApp } from "./helpers/app";
+import { authenticatedFetch, openApp, reloadApp } from "./helpers/app";
 import {
   addRemoteHost,
   addRemoteProject,
   execRemoteSsh,
   readContainerCodexVersion,
   readRemoteEnv,
+  readUpgradeRemoteEnvs,
   resetRemoteAppServer,
   remoteCodexCommand,
   sendTextTurn,
   startRemoteThreadFromProjectMenu,
+  stopRemoteFixture,
 } from "./helpers/remote-codex";
 
 test("parses current Codex CLI and app-server user-agent versions", () => {
@@ -28,49 +31,59 @@ test("parses current Codex CLI and app-server user-agent versions", () => {
   );
 });
 
-test("upgrades an old remote npm Codex install before using the app-server", async ({ page }) => {
-  const remote = await readRemoteEnv();
-  test.skip(
-    !remote.initialCodexVersion ||
-      !remote.supportedCodexVersion ||
-      remote.initialCodexVersion === remote.supportedCodexVersion,
-    "The E2E image is already using the supported Codex version.",
-  );
+test("upgrades empty, legacy Node, and legacy Codex SSH hosts serially", async ({ page }) => {
+  test.setTimeout(10 * 60_000);
+  const environments = await readUpgradeRemoteEnvs();
+  const remote = environments.find(({ runtimeFixture }) => runtimeFixture === "empty-runtime")!;
 
-  await expect
-    .poll(async () => readContainerCodexVersion(remote), {
-      timeout: 30_000,
-    })
-    .toContain(remote.initialCodexVersion!);
+  for (const environment of environments) {
+    await verifyInitialRuntime(environment);
+  }
 
   await openApp(page);
+  const hosts: HostRecord[] = [];
+  for (const environment of environments) {
+    hosts.push(
+      await authenticatedFetch<HostRecord>(page, {
+        url: "/api/hosts",
+        method: "POST",
+        body: {
+          name: `upgrade-${environment.runtimeFixture}-${Date.now()}`,
+          sshHost: environment.host,
+          username: environment.username,
+          port: Number(environment.port),
+          authMode: "password",
+          password: environment.password,
+          proxyUrl: environment.proxyUrl ?? null,
+        },
+      }),
+    );
+  }
 
-  const host = await addRemoteHost(page, remote, `old-codex-upgrade-${Date.now()}`);
-  await expect
-    .poll(async () => readContainerCodexVersion(remote), {
-      timeout: 30_000,
-    })
-    .toContain(remote.supportedCodexVersion!);
+  for (const environment of environments) {
+    await expect
+      .poll(async () => readContainerCodexVersion(environment).catch(() => "runtime not ready"), {
+        timeout: 240_000,
+      })
+      .toContain(environment.supportedCodexVersion!);
+    // Seeing the binary version only proves npm has replaced the package. Wait for the
+    // install shell's cleanup trap instead of coupling this backend test to sidebar state.
+    await verifyOfficialNpmLayout(environment);
+  }
 
-  const npmLayout = await execRemoteSsh(
-    remote,
-    `
-set -eu
-codex_bin=${JSON.stringify(remote.codexBin)}
-codex_bin_dir="$(dirname "$codex_bin")"
-PATH="$codex_bin_dir:$PATH"
-export PATH
-npm_root="$(npm root -g)"
-test -f "$npm_root/@openai/codex/package.json"
-node -e 'require.resolve("@openai/codex-linux-x64/package.json", { paths: [process.argv[1]] })' "$npm_root/@openai/codex"
-if [ -d "$HOME/.cache/codex-gateway/upgrades" ]; then
-  test -z "$(find "$HOME/.cache/codex-gateway/upgrades" -mindepth 1 -maxdepth 1 -type d -name 'upgrade.*' -print -quit)"
-fi
-printf 'official npm layout and staging cleanup verified\\n'
-`,
-  );
-  expect(npmLayout.stdout).toContain("official npm layout and staging cleanup verified");
+  for (const [index, environment] of environments.entries()) {
+    if (environment === remote) continue;
+    await authenticatedFetch(page, {
+      url: `/api/hosts/${hosts[index]!.id}`,
+      method: "DELETE",
+    });
+    await stopRemoteFixture(environment);
+  }
 
+  const host = hosts[environments.indexOf(remote)]!;
+  // Hosts were registered directly through the API so all upgrades could queue immediately.
+  // Refresh once before the sole product-flow test to hydrate Pinia with the surviving Host.
+  await reloadApp(page);
   const project = await addRemoteProject(page, remote, host.id, `upgrade-project-${Date.now()}`);
   const threadId = await startRemoteThreadFromProjectMenu(page, project.id);
   const marker = `E2E 升级后发送 ${Date.now()}`;
@@ -82,6 +95,62 @@ printf 'official npm layout and staging cleanup verified\\n'
     timeout: 120_000,
   });
 });
+
+async function verifyInitialRuntime(remote: Awaited<ReturnType<typeof readRemoteEnv>>) {
+  const checks = {
+    "empty-runtime":
+      "! command -v node && ! command -v npm && ! command -v codex && printf 'empty runtime verified\\n'",
+    "legacy-node": `
+test "$(node --version)" = "v${remote.initialNodeVersion}"
+command -v npm >/dev/null
+! command -v codex
+printf 'legacy Node runtime verified\\n'
+`,
+    "legacy-codex": `
+node_bin=${JSON.stringify(remote.codexBin?.replace(/\/codex$/, "/node"))}
+test "$("$node_bin" --version)" = "v${remote.initialNodeVersion}"
+${remoteCodexCommand(remote)} --version | grep -F ${JSON.stringify(remote.initialCodexVersion)}
+printf 'legacy Codex runtime verified\\n'
+`,
+  } as const;
+  const result = await execRemoteSsh(remote, `set -eu\n${checks[remote.runtimeFixture!]}`);
+  expect(result.stdout).toContain("verified");
+}
+
+async function verifyOfficialNpmLayout(remote: Awaited<ReturnType<typeof readRemoteEnv>>) {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const { stdout } = await execRemoteSsh(
+            remote,
+            `
+set -eu
+codex_bin=${JSON.stringify(remote.codexBin)}
+codex_bin_dir="$(dirname "$codex_bin")"
+PATH="$codex_bin_dir:$PATH"
+export PATH
+npm_root="$(npm root -g)"
+fail() { printf 'npm layout check failed: %s\n' "$1" >&2; exit 1; }
+test -f "$npm_root/@openai/codex/package.json" || fail "missing @openai/codex under $npm_root"
+test "$(node -p 'Number(process.versions.node.split(".")[0])')" -ge 16 || fail "Node is older than 16"
+test "$(command -v node)" = "$(dirname "$codex_bin")/node" || fail "Codex and Node do not share the official npm prefix"
+node -e 'require.resolve("@openai/codex-linux-x64/package.json", { paths: [process.argv[1]] })' "$npm_root/@openai/codex" || fail "missing official platform package"
+if [ -d "$HOME/.cache/codex-gateway/upgrades" ]; then
+  test -z "$(find "$HOME/.cache/codex-gateway/upgrades" -mindepth 1 -maxdepth 1 -type d -name 'upgrade.*' -print -quit)" || fail "remote staging directory was not cleaned"
+fi
+printf 'official npm layout and staging cleanup verified\\n'
+`,
+          );
+          return stdout.trim();
+        } catch (error) {
+          return error instanceof Error ? error.message : String(error);
+        }
+      },
+      { timeout: 120_000 },
+    )
+    .toContain("official npm layout and staging cleanup verified");
+}
 
 test("replaces an existing socket app-server when no loaded turn is active", async ({ page }) => {
   const remote = await readRemoteEnv();

--- a/tests/e2e/browser-preview.spec.ts
+++ b/tests/e2e/browser-preview.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { openApp, reloadApp } from "./helpers/app";
-import { addRemoteHost, readRemoteEnv } from "./helpers/remote-codex";
+import { addRemoteHost, readRemoteEnv, startRemotePreviewServer } from "./helpers/remote-codex";
 
 test("opens a real remote HTTP and WebSocket service through the SSH preview proxy", async ({
   page,
@@ -8,6 +8,7 @@ test("opens a real remote HTTP and WebSocket service through the SSH preview pro
   const remote = await readRemoteEnv();
   await openApp(page);
   await addRemoteHost(page, remote, `preview-host-${Date.now()}`);
+  await startRemotePreviewServer(remote);
 
   await page.getByTestId("open-browser-button").click();
   await page.getByPlaceholder("http://localhost:3000").fill("http://localhost:4173");

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,3 +1,9 @@
+x-ssh-target: &ssh-target
+  environment:
+    CODEX_HOME: /home/codex/.codex
+  volumes:
+    - ../..:/workspace/codex-gateway
+
 services:
   bark-target:
     image: node:22-bookworm
@@ -12,14 +18,30 @@ services:
   ssh-target:
     build:
       context: ./docker
+      target: empty-runtime
+      args:
+        E2E_UID: ${E2E_UID:-12345}
+        E2E_GID: ${E2E_GID:-12345}
+    <<: *ssh-target
+
+  ssh-target-legacy-node:
+    build:
+      context: ./docker
+      target: legacy-node
+      args:
+        E2E_UID: ${E2E_UID:-12345}
+        E2E_GID: ${E2E_GID:-12345}
+    <<: *ssh-target
+
+  ssh-target-legacy-codex:
+    build:
+      context: ./docker
+      target: legacy-codex
       args:
         CODEX_CLI_VERSION: ${E2E_CODEX_CLI_VERSION:-0.140.0}
         E2E_UID: ${E2E_UID:-12345}
         E2E_GID: ${E2E_GID:-12345}
-    environment:
-      CODEX_HOME: /home/codex/.codex
-    volumes:
-      - ../..:/workspace/codex-gateway
+    <<: *ssh-target
 
   build-runner:
     image: codex-gateway-e2e-runner
@@ -41,6 +63,8 @@ services:
     mem_limit: 2g
     depends_on:
       - ssh-target
+      - ssh-target-legacy-node
+      - ssh-target-legacy-codex
       - bark-target
     environment:
       HOST: 0.0.0.0
@@ -81,6 +105,8 @@ services:
       E2E_SOURCE_DIR: /workspace/source
       E2E_CODEX_HOME: /codex-auth
       E2E_REMOTE_HOST: ssh-target
+      E2E_LEGACY_NODE_REMOTE_HOST: ssh-target-legacy-node
+      E2E_LEGACY_CODEX_REMOTE_HOST: ssh-target-legacy-codex
       E2E_REMOTE_PORT: "22"
       E2E_REMOTE_USERNAME: codex
       E2E_REMOTE_PASSWORD: codex

--- a/tests/e2e/docker-environment.ts
+++ b/tests/e2e/docker-environment.ts
@@ -9,7 +9,10 @@ import { SUPPORTED_CODEX_VERSION } from "../../server/utils/gateway/infra/codex-
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const runtimeDir = join(rootDir, ".e2e-runtime", "ssh-container");
 const envFile = join(runtimeDir, "env.json");
-const remoteCodexBin = "/home/codex/.nvm/versions/node/v22.0.0/bin/codex";
+const upgradeEnvFile = join(runtimeDir, "upgrade-env.json");
+const managedCodexBin = `/home/codex/.nvm/versions/node/v${process.versions.node}/bin/codex`;
+
+type RuntimeFixture = "empty-runtime" | "legacy-node" | "legacy-codex";
 
 interface RemoteEnv {
   host: string;
@@ -18,7 +21,9 @@ interface RemoteEnv {
   password: string;
   projectPath: string;
   imagePath: string;
-  initialCodexVersion: string;
+  runtimeFixture: RuntimeFixture;
+  initialNodeVersion: string | null;
+  initialCodexVersion: string | null;
   supportedCodexVersion: string;
   testModel: string;
   codexBin: string;
@@ -28,28 +33,53 @@ interface RemoteEnv {
 export async function startDockerEnvironment() {
   await mkdir(runtimeDir, { recursive: true });
   const password = process.env.E2E_REMOTE_PASSWORD || "codex";
-  const env: RemoteEnv = {
-    host: process.env.E2E_REMOTE_HOST || "ssh-target",
+  const shared = {
     port: process.env.E2E_REMOTE_PORT || "22",
     username: process.env.E2E_REMOTE_USERNAME || "codex",
     password,
     projectPath: process.env.E2E_REMOTE_PROJECT_PATH || "/workspace/codex-gateway",
     imagePath: "/home/codex/e2e-image.png",
-    initialCodexVersion: "",
     supportedCodexVersion: SUPPORTED_CODEX_VERSION,
     testModel: process.env.E2E_CODEX_MODEL || "gpt-5.4-mini",
-    codexBin: remoteCodexBin,
     proxyUrl: null,
   };
+  const environments: RemoteEnv[] = [
+    {
+      ...shared,
+      host: process.env.E2E_REMOTE_HOST || "ssh-target",
+      runtimeFixture: "empty-runtime",
+      initialNodeVersion: null,
+      initialCodexVersion: null,
+      codexBin: managedCodexBin,
+    },
+    {
+      ...shared,
+      host: process.env.E2E_LEGACY_NODE_REMOTE_HOST || "ssh-target-legacy-node",
+      runtimeFixture: "legacy-node",
+      initialNodeVersion: "14.21.3",
+      initialCodexVersion: null,
+      codexBin: managedCodexBin,
+    },
+    {
+      ...shared,
+      host: process.env.E2E_LEGACY_CODEX_REMOTE_HOST || "ssh-target-legacy-codex",
+      runtimeFixture: "legacy-codex",
+      initialNodeVersion: "22.23.1",
+      initialCodexVersion: process.env.E2E_CODEX_CLI_VERSION || "0.140.0",
+      codexBin: "/home/codex/.nvm/versions/node/v22.23.1/bin/codex",
+    },
+  ];
 
-  await waitForSsh(env.host, env.port);
-  env.initialCodexVersion = parseCodexVersionOutput(
-    (await execRemoteSsh(env, `${remoteCodexBin} --version`)).stdout,
-  );
-  await prepareRemoteCodexHome(env);
-  await writeRemoteImage(env);
-  await writeFile(envFile, JSON.stringify(env, null, 2));
-  return env;
+  await Promise.all(environments.map((env) => waitForSsh(env.host, env.port)));
+  for (const env of environments) {
+    await prepareRemoteCodexHome(env);
+  }
+  await writeRemoteImage(environments[0]!);
+  await Promise.all([
+    writeFile(envFile, JSON.stringify(environments[0], null, 2)),
+    writeFile(upgradeEnvFile, JSON.stringify(environments, null, 2)),
+  ]);
+  return environments[0];
 }
 
 export async function stopDockerEnvironment() {
@@ -178,14 +208,6 @@ export async function execRemoteSsh(env: RemoteEnv, command: string) {
   }
 }
 
-function parseCodexVersionOutput(output: string) {
-  const match = output.match(/\b\d+\.\d+\.\d+\b/);
-  if (!match) {
-    throw new Error(`Unable to parse Codex version from: ${output}`);
-  }
-  return match[0];
-}
-
 async function uploadDirectory(
   connection: Client,
   localDirectory: string,
@@ -252,7 +274,7 @@ async function uploadFile(sftp: import("ssh2").SFTPWrapper, localPath: string, r
   });
 }
 
-export { envFile };
+export { envFile, upgradeEnvFile };
 
 async function prepareCodexHome(sourceCodexHome: string, codexHome: string) {
   await rm(codexHome, { recursive: true, force: true });

--- a/tests/e2e/docker/Dockerfile
+++ b/tests/e2e/docker/Dockerfile
@@ -1,6 +1,18 @@
-FROM node:22-bookworm
+FROM node:22-bookworm AS preview-dependencies
+
+RUN npm install --prefix /tmp/preview ws@8.21.0
+
+FROM node:14.21.3-bullseye-slim AS legacy-node-runtime
+
+FROM node:22.23.1-bookworm-slim AS legacy-codex-runtime
 
 ARG CODEX_CLI_VERSION=0.140.0
+RUN mkdir -p /tmp/codex-node \
+  && cp -a /usr/local/. /tmp/codex-node/ \
+  && npm install -g --prefix /tmp/codex-node @openai/codex@${CODEX_CLI_VERSION}
+
+FROM debian:bookworm-slim AS ssh-base
+
 ARG E2E_UID=1000
 ARG E2E_GID=1000
 
@@ -8,24 +20,28 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends openssh-server git ca-certificates sudo tmux \
   && rm -rf /var/lib/apt/lists/*
 
-ENV E2E_NODE_DIR=/home/codex/.nvm/versions/node/v22.0.0
-
-RUN npm install -g --prefix /tmp/codex-node @openai/codex@${CODEX_CLI_VERSION} ws@8.21.0
-
 RUN groupadd --gid ${E2E_GID} codex \
   && useradd --uid ${E2E_UID} --gid ${E2E_GID} --create-home --shell /bin/bash codex \
   && echo 'codex:codex' | chpasswd \
   && usermod -aG sudo codex \
-  && mkdir -p /run/sshd \
-  && mkdir -p "$E2E_NODE_DIR" \
-  && cp -a /tmp/codex-node/bin "$E2E_NODE_DIR/bin" \
-  && cp -a /tmp/codex-node/lib "$E2E_NODE_DIR/lib" \
-  && chown -R codex:"$(id -gn codex)" /home/codex/.nvm \
-  && rm -rf /tmp/codex-node
+  && mkdir -p /run/sshd
 
 COPY entrypoint.sh /usr/local/bin/codex-e2e-entrypoint
 COPY preview-server.mjs /usr/local/lib/codex-preview-server.mjs
+COPY --from=preview-dependencies /tmp/preview/node_modules /usr/local/lib/node_modules
 RUN chmod +x /usr/local/bin/codex-e2e-entrypoint
 
 EXPOSE 22
 ENTRYPOINT ["/usr/local/bin/codex-e2e-entrypoint"]
+
+FROM ssh-base AS empty-runtime
+
+FROM ssh-base AS legacy-node
+COPY --from=legacy-node-runtime /usr/local/ /usr/local/
+
+FROM ssh-base AS legacy-codex
+ARG E2E_UID=1000
+ARG E2E_GID=1000
+ENV E2E_NODE_DIR=/home/codex/.nvm/versions/node/v22.23.1
+COPY --from=legacy-codex-runtime /tmp/codex-node/ ${E2E_NODE_DIR}/
+RUN chown -R ${E2E_UID}:${E2E_GID} /home/codex/.nvm

--- a/tests/e2e/docker/entrypoint.sh
+++ b/tests/e2e/docker/entrypoint.sh
@@ -4,9 +4,6 @@ set -euo pipefail
 mkdir -p /home/codex/.ssh /home/codex/.codex /workspace
 mkdir -p /home/codex/.local
 chmod 700 /home/codex/.ssh
-printf 'prefix=/home/codex/.nvm/versions/node/v22.0.0\n' >/home/codex/.npmrc
-chown -R codex:"$(id -gn codex)" /home/codex/.ssh /home/codex/.local /home/codex/.codex /home/codex/.npmrc
-
-NODE_PATH="$E2E_NODE_DIR/lib/node_modules" node /usr/local/lib/codex-preview-server.mjs &
+chown -R codex:"$(id -gn codex)" /home/codex/.ssh /home/codex/.local /home/codex/.codex
 
 exec /usr/sbin/sshd -D -e

--- a/tests/e2e/docker/preview-server.mjs
+++ b/tests/e2e/docker/preview-server.mjs
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { WebSocketServer } from "/home/codex/.nvm/versions/node/v22.0.0/lib/node_modules/ws/wrapper.mjs";
+import { WebSocketServer } from "ws";
 
 const server = createServer((request, response) => {
   if (request.url === "/api/message") {

--- a/tests/e2e/helpers/remote-codex.ts
+++ b/tests/e2e/helpers/remote-codex.ts
@@ -1,7 +1,9 @@
 import { expect, type Page } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import { Client } from "ssh2";
-import { envFile } from "../docker-environment";
+import { envFile, upgradeEnvFile } from "../docker-environment";
+
+export type RemoteRuntimeFixture = "empty-runtime" | "legacy-node" | "legacy-codex";
 
 export interface RemoteCodexEnv {
   host: string;
@@ -10,7 +12,9 @@ export interface RemoteCodexEnv {
   password: string;
   projectPath: string;
   imagePath: string;
-  initialCodexVersion?: string;
+  runtimeFixture?: RemoteRuntimeFixture;
+  initialNodeVersion?: string | null;
+  initialCodexVersion?: string | null;
   supportedCodexVersion?: string;
   testModel?: string;
   codexBin?: string;
@@ -32,6 +36,10 @@ export async function readRemoteEnv() {
   return JSON.parse(await readFile(envFile, "utf8")) as RemoteCodexEnv;
 }
 
+export async function readUpgradeRemoteEnvs() {
+  return JSON.parse(await readFile(upgradeEnvFile, "utf8")) as RemoteCodexEnv[];
+}
+
 export async function readContainerCodexVersion(remote: RemoteCodexEnv) {
   return await runRemoteCodexVersion(remote);
 }
@@ -43,6 +51,15 @@ export async function execRemoteSsh(remote: RemoteCodexEnv, command: string) {
   } finally {
     connection.end();
   }
+}
+
+export async function stopRemoteFixture(remote: RemoteCodexEnv) {
+  // Auxiliary upgrade Hosts are not used by the product E2E suite. Stop their PID 1 after the
+  // matrix test so they cannot retain an SSH connection, app-server, or memory for later tests.
+  await execRemoteSsh(
+    remote,
+    `(sleep 0.1; printf '%s\\n' ${shellQuote(remote.password)} | sudo -S kill -TERM 1) >/dev/null 2>&1 &`,
+  );
 }
 
 export async function resetRemoteAppServer(remote: RemoteCodexEnv) {
@@ -75,6 +92,30 @@ if [ -n "$pids" ]; then
 fi
 rm -f "$socket"
 rm -f "$daemon_dir"/app-server.pid "$daemon_dir"/app-server.pid.lock "$daemon_dir"/app-server.stderr.log
+`,
+  );
+}
+
+export async function startRemotePreviewServer(remote: RemoteCodexEnv) {
+  const nodeBin = remote.codexBin?.replace(/\/codex$/, "/node");
+  if (!nodeBin) throw new Error("Missing managed remote Node path");
+  await execRemoteSsh(
+    remote,
+    `
+set -eu
+if [ -f /tmp/codex-preview-server.pid ]; then
+  kill "$(cat /tmp/codex-preview-server.pid)" >/dev/null 2>&1 || true
+fi
+nohup ${shellQuote(nodeBin)} /usr/local/lib/codex-preview-server.mjs >/tmp/codex-preview-server.log 2>&1 </dev/null &
+echo $! >/tmp/codex-preview-server.pid
+for i in $(seq 1 50); do
+  if ${shellQuote(nodeBin)} -e 'const s=require("net").connect(4173,"127.0.0.1",()=>{s.end();process.exit(0)});s.on("error",()=>process.exit(1))' >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 0.1
+done
+cat /tmp/codex-preview-server.log >&2 || true
+exit 1
 `,
   );
 }
@@ -253,8 +294,10 @@ async function closeSettings(page: Page) {
   if (!(await panel.isVisible().catch(() => false))) {
     return;
   }
-  await page.getByTestId("settings-close-button").last().click();
-  await expect(panel).toBeHidden();
+  // Adding a Host updates the Dockview contents and may replace its dialog subtree. Use the
+  // dialog's keyboard close contract instead of retaining a close button that can be detached.
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("settings-dialog")).toBeHidden();
 }
 
 function shellQuote(value: string) {
@@ -267,11 +310,13 @@ async function runRemoteCodexVersion(remote: RemoteCodexEnv) {
 }
 
 export function remoteCodexCommand(remote: RemoteCodexEnv) {
-  const candidates = [
-    remote.codexBin,
-    "$HOME/.npm-global/bin/codex",
-    "$HOME/.local/bin/codex",
-  ].filter(Boolean) as string[];
+  if (remote.codexBin) {
+    const binDirectory = remote.codexBin.replace(/\/[^/]+$/, "");
+    return `env PATH=${shellQuote(binDirectory)}:"$PATH" ${shellQuote(remote.codexBin)}`;
+  }
+  const candidates = ["$HOME/.npm-global/bin/codex", "$HOME/.local/bin/codex"].filter(
+    Boolean,
+  ) as string[];
   const candidateList = candidates.map(shellQuote).join(" ");
   return `$(
 for candidate in ${candidateList}; do

--- a/tests/e2e/remote-host-project.spec.ts
+++ b/tests/e2e/remote-host-project.spec.ts
@@ -319,7 +319,7 @@ async function verifyRemoteDirectoryBrowser(
   );
   await expect(page.getByRole("button", { name: directoryName })).toBeVisible();
 
-  const missingPath = `missing-directory-${Date.now()}`;
+  const missingPath = `/home/${remote.username}/missing-directory-${Date.now()}`;
   const responsePromise = page.waitForResponse(
     (response) =>
       response.url().includes("/api/remote/directories?") && response.request().method() === "GET",
@@ -331,9 +331,20 @@ async function verifyRemoteDirectoryBrowser(
   const payload = await response.json();
   expect(payload.code).toBe("remoteDirectoryNotFound");
   expect(payload.message).toContain(missingPath);
-  expect(payload.message).toContain(`/home/${remote.username}/${missingPath}`);
   await expect(page.getByText(new RegExp(`Remote directory.*${missingPath}`))).toBeVisible();
   await expect(page.getByText(new RegExp(`主机: ${hostName}|Host: ${hostName}`))).toBeVisible();
+
+  const deniedResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/remote/directories?") && response.request().method() === "GET",
+  );
+  await page.getByTestId("project-browse-path-input").fill("/root");
+  await page.getByRole("button", { name: /浏览|Browse/ }).click();
+  const deniedResponse = await deniedResponsePromise;
+  expect(deniedResponse.status()).toBe(403);
+  const deniedPayload = await deniedResponse.json();
+  expect(deniedPayload.code).toBe("remoteDirectoryAccessDenied");
+  expect(deniedPayload.message).toContain("/root");
   await page.keyboard.press("Escape");
 }
 

--- a/tests/e2e/run-in-containers.sh
+++ b/tests/e2e/run-in-containers.sh
@@ -24,7 +24,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-docker compose -p "$project_name" -f "$compose_file" build build-runner ssh-target
+docker compose -p "$project_name" -f "$compose_file" build \
+  build-runner ssh-target ssh-target-legacy-node ssh-target-legacy-codex
 # Build, application server, and browser runner use separate 2 GiB cgroups. Sharing only the
 # gateway network namespace preserves the production-like nip.io subdomain routing used by browser
 # preview tests without coupling process memory.


### PR DESCRIPTION
## Summary\n- map remote directory errors to stable 403/404 states and prune invalid expanded paths\n- serialize Codex artifact installation globally while preserving concurrent SSH/RPC traffic\n- bootstrap official Node.js through SFTP for missing or legacy runtimes and preserve the official NVM/npm layout\n- add dedicated empty, Node 14, and old-Codex upgrade fixtures; stop auxiliary fixtures before running the remaining product E2E on the primary Host\n\n## Validation\n- pnpm lint\n- git diff --check\n- pnpm test:e2e (60 passed)