### PR TITLE
fix: support symlink directories in file tree

### DIFF
--- a/app/components/files/RemoteFileTreeRow.vue
+++ b/app/components/files/RemoteFileTreeRow.vue
@@ -41,10 +41,10 @@ const { longPressContextMenuHandlers } = useLongPressContextMenu({ menuWidthEsti
 
 <template>
   <ContextMenu>
-    <ContextMenuTrigger as-child :disabled="node.type !== 'file'">
+    <ContextMenuTrigger as-child :disabled="node.type === 'other'">
       <TreeItem
         v-slot="{ isExpanded }"
-        v-bind="node.type === 'file' ? longPressContextMenuHandlers : {}"
+        v-bind="node.type !== 'other' ? longPressContextMenuHandlers : {}"
         :value="node"
         :data-file-path="node.path"
         :level="level"
@@ -67,12 +67,12 @@ const { longPressContextMenuHandlers } = useLongPressContextMenu({ menuWidthEsti
       </TreeItem>
     </ContextMenuTrigger>
     <ContextMenuContent
-      v-if="node.type === 'file'"
+      v-if="node.type !== 'other'"
       :collision-padding="12"
       prioritize-position
       class="w-48"
     >
-      <ContextMenuItem @select="emit('download', node.path)">
+      <ContextMenuItem v-if="node.type === 'file'" @select="emit('download', node.path)">
         <DownloadIcon class="size-4" />
         {{ $t("app.downloadFile") }}
       </ContextMenuItem>
@@ -80,7 +80,11 @@ const { longPressContextMenuHandlers } = useLongPressContextMenu({ menuWidthEsti
         <CopyIcon class="size-4" />
         {{ $t("app.copyAbsolutePath") }}
       </ContextMenuItem>
-      <ContextMenuItem variant="destructive" @select="emit('delete', node.path)">
+      <ContextMenuItem
+        v-if="node.type === 'file'"
+        variant="destructive"
+        @select="emit('delete', node.path)"
+      >
         <Trash2Icon class="size-4" />
         {{ $t("app.deleteFile") }}
       </ContextMenuItem>

--- a/server/utils/gateway/infra/remote-files.ts
+++ b/server/utils/gateway/infra/remote-files.ts
@@ -1,4 +1,5 @@
-import type { FileEntryWithStats } from "ssh2";
+import pLimit from "p-limit";
+import type { FileEntryWithStats, SFTPWrapper, Stats } from "ssh2";
 import { randomUUID } from "node:crypto";
 import { posix } from "node:path";
 import { remoteLoginShellCommand } from "./remote-command";
@@ -43,15 +44,16 @@ export class RemoteFileService {
   async listDirectories(host: HostWithSecret, path: string) {
     const resolvedPath = await this.resolveRemoteDirectory(host, path);
     const sftp = await this.ssh.sftp(host);
-    return new Promise<ReturnType<typeof directoryResult>>((resolve, reject) => {
+    const entries = await new Promise<FileEntryWithStats[]>((resolve, reject) => {
       sftp.readdir(resolvedPath, (readError, entries) => {
         if (readError) {
           reject(directoryReadError(readError, path, resolvedPath));
           return;
         }
-        resolve(directoryResult(resolvedPath, entries));
+        resolve(entries);
       });
     });
+    return directoryResult(sftp, resolvedPath, entries);
   }
 
   async uploadFile(host: HostWithSecret, localPath: string, remotePath: string) {
@@ -296,18 +298,27 @@ function directoryReadError(error: unknown, inputPath: string, resolvedPath: str
   return error;
 }
 
-function directoryResult(path: string, source: FileEntryWithStats[]) {
-  const entries = source.map(({ filename, attrs }) => ({
-    name: filename,
-    path: `${path.replace(/\/$/, "")}/${filename}`,
-    type: attrs.isDirectory()
-      ? ("directory" as const)
-      : attrs.isFile()
-        ? ("file" as const)
-        : ("other" as const),
-    size: attrs.isFile() ? attrs.size : null,
-    modifiedAt: attrs.mtime ? attrs.mtime * 1000 : null,
-  }));
+async function directoryResult(sftp: SFTPWrapper, path: string, source: FileEntryWithStats[]) {
+  const limitSymlinkStat = pLimit(8);
+  const entries = await Promise.all(
+    source.map(async ({ filename, attrs }) => {
+      const entryPath = posix.join(path, filename);
+      // SFTP readdir returns lstat-like attributes, so a link is neither a file nor a directory.
+      // Follow only links to recover the target type; regular entries need no extra round trip.
+      // Broken or inaccessible links intentionally remain `other` instead of making the entire
+      // directory unreadable. Limit concurrency because every stat shares the Host's SFTP channel.
+      const effectiveAttrs = attrs.isSymbolicLink()
+        ? await limitSymlinkStat(() => statLinkedEntry(sftp, entryPath))
+        : attrs;
+      return {
+        name: filename,
+        path: entryPath,
+        type: directoryEntryType(effectiveAttrs),
+        size: effectiveAttrs?.isFile() ? effectiveAttrs.size : null,
+        modifiedAt: effectiveAttrs?.mtime ? effectiveAttrs.mtime * 1000 : null,
+      };
+    }),
+  );
   entries.sort((left, right) => {
     if (left.type !== right.type) {
       return left.type === "directory" ? -1 : 1;
@@ -315,4 +326,16 @@ function directoryResult(path: string, source: FileEntryWithStats[]) {
     return left.name.localeCompare(right.name);
   });
   return { path, entries };
+}
+
+function statLinkedEntry(sftp: SFTPWrapper, path: string) {
+  return new Promise<Stats | null>((resolve) => {
+    sftp.stat(path, (error, stats) => resolve(error ? null : stats));
+  });
+}
+
+function directoryEntryType(attrs: Stats | null) {
+  if (attrs?.isDirectory()) return "directory" as const;
+  if (attrs?.isFile()) return "file" as const;
+  return "other" as const;
 }

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -19,6 +19,9 @@ test("the unified file workspace browses, restores, and refreshes real remote fi
   const binaryPath = `${projectPath}/codex-gateway-preview-${Date.now()}.bin`;
   const longFilePath = `${projectPath}/${"very-long-file-name-".repeat(8)}preview.log`;
   const treeStressPath = `${projectPath}/tree-stability-${Date.now()}`;
+  const symlinkTargetPath = `/tmp/codex-gateway-symlink-target-${Date.now()}`;
+  const symlinkDirectoryPath = `${projectPath}/linked-training-${Date.now()}`;
+  const symlinkChildName = `checkpoint-${Date.now()}.log`;
   const wideTable = `| metric | sample-a | sample-b | sample-c |
 | --- | --- | --- | --- |
 | very-long-column | ${"unbroken-value-".repeat(12)}a | ${"unbroken-value-".repeat(12)}b | ${"unbroken-value-".repeat(12)}c |`;
@@ -27,6 +30,9 @@ test("the unified file workspace browses, restores, and refreshes real remote fi
     `
 set -eu
 mkdir -p ${shellQuote(projectPath)} ${shellQuote(`${projectPath}/deep/prefix`)}
+mkdir -p ${shellQuote(symlinkTargetPath)}
+printf '%s\n' 'linked training checkpoint' > ${shellQuote(`${symlinkTargetPath}/${symlinkChildName}`)}
+ln -sfn ${shellQuote(symlinkTargetPath)} ${shellQuote(symlinkDirectoryPath)}
 cat > ${shellQuote(remotePath)} <<'EOF'
 export function previewMarker() {
   return "codex-gateway-file-preview";
@@ -176,7 +182,17 @@ done
   const treeScroll = page.getByTestId("remote-file-tree-scroll");
   const longFileLabel = tree.getByTitle(longFilePath, { exact: true });
   const longFileRow = longFileLabel.locator("xpath=..");
+  const symlinkDirectoryLabel = tree.getByTitle(symlinkDirectoryPath, { exact: true });
+  const symlinkDirectoryRow = symlinkDirectoryLabel.locator("xpath=..");
   await expect(longFileLabel).toBeVisible();
+  await expect(symlinkDirectoryLabel).toBeVisible();
+  await symlinkDirectoryRow.click({ button: "right", position: { x: 20, y: 16 } });
+  await page.getByRole("menuitem", { name: "复制绝对路径" }).click();
+  await expect(
+    page.locator("[data-sonner-toast]").filter({ hasText: "已复制绝对路径" }).last(),
+  ).toBeVisible();
+  await symlinkDirectoryRow.click({ position: { x: 20, y: 16 } });
+  await expect(tree.getByText(symlinkChildName, { exact: true })).toBeVisible();
   await tree.getByText("deep", { exact: true }).click();
   await tree.getByText("prefix", { exact: true }).click();
   await expect(tree.getByText(nestedPythonPath.split("/").pop()!, { exact: true })).toBeVisible();
@@ -246,7 +262,9 @@ done
   await expect(fileTab(page, longFilePath)).toBeVisible();
   await longFileRow.click({ button: "right", position: { x: 20, y: 16 } });
   await page.getByRole("menuitem", { name: "复制绝对路径" }).click();
-  await expect(page.getByText("已复制绝对路径")).toBeVisible();
+  await expect(
+    page.locator("[data-sonner-toast]").filter({ hasText: "已复制绝对路径" }).last(),
+  ).toBeVisible();
 
   await longFileRow.click({ button: "right", position: { x: 20, y: 16 } });
   const downloadPromise = page.waitForEvent("download");


### PR DESCRIPTION
## Summary
- follow SFTP symlink targets so linked directories can expand in the file tree
- allow directory context menus to copy absolute paths
- cover real SSH symlink expansion and directory path copying in E2E

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e (67 passed)