### PR TITLE
fix: sync pinned threads across browsers

### DIFF
--- a/app/stores/gateway-realtime/index.ts
+++ b/app/stores/gateway-realtime/index.ts
@@ -12,6 +12,7 @@ import {
   type RealtimeServerMessageMap,
 } from "./server-message-handlers";
 import { createRealtimeThreadSubscriptions } from "./thread-subscriptions";
+import { createPinnedThreadSync } from "./pinned-thread-sync";
 
 export const useGatewayRealtimeStore = defineStore("gateway-realtime", () => {
   const { t } = useI18n();
@@ -33,6 +34,7 @@ export const useGatewayRealtimeStore = defineStore("gateway-realtime", () => {
     connect: connection.connect,
     send: connection.send,
   });
+  const pinnedThreadSync = createPinnedThreadSync();
 
   registerRealtimeServerMessageHandlers(serverMessages, {
     t,
@@ -45,6 +47,7 @@ export const useGatewayRealtimeStore = defineStore("gateway-realtime", () => {
     acknowledgePong: connection.acknowledgePong,
     restoreTerminalSessions,
     refreshSelectedThreadAfterReconnect,
+    refreshPinnedThreads,
     advanceThreadSubscriptionCursor: subscriptions.advanceThreadSubscriptionCursor,
   });
 
@@ -82,6 +85,12 @@ export const useGatewayRealtimeStore = defineStore("gateway-realtime", () => {
       .catch((error: unknown) => {
         console.warn("[gateway] failed to refresh selected thread after realtime reconnect", error);
       });
+  }
+
+  function refreshPinnedThreads() {
+    void pinnedThreadSync.refresh().catch((error: unknown) => {
+      console.warn("[gateway] failed to refresh pinned threads", error);
+    });
   }
 
   return {

--- a/app/stores/gateway-realtime/pinned-thread-sync.ts
+++ b/app/stores/gateway-realtime/pinned-thread-sync.ts
@@ -1,0 +1,39 @@
+import { gatewayApi } from "@/utils/gateway-api";
+import { useGatewayStore } from "@/stores/gateway";
+import { useGatewayNavigationStore } from "@/stores/gateway-navigation";
+import { sortThreads } from "@/stores/gateway/thread-utils/identity";
+import type { GatewayConfig } from "~~/shared/types";
+
+export function createPinnedThreadSync() {
+  let pending: Promise<void> | null = null;
+  let refreshAgain = false;
+
+  function refresh() {
+    if (pending) {
+      // An invalidation received during the current fetch must trigger one trailing fetch.
+      refreshAgain = true;
+      return pending;
+    }
+    pending = refreshUntilCurrent().finally(() => {
+      pending = null;
+    });
+    return pending;
+  }
+
+  async function refreshUntilCurrent() {
+    do {
+      refreshAgain = false;
+      const config = await gatewayApi<GatewayConfig>("/api/config/export");
+      applyPinnedThreads(config.pinnedThreads);
+    } while (refreshAgain);
+  }
+
+  return { refresh };
+}
+
+function applyPinnedThreads(pinnedThreads: GatewayConfig["pinnedThreads"]) {
+  const gateway = useGatewayStore();
+  const navigation = useGatewayNavigationStore();
+  gateway.gatewayConfig = { ...gateway.gatewayConfig, pinnedThreads };
+  navigation.threads = sortThreads(navigation.decorateThreads(navigation.threads));
+}

--- a/app/stores/gateway-realtime/server-message-handlers.ts
+++ b/app/stores/gateway-realtime/server-message-handlers.ts
@@ -30,6 +30,7 @@ export interface RealtimeServerMessageHandlerContext {
   acknowledgePong: (nonce?: string) => void;
   restoreTerminalSessions: () => Promise<void>;
   refreshSelectedThreadAfterReconnect: () => void;
+  refreshPinnedThreads: () => void;
   advanceThreadSubscriptionCursor: (event: GatewayEvent) => void;
 }
 
@@ -68,6 +69,7 @@ function createServerMessageHandlers(ctx: RealtimeServerMessageHandlerContext) {
   return {
     ready: () => handleReady(ctx),
     "notification.published": (message) => handlePublishedNotification(ctx, message),
+    "config.pinnedThreads.changed": () => ctx.refreshPinnedThreads(),
     "host.lifecycle": (message) => handleHostLifecycle(ctx, message.event),
     "thread.event": (message) => handleThreadEvent(ctx, message.event),
     "thread.goal.updated": (message) => handleGoalUpdated(ctx, message),
@@ -139,6 +141,7 @@ function handleReady(ctx: RealtimeServerMessageHandlerContext) {
   ctx.resubscribe();
   void ctx.restoreTerminalSessions();
   if (wasAlreadyReady) {
+    ctx.refreshPinnedThreads();
     ctx.refreshSelectedThreadAfterReconnect();
   }
 }

--- a/server/api/config/sync.post.ts
+++ b/server/api/config/sync.post.ts
@@ -9,9 +9,11 @@ import { hostRuntimeSupervisor } from "../../utils/gateway/runtime/host-runtime-
 import { hostStore } from "../../utils/gateway/state/hosts";
 import type { StoredHostRecord } from "../../utils/gateway/state/memory";
 import { runtimeConfigStore } from "../../utils/gateway/state/runtime-config";
+import { pinnedThreadEvents } from "../../utils/gateway/config/pinned-thread-events";
 
 export default defineGatewayConfigMutationHandler(async (event) => {
   const previousHosts = hostStore.listWithSecret();
+  const previousPinnedThreads = runtimeConfigStore.export().pinnedThreads;
   const userId = event.context.auth!.user.id;
   const config = await readValidatedBody(event, parseGatewayConfig);
   runtimeConfigStore.replace(config);
@@ -30,8 +32,16 @@ export default defineGatewayConfigMutationHandler(async (event) => {
     hostRuntimeSupervisor.syncCurrentUserConfig();
   }
   saveCurrentUserConfig(event);
-  return runtimeConfigStore.export();
+  const savedConfig = runtimeConfigStore.export();
+  if (!samePinnedThreads(previousPinnedThreads, savedConfig.pinnedThreads)) {
+    pinnedThreadEvents.publish(userId);
+  }
+  return savedConfig;
 });
+
+function samePinnedThreads(previous: unknown, next: unknown) {
+  return JSON.stringify(previous) === JSON.stringify(next);
+}
 
 function hostRuntimeChanged(previousHosts: StoredHostRecord[], nextHosts: StoredHostRecord[]) {
   const previousById = new Map(previousHosts.map((host) => [host.id, host]));

--- a/server/utils/gateway/config/pinned-thread-events.ts
+++ b/server/utils/gateway/config/pinned-thread-events.ts
@@ -1,0 +1,27 @@
+type PinnedThreadSubscriber = () => void;
+
+class PinnedThreadEvents {
+  private readonly subscribersByUser = new Map<number, Set<PinnedThreadSubscriber>>();
+
+  publish(userId: number) {
+    for (const subscriber of this.subscribersByUser.get(userId) ?? []) {
+      try {
+        subscriber();
+      } catch (error) {
+        console.warn("[gateway] pinned thread subscriber failed", error);
+      }
+    }
+  }
+
+  subscribe(userId: number, subscriber: PinnedThreadSubscriber) {
+    const subscribers = this.subscribersByUser.get(userId) ?? new Set<PinnedThreadSubscriber>();
+    subscribers.add(subscriber);
+    this.subscribersByUser.set(userId, subscribers);
+    return () => {
+      subscribers.delete(subscriber);
+      if (!subscribers.size) this.subscribersByUser.delete(userId);
+    };
+  }
+}
+
+export const pinnedThreadEvents = new PinnedThreadEvents();

--- a/server/utils/gateway/realtime/connection.ts
+++ b/server/utils/gateway/realtime/connection.ts
@@ -55,6 +55,8 @@ export function cleanupRealtimePeer(peer: RealtimePeer) {
   state.terminalUnsubscribe = undefined;
   state.notificationUnsubscribe?.();
   state.notificationUnsubscribe = undefined;
+  state.pinnedThreadsUnsubscribe?.();
+  state.pinnedThreadsUnsubscribe = undefined;
   state.browserPreviewUnsubscribe?.();
   state.browserPreviewUnsubscribe = undefined;
   if (state.browserOwnerId) browserPreviewManager.closeOwner(state.browserOwnerId);

--- a/server/utils/gateway/realtime/handlers/auth.ts
+++ b/server/utils/gateway/realtime/handlers/auth.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { RealtimeClientMessage } from "~~/shared/types";
 import { userStore } from "../../auth/users";
 import { notificationRealtimeEvents } from "../../notifications/notification-realtime-events";
+import { pinnedThreadEvents } from "../../config/pinned-thread-events";
 import { sessionRevocationEvents } from "../../auth/session-events";
 import { hashToken } from "../../storage/crypto";
 import { subscribeTerminalEvents } from "./terminal";
@@ -35,6 +36,9 @@ export function authenticatePeer(
     }),
     notificationUnsubscribe: notificationRealtimeEvents.subscribe(user.id, (notification) => {
       sendRealtimePeerMessage(peer, { type: "notification.published", notification });
+    }),
+    pinnedThreadsUnsubscribe: pinnedThreadEvents.subscribe(user.id, () => {
+      sendRealtimePeerMessage(peer, { type: "config.pinnedThreads.changed" });
     }),
   };
   sendRealtimePeerMessage(peer, { type: "ready", connectionId });

--- a/server/utils/gateway/realtime/peer-state.ts
+++ b/server/utils/gateway/realtime/peer-state.ts
@@ -14,6 +14,7 @@ export interface RealtimePeerState {
   hostLifecycleUnsubscribe?: () => void;
   terminalUnsubscribe?: () => void;
   notificationUnsubscribe?: () => void;
+  pinnedThreadsUnsubscribe?: () => void;
   browserPreviewUnsubscribe?: () => void;
   browserOwnerId?: string;
   sessionRevocationUnsubscribe?: () => void;

--- a/shared/types/realtime.ts
+++ b/shared/types/realtime.ts
@@ -173,6 +173,9 @@ export type RealtimeServerMessage =
       notification: ServerNotification;
     }
   | {
+      type: "config.pinnedThreads.changed";
+    }
+  | {
       type: "host.lifecycle";
       event: {
         hostId: number;

--- a/tests/e2e/realtime-multi-client.spec.ts
+++ b/tests/e2e/realtime-multi-client.spec.ts
@@ -150,6 +150,20 @@ test("fans out a real remote app-server thread to multiple browser clients acros
       )
       .toBe(true);
 
+    await page.getByTestId(`thread-button-${threadId}`).click({ button: "right" });
+    await page.getByRole("menuitem", { name: /置顶会话|Pin thread/ }).click();
+    await expect(page.getByTestId(`pinned-thread-button-${threadId}`)).toBeVisible();
+    await expect(secondPage.getByTestId(`pinned-thread-button-${threadId}`)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await secondPage.getByTestId(`pinned-thread-button-${threadId}`).click({ button: "right" });
+    await secondPage.getByRole("menuitem", { name: /取消置顶|Unpin thread/ }).click();
+    await expect(secondPage.getByTestId(`pinned-thread-button-${threadId}`)).toBeHidden();
+    await expect(page.getByTestId(`pinned-thread-button-${threadId}`)).toBeHidden({
+      timeout: 10_000,
+    });
+
     const secondMarker = `E2E 第二轮图片 ${Date.now()}`;
     await sendImageTurnThroughGateway(secondPage, {
       hostId: host.id,


### PR DESCRIPTION
## Summary
- broadcast pinned thread config invalidations to every realtime peer for the same user
- refresh only pinned thread state with coalesced HTTP reads and reconnect recovery
- cover pin and unpin fan-out with the real multi-browser E2E flow

## Verification
- pnpm lint
- pnpm test:e2e (60 passed)
- git diff --check

No database migration or project persistence changes.