### PR TITLE
fix: prevent mobile crashes on large threads

### DIFF
--- a/app/components/common/DeferredCollapsibleContent.vue
+++ b/app/components/common/DeferredCollapsibleContent.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { CollapsibleContent } from "@/components/ui/collapsible";
+
+defineProps<{
+  open: boolean;
+}>();
+</script>
+
+<template>
+  <!--
+    Reka owns the disclosure semantics, but explicitly gate the slot so expensive Markdown,
+    syntax highlighting, and nested scroll areas do not enter Vue's component tree while closed.
+    This matters for long agent turns containing hundreds of collapsed command/tool cards.
+  -->
+  <CollapsibleContent v-if="open">
+    <slot />
+  </CollapsibleContent>
+</template>

--- a/app/components/thread/items/AppNotificationItem.vue
+++ b/app/components/thread/items/AppNotificationItem.vue
@@ -2,8 +2,9 @@
 import { AlertTriangleIcon, BellIcon, InfoIcon } from "@lucide/vue";
 import { computed } from "vue";
 import { Badge } from "@/components/ui/badge";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Collapsible, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
+import DeferredCollapsibleContent from "@/components/common/DeferredCollapsibleContent.vue";
 
 const props = defineProps<{ item: Record<string, any> }>();
 const { t } = useI18n();
@@ -35,11 +36,11 @@ const details = computed(() => props.item.details || "");
           {{ open ? t("app.hideNotificationDetails") : t("app.showNotificationDetails") }}
         </Button>
       </CollapsibleTrigger>
-      <CollapsibleContent>
+      <DeferredCollapsibleContent :open="open">
         <pre
           class="mt-2 max-h-40 overflow-auto rounded-md bg-canvas-soft p-2 text-xs leading-5 text-ink-secondary"
           >{{ details }}</pre>
-      </CollapsibleContent>
+      </DeferredCollapsibleContent>
     </Collapsible>
   </div>
 </template>

--- a/app/components/thread/items/CommandExecutionItem.vue
+++ b/app/components/thread/items/CommandExecutionItem.vue
@@ -9,8 +9,9 @@ import {
 import { computed } from "vue";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Collapsible, CollapsibleTrigger } from "@/components/ui/collapsible";
 import HighlightedCode from "@/components/common/HighlightedCode.vue";
+import DeferredCollapsibleContent from "@/components/common/DeferredCollapsibleContent.vue";
 import { ChatStickToBottomScrollArea } from "@/components/common/chat-virtualizer";
 import { useServerRequestResponder } from "@/composables/thread/useServerRequestResponder";
 
