### PR TITLE
fix: virtualize large turn intermediate items

### DIFF
--- a/app/components/thread/ThreadTurnView.vue
+++ b/app/components/thread/ThreadTurnView.vue
@@ -5,6 +5,7 @@ import type { ThreadRuntimeStatus } from "~~/shared/types";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import ThreadItemView from "@/components/thread/ThreadItemView.vue";
+import VirtualIntermediateItems from "@/components/thread/VirtualIntermediateItems.vue";
 import { provideFilePreviewContext } from "@/composables/files/useFilePreviewContext";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
 import {
@@ -97,14 +98,12 @@ function userMessageVariant(item: any) {
         <Badge variant="outline">{{ intermediateItems.length }}</Badge>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div data-testid="intermediate-steps" class="space-y-5 border-t border-hairline px-3 py-4">
-          <ThreadItemView
-            v-for="(item, index) in intermediateItems"
-            :key="itemKey(item, 'middle', index)"
-            :item="item"
+        <div data-testid="intermediate-steps" class="border-t border-hairline px-3 py-4">
+          <VirtualIntermediateItems
+            :items="intermediateItems"
             :host-id="hostId"
             :thread-id="threadId"
-            :user-message-variant="userMessageVariant(item)"
+            :user-message-variant="userMessageVariant"
           />
         </div>
       </CollapsibleContent>

--- a/app/components/thread/VirtualIntermediateItems.vue
+++ b/app/components/thread/VirtualIntermediateItems.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import type { VirtualItem } from "@tanstack/virtual-core";
+import { useVirtualizer } from "@tanstack/vue-virtual";
+import { useMutationObserver, useResizeObserver } from "@vueuse/core";
+import type { ComponentPublicInstance } from "vue";
+import { computed, nextTick, onMounted, ref, shallowRef, watch } from "vue";
+import ThreadItemView from "@/components/thread/ThreadItemView.vue";
+import { itemKey } from "@/components/thread/thread-turn-sections";
+import { useTimelineViewport } from "@/components/thread/timeline-viewport-context";
+
+const props = defineProps<{
+  items: any[];
+  hostId: number | null;
+  threadId: string | null;
+  userMessageVariant: (item: any) => "normal" | "steer";
+}>();
+
+const getViewport = useTimelineViewport();
+const containerElement = ref<HTMLElement | null>(null);
+const outerTurnRow = shallowRef<HTMLElement | null>(null);
+const scrollMargin = ref(0);
+
+const virtualizer = useVirtualizer(
+  computed(() => ({
+    count: props.items.length,
+    getScrollElement: getViewport,
+    getItemKey: (index: number) => itemKey(props.items[index], "middle", index),
+    estimateSize: (index: number) => estimateIntermediateItem(props.items[index]),
+    overscan: 5,
+    scrollMargin: scrollMargin.value,
+  })),
+);
+const virtualItems = computed(() => virtualizer.value.getVirtualItems());
+const totalSize = computed(() => virtualizer.value.getTotalSize());
+
+function setContainerRef(refValue: Element | ComponentPublicInstance | null) {
+  const element = refValue instanceof HTMLElement ? refValue : null;
+  if (containerElement.value === element) return;
+  containerElement.value = element;
+  outerTurnRow.value = element?.closest<HTMLElement>("[data-row-key]") ?? null;
+  void updateScrollMargin();
+}
+
+function setItemRef(refValue: Element | ComponentPublicInstance | null) {
+  const element = refValue instanceof Element ? refValue : null;
+  if (element) virtualizer.value.measureElement(element);
+}
+
+function itemStyle(virtualItem: VirtualItem) {
+  return {
+    position: "absolute",
+    top: "0",
+    left: "0",
+    width: "100%",
+    transform: `translate3d(0, ${virtualItem.start - scrollMargin.value}px, 0)`,
+  } as const;
+}
+
+async function updateScrollMargin() {
+  await nextTick();
+  const viewport = getViewport();
+  const container = containerElement.value;
+  if (!viewport || !container) return;
+  const nextMargin =
+    container.getBoundingClientRect().top -
+    viewport.getBoundingClientRect().top +
+    viewport.scrollTop;
+  if (Math.abs(nextMargin - scrollMargin.value) < 0.5) return;
+  scrollMargin.value = nextMargin;
+}
+
+useResizeObserver(containerElement, updateScrollMargin);
+useResizeObserver(outerTurnRow, updateScrollMargin);
+useResizeObserver(() => getViewport(), updateScrollMargin);
+useMutationObserver(outerTurnRow, updateScrollMargin, {
+  attributes: true,
+  attributeFilter: ["style"],
+});
+
+watch(
+  () => props.items.map((item, index) => itemKey(item, "middle", index)).join("\0"),
+  () => void updateScrollMargin(),
+  { flush: "post" },
+);
+
+onMounted(() => void updateScrollMargin());
+
+function estimateIntermediateItem(item: any) {
+  switch (item?.type) {
+    case "commandExecution":
+      return 48;
+    case "fileChange":
+      return 440;
+    case "agentMessage":
+      return 144;
+    case "reasoning":
+      return 128;
+    default:
+      return 96;
+  }
+}
+</script>
+
+<template>
+  <!--
+    The outer timeline virtualizes turns. A single long-running turn can still contain hundreds of
+    intermediate items, so this nested virtualizer shares the outer scroll element and only mounts
+    visible item components. Do not add overflow here: command/diff cards keep their own bounded
+    scrollers, while the Agent timeline remains the only owner of vertical navigation and
+    follow-latest intent. In particular, this component must not infer user detachment from its
+    own range changes; the shared viewport's wheel/touch/keyboard state owns that decision.
+  -->
+  <div
+    :ref="setContainerRef"
+    class="relative"
+    :style="{ height: `${totalSize}px` }"
+    data-testid="virtual-intermediate-items"
+  >
+    <div
+      v-for="virtualItem in virtualItems"
+      :key="String(virtualItem.key)"
+      :ref="setItemRef"
+      :data-index="virtualItem.index"
+      class="pb-5"
+      :style="itemStyle(virtualItem)"
+    >
+      <ThreadItemView
+        :item="items[virtualItem.index]"
+        :host-id="hostId"
+        :thread-id="threadId"
+        :user-message-variant="userMessageVariant(items[virtualItem.index])"
+      />
+    </div>
+  </div>
+</template>

--- a/app/components/thread/VirtualTimelineViewport.vue
+++ b/app/components/thread/VirtualTimelineViewport.vue
@@ -9,6 +9,7 @@ import {
 import type { ComponentPublicInstance } from "vue";
 import { computed, onMounted, ref, watch } from "vue";
 import { ChatVirtualScrollFrame, useChatVirtualizer } from "@/components/common/chat-virtualizer";
+import { provideTimelineViewport } from "@/components/thread/timeline-viewport-context";
 
 interface TimelineViewportRow {
   key: string;
@@ -69,6 +70,8 @@ const documentVisibility = useDocumentVisibility();
 function scrollViewport() {
   return scrollFrameRef.value?.getViewport() ?? null;
 }
+
+provideTimelineViewport(scrollViewport);
 
 function setRowRef(refValue: Element | ComponentPublicInstance | null) {
   const element = refValue instanceof Element ? refValue : null;

--- a/app/components/thread/timeline-viewport-context.ts
+++ b/app/components/thread/timeline-viewport-context.ts
@@ -1,0 +1,14 @@
+import type { InjectionKey } from "vue";
+import { inject, provide } from "vue";
+
+type TimelineViewportGetter = () => HTMLElement | null;
+
+const timelineViewportKey: InjectionKey<TimelineViewportGetter> = Symbol("timeline-viewport");
+
+export function provideTimelineViewport(getViewport: TimelineViewportGetter) {
+  provide(timelineViewportKey, getViewport);
+}
+
+export function useTimelineViewport() {
+  return inject(timelineViewportKey, () => null);
+}

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -32,16 +32,40 @@ test("uses the mobile layout with hidden sidebar and usable composer shell", asy
   await expect(page.getByText("先选择一个项目")).toBeVisible();
 });
 
-test("defers collapsed command output rendering in a large running turn", async ({ page }) => {
+test("virtualizes intermediate items inside a large running turn", async ({ page }) => {
   await openApp(page);
   const threadId = "mobile-large-running-turn";
-  const commands = Array.from({ length: 160 }, (_, index) => ({
+  const commands = Array.from({ length: 351 }, (_, index) => ({
     type: "commandExecution",
     id: `large-command-${index}`,
     command: `large command ${index}`,
-    aggregatedOutput: `output-${index} ${"x".repeat(8_000)}`,
+    aggregatedOutput: `output-${index} ${"x".repeat(4_000)}`,
     status: "completed",
     exitCode: 0,
+  }));
+  const fileChanges = Array.from({ length: 91 }, (_, index) => ({
+    type: "fileChange",
+    id: `large-file-change-${index}`,
+    status: "completed",
+    changes: [
+      {
+        path: `src/large_file_${index}.py`,
+        kind: "update",
+        diff: [
+          `diff --git a/src/large_file_${index}.py b/src/large_file_${index}.py`,
+          `--- a/src/large_file_${index}.py`,
+          `+++ b/src/large_file_${index}.py`,
+          "@@ -1,20 +1,20 @@",
+          ...Array.from({ length: 20 }, (_, line) => `-old_value_${line} = ${line}`),
+          ...Array.from({ length: 20 }, (_, line) => `+new_value_${line} = ${line + index}`),
+        ].join("\n"),
+      },
+    ],
+  }));
+  const agentMessages = Array.from({ length: 97 }, (_, index) => ({
+    type: "agentMessage",
+    id: `large-agent-message-${index}`,
+    text: `Agent progress ${index}: ${"analysis ".repeat(40)}`,
   }));
   await seedGatewayThread(page, {
     projectId: 1,
@@ -51,17 +75,57 @@ test("defers collapsed command output rendering in a large running turn", async 
     history: {
       thread: {
         id: threadId,
-        turns: [{ id: "large-running-turn", status: "inProgress", items: commands }],
+        turns: [
+          {
+            id: "large-running-turn",
+            status: "inProgress",
+            items: [...commands, ...fileChanges, ...agentMessages],
+          },
+        ],
       },
     },
   });
 
-  await expect(page.getByText("large command 159", { exact: true })).toBeVisible();
-  await expect(page.locator(".syntax-highlight")).toHaveCount(0);
+  const intermediate = page.getByTestId("virtual-intermediate-items");
+  const mountedRows = intermediate.locator(":scope > [data-index]");
+  await expect(intermediate).toBeAttached();
+  await expect.poll(() => mountedRows.count()).toBeLessThan(30);
 
-  await page.getByText("large command 159", { exact: true }).click();
-  await expect(page.locator(".syntax-highlight")).toHaveCount(1);
-  await expect(page.getByText(/output-159/)).toBeVisible();
+  await intermediate.evaluate((element) => {
+    const viewport = element.closest<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    if (!viewport) throw new Error("Missing Agent timeline viewport");
+    // The production timeline only detaches after real backward input. A direct scrollTop write
+    // without this intent remains in follow-latest mode and is correctly returned to the running
+    // turn's end as nested rows replace estimates with measured heights.
+    viewport.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: -240 }));
+    const start =
+      viewport.scrollTop +
+      element.getBoundingClientRect().top -
+      viewport.getBoundingClientRect().top;
+    viewport.scrollTop = start + 350 * 48 - viewport.clientHeight / 2;
+    viewport.dispatchEvent(new Event("scroll"));
+  });
+  await expect(page.getByText("large command 350", { exact: true })).toBeVisible();
+  await expect(page.getByText(/output-350/)).toHaveCount(0);
+  await page.getByText("large command 350", { exact: true }).click();
+  await expect(page.getByText(/output-350/)).toBeVisible();
+
+  await intermediate.evaluate((element) => {
+    const viewport = element.closest<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    if (!viewport) throw new Error("Missing Agent timeline viewport");
+    viewport.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: 240 }));
+    const start =
+      viewport.scrollTop +
+      element.getBoundingClientRect().top -
+      viewport.getBoundingClientRect().top;
+    viewport.scrollTop = start + element.scrollHeight * 0.55;
+    viewport.dispatchEvent(new Event("scroll"));
+  });
+  await expect(page.getByRole("button", { name: /src\/large_file_/ }).first()).toBeVisible();
+  await expect(page.locator(".diff-markdown .syntax-highlight").first()).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect.poll(() => mountedRows.count()).toBeLessThan(30);
 });
 
 test("background history top-up keeps the mobile timeline visually stable", async ({ page }) => {


### PR DESCRIPTION
## Summary
- virtualize intermediate items within a single large Codex turn
- share the existing Agent timeline viewport without adding a nested vertical scroller
- preserve outer follow-latest and user-detachment ownership
- add a mobile regression covering 351 commands, 91 file changes, and 97 Agent messages

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`61 passed`)