### PR TITLE
fix: stabilize streaming timeline scrolling

### DIFF
--- a/app/components/common/chat-virtualizer/anchoring.ts
+++ b/app/components/common/chat-virtualizer/anchoring.ts
@@ -42,14 +42,21 @@ export function createChatVirtualizerBehavior(options: {
 }
 
 export function shouldAdjustChatScrollForSizeChange(
-  _item: VirtualItem,
-  _instance: Virtualizer<HTMLElement, Element>,
+  item: VirtualItem,
+  instance: Virtualizer<HTMLElement, Element>,
   followLatest: boolean,
 ) {
-  // Do not add a positional fallback here. A turn can contain Agent text followed by command and
-  // diff blocks, so streamed text may resize a row that is geometrically above the viewport even
-  // though the user expects the raw viewport to stay parked. Once detached, all row-resize
-  // compensation is disabled. Keyed history prepends use anchorTo="end", while panel restoration
-  // uses the explicit DOM anchor in reflow(); neither path depends on this resize hook.
-  return followLatest;
+  if (followLatest) return true;
+
+  const viewport = instance.scrollElement;
+  const scrollOffset = viewport instanceof HTMLElement ? viewport.scrollTop : instance.scrollOffset;
+  // Dynamic rows entering the overscan window still use estimated heights. While scrolling
+  // upward, replacing an estimate above the viewport without compensation moves every visible
+  // row; once scrolling stops, nearby rows are measured and the same bug appears to disappear.
+  //
+  // Vibe Kanban and NextClaw use this same fully-above-fold predicate for TanStack chat lists.
+  // Do not broaden it to item.start < scrollOffset: a visible streaming Agent row can begin above
+  // the fold, and compensating that row would fight the reader. Diff and command output own
+  // separate bounded scrollports, so their internal size changes do not enter this predicate.
+  return item.end <= (scrollOffset ?? 0);
 }

--- a/tests/e2e/helpers/gateway-store.ts
+++ b/tests/e2e/helpers/gateway-store.ts
@@ -157,8 +157,11 @@ export async function appendAgentStreamLines(
     if (!views) {
       throw new Error("Unable to locate gateway thread-view Pinia store");
     }
-    const turn = views.history.thread.turns[0];
-    const agent = turn.items.find((item: any) => item.id === input.itemId);
+    const turns = views.history.thread.turns as Array<{ items?: any[] }>;
+    const agent = turns
+      .flatMap((turn) => turn.items ?? [])
+      .find((item: any) => item.id === input.itemId);
+    if (!agent) throw new Error(`Missing Agent stream item ${input.itemId}`);
     agent.text +=
       "\n\n" +
       Array.from(

--- a/tests/e2e/helpers/scroll.ts
+++ b/tests/e2e/helpers/scroll.ts
@@ -57,8 +57,12 @@ export async function captureVisibleTextAnchor(page: Page, prefix: string) {
       const rect = candidate.getBoundingClientRect();
       return (
         text.startsWith(prefix) &&
-        rect.top >= viewportRect.top + 8 &&
-        rect.bottom <= viewportRect.bottom - 8
+        // A single Markdown paragraph can be taller than a mobile viewport.
+        // It is still a valid visual anchor when it intersects the viewport;
+        // requiring the entire element to fit turns a real scrolling test into
+        // a false negative as soon as the reader reaches such a paragraph.
+        rect.bottom >= viewportRect.top + 8 &&
+        rect.top <= viewportRect.bottom - 8
       );
     });
     if (!element) {
@@ -127,6 +131,59 @@ export async function scrollChatViewportToTop(page: Page) {
     viewport.scrollTop = 0;
     viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
   });
+}
+
+export async function scrollChatViewportBy(page: Page, deltaY: number) {
+  return await page.getByTestId(chatScrollAreaTestId).evaluate((root: HTMLElement, deltaY) => {
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
+    if (!viewport) throw new Error("Missing chat viewport");
+    const before = viewport.scrollTop;
+    viewport.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY }));
+    viewport.scrollTop += deltaY;
+    viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    return { before, after: viewport.scrollTop };
+  }, deltaY);
+}
+
+export async function startChatTouchScrollUp(page: Page, distance: number) {
+  return await page.getByTestId(chatScrollAreaTestId).evaluate((root: HTMLElement, distance) => {
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
+    if (!viewport) throw new Error("Missing chat viewport");
+    const touchEvent = (type: string, clientY: number) => {
+      const event = new Event(type, { bubbles: true });
+      Object.defineProperty(event, "touches", { value: [{ clientY }] });
+      return event;
+    };
+    const before = viewport.scrollTop;
+    viewport.dispatchEvent(touchEvent("touchstart", 320));
+    // A finger moving down makes the scrollable content travel upward.
+    viewport.dispatchEvent(touchEvent("touchmove", 520));
+    viewport.scrollTop = Math.max(0, viewport.scrollTop - distance);
+    viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    return { before, after: viewport.scrollTop };
+  }, distance);
+}
+
+export async function endChatTouchScroll(page: Page) {
+  await page.getByTestId(chatScrollAreaTestId).evaluate((root: HTMLElement) => {
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
+    if (!viewport) throw new Error("Missing chat viewport");
+    viewport.dispatchEvent(new Event("touchend", { bubbles: true }));
+  });
+}
+
+export async function continueChatTouchMomentumUp(page: Page, distance: number) {
+  return await page.getByTestId(chatScrollAreaTestId).evaluate((root: HTMLElement, distance) => {
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
+    if (!viewport) throw new Error("Missing chat viewport");
+    const before = viewport.scrollTop;
+    // Native momentum continues with scroll events after touchend. Do not emit
+    // another touchmove here: the regression is specifically the period where
+    // the browser is moving the viewport without new pointer input.
+    viewport.scrollTop = Math.max(0, viewport.scrollTop - distance);
+    viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    return { before, after: viewport.scrollTop };
+  }, distance);
 }
 
 export async function parkCommandOutputInMiddle(page: Page) {

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import type { HostRecord, ProjectRecord } from "../../shared/types";
 import { authenticatedFetch, openApp, reloadApp } from "./helpers/app";
-import { seedGatewayThread } from "./helpers/gateway-store";
+import { appendAgentStreamLines, seedGatewayThread } from "./helpers/gateway-store";
 import {
   buildTextTurns,
   frameSpread,
@@ -15,6 +15,13 @@ import {
   threadTurnsLoadRequests,
   waitForAnimationFrames,
 } from "./helpers/history-pagination";
+import {
+  captureVisibleTextAnchor,
+  continueChatTouchMomentumUp,
+  endChatTouchScroll,
+  startChatTouchScrollUp,
+  visibleTextTop,
+} from "./helpers/scroll";
 import { execRemoteSsh, readRemoteEnv, waitForSelectedThreadId } from "./helpers/remote-codex";
 
 test("uses the mobile layout with hidden sidebar and usable composer shell", async ({ page }) => {
@@ -214,6 +221,117 @@ test("mobile viewport resize during explicit history prepend stays bottom pinned
     JSON.stringify(samples),
   ).toBeLessThanOrEqual(1);
   expect(Math.max(...samples.slice(-4)), JSON.stringify(samples)).toBeLessThanOrEqual(2);
+});
+
+test("mobile touch scrolling stays anchored while Agent output streams", async ({ page }) => {
+  await openApp(page);
+  const threadId = "mobile-active-touch-stream";
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Active Touch Stream" },
+    status: "running",
+    history: {
+      thread: {
+        id: threadId,
+        turns: [
+          ...buildTextTurns(1, 28, "touch scroll history", 12),
+          {
+            id: "turn-touch-streaming",
+            status: "running",
+            items: [
+              {
+                id: "agent-touch-streaming",
+                type: "agentMessage",
+                status: "inProgress",
+                text: "touch stream initial output",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await expect(page.getByText("touch stream initial output")).toBeVisible();
+  for (let batch = 0; batch < 3; batch += 1) {
+    await startChatTouchScrollUp(page, 180);
+    const anchor = await captureVisibleTextAnchor(page, "touch scroll history");
+    await appendAgentStreamLines(page, {
+      itemId: "agent-touch-streaming",
+      prefix: `touch stream batch ${batch + 1}`,
+      count: 8,
+    });
+    await waitForAnimationFrames(page, 2);
+
+    await expect
+      .poll(() => visibleTextTop(page, anchor.text))
+      .toBeGreaterThanOrEqual(anchor.top - 2);
+    await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+    await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute(
+      "data-follow-latest",
+      "false",
+    );
+  }
+  await endChatTouchScroll(page);
+});
+
+test("mobile momentum scrolling stays anchored after touchend while output streams", async ({
+  page,
+}) => {
+  await openApp(page);
+  const threadId = "mobile-momentum-stream";
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Momentum Stream" },
+    status: "running",
+    history: {
+      thread: {
+        id: threadId,
+        turns: [
+          ...buildTextTurns(1, 30, "momentum history", 10),
+          {
+            id: "turn-momentum-streaming",
+            status: "running",
+            items: [
+              {
+                id: "agent-momentum-streaming",
+                type: "agentMessage",
+                status: "inProgress",
+                text: "momentum stream initial output",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await expect(page.getByText("momentum stream initial output")).toBeVisible();
+  await startChatTouchScrollUp(page, 220);
+  await endChatTouchScroll(page);
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "false");
+
+  for (let frame = 0; frame < 3; frame += 1) {
+    await continueChatTouchMomentumUp(page, 90);
+    const anchor = await captureVisibleTextAnchor(page, "momentum history");
+    await appendAgentStreamLines(page, {
+      itemId: "agent-momentum-streaming",
+      prefix: `momentum stream frame ${frame + 1}`,
+      count: 8,
+    });
+    await waitForAnimationFrames(page, 2);
+
+    await expect
+      .poll(() => visibleTextTop(page, anchor.text))
+      .toBeGreaterThanOrEqual(anchor.top - 2);
+    await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+    await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute(
+      "data-follow-latest",
+      "false",
+    );
+  }
 });
 
 test("opens sidebar context actions with long press on mobile", async ({ page }) => {

--- a/tests/e2e/thread-scroll-behavior.spec.ts
+++ b/tests/e2e/thread-scroll-behavior.spec.ts
@@ -19,6 +19,7 @@ import {
   detachChatViewportNearBottom,
   parkChatViewportInMiddle,
   parkCommandOutputInMiddle,
+  scrollChatViewportBy,
   scrollChatViewportToBottom,
   scrollChatViewportToTop,
   visibleAgentLineTop,
@@ -255,6 +256,128 @@ test("streaming Agent output keeps a manually detached reader in place", async (
   await expect.poll(() => visibleTextTop(page, anchor.text)).toBeGreaterThanOrEqual(anchor.top - 2);
   await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
   await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "false");
+});
+
+test("streaming output does not drift the viewport during upward wheel scrolling", async ({
+  page,
+}) => {
+  await openApp(page);
+  const threadId = "e2e-active-wheel-stream-thread";
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Active Wheel Stream" },
+    status: "running",
+    history: {
+      thread: {
+        id: threadId,
+        turns: [
+          ...buildVariableHeightTurns(threadId, 36, "wheel scroll history"),
+          {
+            id: "turn-wheel-streaming",
+            status: "running",
+            items: [
+              {
+                id: "agent-wheel-streaming",
+                type: "agentMessage",
+                status: "inProgress",
+                text: "wheel stream initial output",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await expect(page.getByText("wheel stream initial output")).toBeVisible();
+  await scrollChatViewportToBottom(page);
+
+  for (let batch = 0; batch < 4; batch += 1) {
+    await scrollChatViewportBy(page, -180);
+    const anchor = await captureVisibleTextAnchor(page, "wheel scroll history");
+    await appendAgentStreamLines(page, {
+      itemId: "agent-wheel-streaming",
+      prefix: `wheel stream batch ${batch + 1}`,
+      count: 8,
+    });
+    await waitForAnimationFrames(page, 2);
+
+    await expect
+      .poll(() => visibleTextTop(page, anchor.text))
+      .toBeGreaterThanOrEqual(anchor.top - 2);
+    await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+    await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute(
+      "data-follow-latest",
+      "false",
+    );
+  }
+});
+
+test("downward wheel scrolling stays detached until the reader reaches latest", async ({
+  page,
+}) => {
+  await openApp(page);
+  const threadId = "e2e-downward-wheel-stream-thread";
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Downward Wheel Stream" },
+    status: "running",
+    history: {
+      thread: {
+        id: threadId,
+        turns: [
+          ...buildVariableHeightTurns(threadId, 32, "downward scroll history"),
+          {
+            id: "turn-downward-streaming",
+            status: "running",
+            items: [
+              {
+                id: "agent-downward-streaming",
+                type: "agentMessage",
+                status: "inProgress",
+                text: "downward stream initial output",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await expect(page.getByText("downward stream initial output")).toBeVisible();
+  await scrollChatViewportBy(page, -900);
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "false");
+
+  for (let batch = 0; batch < 3; batch += 1) {
+    await scrollChatViewportBy(page, 120);
+    const anchor = await captureVisibleTextAnchor(page, "downward scroll history");
+    await appendAgentStreamLines(page, {
+      itemId: "agent-downward-streaming",
+      prefix: `downward stream batch ${batch + 1}`,
+      count: 8,
+    });
+    await waitForAnimationFrames(page, 2);
+
+    await expect
+      .poll(() => visibleTextTop(page, anchor.text))
+      .toBeGreaterThanOrEqual(anchor.top - 2);
+    await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+    await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute(
+      "data-follow-latest",
+      "false",
+    );
+  }
+
+  await scrollChatViewportToBottom(page);
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "true");
+  await appendAgentStreamLines(page, {
+    itemId: "agent-downward-streaming",
+    prefix: "downward stream after relock",
+    count: 12,
+  });
+  await expect.poll(() => chatViewportBottomDistance(page)).toBeLessThanOrEqual(2);
 });
 
 test("switching threads discards stale virtual row measurements", async ({ page }) => {
@@ -561,7 +684,11 @@ test("streaming output does not force scroll when the user is reading earlier co
   await scrollChatViewportToBottom(page);
   await expect(page.getByRole("button", { name: /node long-output\.js/ })).toBeVisible();
   await page.getByRole("button", { name: /node long-output\.js/ }).click();
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "true");
   const commandScrollTop = await parkCommandOutputInMiddle(page);
+  // The command output owns a bounded inner viewport. Its wheel event must not
+  // detach the outer Agent timeline or subsequent Agent streaming will stop following.
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "true");
   await appendCommandOutputLines(page, {
     itemId: "command-scroll-1",
     prefix: "new command output line",
@@ -793,6 +920,67 @@ test("loading older turns prepends history without moving the current viewport a
   expect(httpTurnsRequests()).toBe(0);
 });
 
+test("history prepend and current Agent streaming preserve the same detached anchor", async ({
+  page,
+}) => {
+  await openApp(page);
+  const threadId = "e2e-concurrent-prepend-stream-thread";
+  await installDeferredThreadTurnsLoadStub(page, {
+    type: "thread.turns.page",
+    requestId: "e2e-concurrent-thread-turns-page",
+    hostId: 1,
+    threadId,
+    history: { thread: { id: threadId, turns: buildTextTurns(1, 5, "concurrent turn", 8) } },
+    turnsPage: { nextCursor: null, backwardsCursor: null },
+  });
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Concurrent Prepend Stream" },
+    status: "running",
+    olderTurnsCursor: JSON.stringify({ turnId: "turn-006", includeAnchor: false }),
+    history: {
+      thread: {
+        id: threadId,
+        turns: [
+          ...buildTextTurns(6, 10, "concurrent turn", 8),
+          {
+            id: "turn-concurrent-streaming",
+            status: "running",
+            items: [
+              {
+                id: "agent-concurrent-streaming",
+                type: "agentMessage",
+                status: "inProgress",
+                text: "concurrent stream initial output",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await scrollChatViewportToTop(page);
+  await expect
+    .poll(() => threadTurnsLoadRequests(page).then((requests) => requests.length))
+    .toBe(1);
+  const anchor = await captureVisibleTextAnchor(page, "concurrent turn 006");
+
+  await appendAgentStreamLines(page, {
+    itemId: "agent-concurrent-streaming",
+    prefix: "concurrent incoming line",
+    count: 20,
+  });
+  await releaseDeferredThreadTurnsLoad(page);
+
+  await expect.poll(() => threadTurnCount(page)).toBe(11);
+  await waitForAnimationFrames(page, 4);
+  await expect.poll(() => visibleTextTop(page, anchor.text)).toBeGreaterThanOrEqual(anchor.top - 2);
+  await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "false");
+});
+
 function trackThreadTurnsHttpRequests(page: Page) {
   let count = 0;
   page.on("request", (request) => {
@@ -818,5 +1006,30 @@ async function stopTimelineRowCountTracking(page: Page) {
   return page.evaluate(() => {
     (window as any).__timelineRowCountObserver?.disconnect();
     return ((window as any).__timelineRowCountSamples ?? []) as number[];
+  });
+}
+
+function buildVariableHeightTurns(threadId: string, count: number, prefix: string) {
+  return Array.from({ length: count }, (_, index) => {
+    const label = String(index + 1).padStart(3, "0");
+    const detailCount = 3 + ((index * 7) % 11);
+    return {
+      id: `turn-${threadId}-${label}`,
+      status: "completed",
+      items: [
+        {
+          id: `agent-${threadId}-${label}`,
+          type: "agentMessage",
+          status: "completed",
+          text: [
+            `${prefix} ${label}`,
+            ...Array.from(
+              { length: detailCount },
+              (_, detailIndex) => `${prefix} ${label} detail ${detailIndex + 1}`,
+            ),
+          ].join("\n\n"),
+        },
+      ],
+    };
   });
 }


### PR DESCRIPTION
## Summary
- compensate TanStack virtual row measurements only for rows fully above a detached reader
- preserve pinned, detached, upward/downward wheel, touch and momentum scrolling behavior
- cover concurrent history prepend, streaming updates, and nested command output scroll isolation

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`67 passed`)