@@ -64,7 +65,7 @@ async function respond(decision: "accept" | "decline") {
         <ChevronRightIcon v-else class="size-4 shrink-0 text-ink-faint" />
       </span>
     </CollapsibleTrigger>
-    <CollapsibleContent>
+    <DeferredCollapsibleContent :open="open">
       <div
         v-if="pendingApproval"
         class="mt-2 rounded-lg border border-accent-orange/30 bg-accent-orange/10 px-3 py-2 text-sm text-accent-orange-deep"
@@ -117,6 +118,6 @@ async function respond(decision: "accept" | "decline") {
       >
         {{ t("app.waitingCommandOutput") }}
       </div>
-    </CollapsibleContent>
+    </DeferredCollapsibleContent>
   </Collapsible>
 </template>

--- a/app/components/thread/items/ToolCallItem.vue
+++ b/app/components/thread/items/ToolCallItem.vue
@@ -2,8 +2,9 @@
 import { ChevronDownIcon, ChevronRightIcon, ImageIcon, SearchIcon, WrenchIcon } from "@lucide/vue";
 import { computed } from "vue";
 import { Badge } from "@/components/ui/badge";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Collapsible, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import DeferredCollapsibleContent from "@/components/common/DeferredCollapsibleContent.vue";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import { isItemInProgress } from "@/utils/thread-items";
 import { presentToolCall } from "./tool-call-presenters";
@@ -42,7 +43,7 @@ const detailSections = computed(() => presentation.value.details);
         <ChevronRightIcon v-else class="size-4 shrink-0 text-ink-faint" />
         <span class="min-w-0 flex-1 truncate text-ink-secondary">{{ t("app.toolDetails") }}</span>
       </CollapsibleTrigger>
-      <CollapsibleContent>
+      <DeferredCollapsibleContent :open="open">
         <div class="space-y-3 border-t border-hairline px-3 py-3">
           <div v-for="section in detailSections" :key="section.label" class="space-y-1">
             <div class="text-xs font-medium uppercase text-ink-faint">{{ section.label }}</div>
@@ -67,7 +68,7 @@ const detailSections = computed(() => presentation.value.details);
             </ScrollArea>
           </div>
         </div>
-      </CollapsibleContent>
+      </DeferredCollapsibleContent>
     </Collapsible>
   </div>
 </template>

--- a/app/stores/gateway/thread-open/hydration.ts
+++ b/app/stores/gateway/thread-open/hydration.ts
@@ -21,7 +21,7 @@ export function applyOpenedThreadResult(threadId: string, result: ThreadOpenResu
   navigation.selectedThreadId = threadId;
   useGatewayRealtimeStore().rememberThreadSubscription(result.hostId, threadId, result.lastEventId);
   if (result.project) gateway.mergeProjects([result.project]);
-  applyCommonThreadResult(threadId, result);
+  applyCommonThreadResult(threadId, result, result.lastEventId);
   for (const event of result.recentEvents) views.applyLiveEvent(event);
   syncRuntimeStatusFromResult(threadId, result, {
     thread: views.currentThread,
@@ -54,7 +54,7 @@ export function applyStartedThreadResult(result: ThreadOpenResult) {
   views.currentThread = result.thread;
   views.history = result.history;
   navigation.selectedThreadId = threadId;
-  applyCommonThreadResult(threadId, result);
+  applyCommonThreadResult(threadId, result, result.lastEventId);
   return threadId;
 }
 

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -116,7 +116,7 @@ export class ThreadOpenService {
         projectId,
         project: projectId ? projectStore.get(projectId) : null,
         turnsPage,
-        recentEvents,
+        recentEvents: snapshotRecentEvents(),
       },
     };
   }
@@ -182,7 +182,7 @@ export class ThreadOpenService {
       turnsPage: snapshot.turnsPage,
       threadSettings: snapshot.threadSettings,
       tokenUsage: latestTokenUsageFromEvents(recentEvents) ?? snapshot.tokenUsage,
-      recentEvents,
+      recentEvents: snapshotRecentEvents(),
     };
   }
 
@@ -208,7 +208,7 @@ export class ThreadOpenService {
       turnsPage: snapshot.turnsPage,
       threadSettings: snapshot.threadSettings,
       tokenUsage: latestTokenUsageFromEvents(recentEvents) ?? snapshot.tokenUsage,
-      recentEvents,
+      recentEvents: snapshotRecentEvents(),
     };
   }
 
@@ -266,4 +266,13 @@ function resolveProjectId(hostId: number, projectId: number | null, cwd: unknown
     return projectId;
   }
   return projectStore.ensureForPath(hostId, cwd).id;
+}
+
+function snapshotRecentEvents() {
+  // Thread snapshots already include materialized history plus lastEventId. Re-sending recent
+  // app-server events here duplicates large cumulative diff/output payloads and can push mobile
+  // browsers over their renderer memory limit before the realtime subscription starts. New live
+  // events are replayed through thread.event after lastEventId, so the snapshot path intentionally
+  // keeps this legacy field empty while runtime status/token usage are computed server-side above.
+  return [];
 }

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -32,6 +32,38 @@ test("uses the mobile layout with hidden sidebar and usable composer shell", asy
   await expect(page.getByText("先选择一个项目")).toBeVisible();
 });
 
+test("defers collapsed command output rendering in a large running turn", async ({ page }) => {
+  await openApp(page);
+  const threadId = "mobile-large-running-turn";
+  const commands = Array.from({ length: 160 }, (_, index) => ({
+    type: "commandExecution",
+    id: `large-command-${index}`,
+    command: `large command ${index}`,
+    aggregatedOutput: `output-${index} ${"x".repeat(8_000)}`,
+    status: "completed",
+    exitCode: 0,
+  }));
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Large mobile turn" },
+    status: "running",
+    history: {
+      thread: {
+        id: threadId,
+        turns: [{ id: "large-running-turn", status: "inProgress", items: commands }],
+      },
+    },
+  });
+
+  await expect(page.getByText("large command 159", { exact: true })).toBeVisible();
+  await expect(page.locator(".syntax-highlight")).toHaveCount(0);
+
+  await page.getByText("large command 159", { exact: true }).click();
+  await expect(page.locator(".syntax-highlight")).toHaveCount(1);
+  await expect(page.getByText(/output-159/)).toBeVisible();
+});
+
 test("background history top-up keeps the mobile timeline visually stable", async ({ page }) => {
   await openApp(page);
   const threadId = "mobile-background-turn-top-up";


### PR DESCRIPTION
## Summary
- omit duplicate recent event payloads from materialized thread snapshots
- defer command, tool, and notification detail components until their disclosure is opened
- preserve every intermediate step title and existing file diff behavior

## Diagnosis
The affected thread returned a 4-5 MB snapshot with 553 items in one active turn, including 351 command executions and repeated cumulative diff events. Mobile renderer memory was exhausted while desktop remained usable.

## Verification
- pnpm lint
- pnpm test:e2e (61 passed)
- mobile regression covers 160 commands with large collapsed outputs