### PR TITLE
fix: freeze timeline rendering during active scroll

### DIFF
--- a/app/components/common/chat-virtualizer/index.ts
+++ b/app/components/common/chat-virtualizer/index.ts
@@ -1,3 +1,4 @@
 export { default as ChatStickToBottomScrollArea } from "./ChatStickToBottomScrollArea.vue";
 export { default as ChatVirtualScrollFrame } from "./ChatVirtualScrollFrame.vue";
 export { useChatVirtualizer } from "./useChatVirtualizer";
+export { useScrollBufferedPresentation } from "./useScrollBufferedPresentation";

--- a/app/components/common/chat-virtualizer/useChatVirtualizer.ts
+++ b/app/components/common/chat-virtualizer/useChatVirtualizer.ts
@@ -49,6 +49,13 @@ export function useChatVirtualizer(options: ChatVirtualizerOptions) {
   const virtualizer = directVirtualizer.virtualizer;
   virtualizer.value.shouldAdjustScrollPositionOnItemSizeChange = (item, delta, instance) =>
     shouldAdjustChatScrollForSizeChange(item, delta, instance, sticky.followLatest.value);
+  const isScrolling = computed(() => {
+    // `useDirectDomVirtualizer` triggers its shallow ref when TanStack's range or scrolling flag
+    // changes. Reading the ref before the mutable instance field makes this official Virtualizer
+    // state reactive without installing a second scroll listener or idle timer.
+    const instance = virtualizer.value;
+    return instance.isScrolling;
+  });
   const virtualItems = computed(() => virtualizer.value.getVirtualItems());
 
   function bottomOffset(viewport: HTMLElement) {
@@ -98,6 +105,35 @@ export function useChatVirtualizer(options: ChatVirtualizerOptions) {
     directVirtualizer.refresh();
   }
 
+  async function commitPreservingViewport(commit: () => void) {
+    const generation = ++reflowGeneration;
+    const viewport = options.getViewport();
+    const anchor = captureViewportRowAnchor(viewport);
+    const scrollTop = viewport?.scrollTop ?? 0;
+
+    commit();
+    await nextTick();
+    const currentViewport = options.getViewport();
+    if (!currentViewport || generation !== reflowGeneration) return;
+
+    // The buffered commit happens only after TanStack reports scroll end, so mounted rows can be
+    // synchronously measured in this post-flush phase. Restore one keyed anchor before paint; do
+    // not replay every buffered token or add a RAF compensation loop.
+    directVirtualizer.refresh({ forceStyles: true, remeasure: false });
+    measureVisibleItems();
+    if (sticky.followLatest.value) {
+      scrollToBottom(currentViewport);
+      return;
+    }
+    const anchorElement = anchor ? findViewportRowByKey(currentViewport, anchor.key) : null;
+    if (anchorElement && anchor) {
+      currentViewport.scrollTop += anchorElement.getBoundingClientRect().top - anchor.top;
+    } else {
+      currentViewport.scrollTop = scrollTop;
+    }
+    directVirtualizer.refresh({ forceStyles: true, remeasure: false });
+  }
+
   async function reflow(reflowOptions: { preserveViewport?: boolean } = {}) {
     const generation = ++reflowGeneration;
     const viewport = options.getViewport();
@@ -134,11 +170,13 @@ export function useChatVirtualizer(options: ChatVirtualizerOptions) {
 
   return {
     bindInputListeners: sticky.bindInputListeners,
+    commitPreservingViewport,
     containerElement: directVirtualizer.containerElement,
     containerRef: directVirtualizer.containerRef,
     followLatest: sticky.followLatest,
     followContentChange: sticky.followContentChange,
     initialBottomAligned: sticky.initialBottomAligned,
+    isScrolling,
     isNearBottom: sticky.isNearBottom,
     measureElement,
     measureVisibleItems,

--- a/app/components/common/chat-virtualizer/useScrollBufferedPresentation.ts
+++ b/app/components/common/chat-virtualizer/useScrollBufferedPresentation.ts
@@ -1,0 +1,60 @@
+import { toValue, watch, type MaybeRefOrGetter, type ShallowRef } from "vue";
+
+interface ScrollBufferedPresentationOptions<T> {
+  source: MaybeRefOrGetter<readonly T[]>;
+  sourceRevision: MaybeRefOrGetter<unknown>;
+  frozen: MaybeRefOrGetter<boolean>;
+  presented: ShallowRef<T[]>;
+  presentationRevision: ShallowRef<number>;
+  commitPreservingViewport: (commit: () => void) => Promise<void> | void;
+}
+
+/**
+ * Keeps a virtual list's data source stable while its detached viewport is moving.
+ *
+ * TanStack must still change the mounted range during a scroll, so this does not pause the
+ * virtualizer. It only delays source/content commits and keeps the latest source instead of
+ * queueing every stream delta. The caller pairs `presentationRevision` with Vue `v-memo` because
+ * a shallow row snapshot alone cannot stop nested reactive item proxies from patching mounted DOM.
+ */
+export function useScrollBufferedPresentation<T>(options: ScrollBufferedPresentationOptions<T>) {
+  let committedSource = toValue(options.source);
+  let committedSourceRevision = toValue(options.sourceRevision);
+  let pending = false;
+
+  function commit(source: readonly T[], sourceRevision: unknown) {
+    options.presented.value = [...source];
+    options.presentationRevision.value += 1;
+    committedSource = source;
+    committedSourceRevision = sourceRevision;
+  }
+
+  watch(
+    [
+      () => toValue(options.source),
+      () => toValue(options.sourceRevision),
+      () => toValue(options.frozen),
+    ],
+    ([source, sourceRevision, frozen]) => {
+      const changed =
+        source !== committedSource || !Object.is(sourceRevision, committedSourceRevision);
+      if (!changed) return;
+
+      if (frozen) {
+        // Store only the fact that a newer source exists. Reading `source` again at scroll end
+        // collapses an arbitrary number of token/item updates into one DOM transaction.
+        pending = true;
+        return;
+      }
+
+      if (pending) {
+        pending = false;
+        void options.commitPreservingViewport(() => commit(source, sourceRevision));
+        return;
+      }
+
+      commit(source, sourceRevision);
+    },
+    { flush: "sync" },
+  );
+}

--- a/app/components/thread/ThreadTimelineRowView.vue
+++ b/app/components/thread/ThreadTimelineRowView.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import IntermediateStepsToggle from "@/components/thread/IntermediateStepsToggle.vue";
 import ThreadItemView from "@/components/thread/ThreadItemView.vue";
-import type { ThreadTimelineRow } from "@/components/thread/timeline-rows";
+import {
+  createThreadTimelinePresentationRow,
+  type ThreadTimelineRow,
+} from "@/components/thread/timeline-rows";
 
-defineProps<{
+const props = defineProps<{
   row: ThreadTimelineRow;
+  presentationRevision: number;
   hostId: number | null;
   threadId: string | null;
 }>();
@@ -12,20 +17,31 @@ defineProps<{
 const emit = defineEmits<{
   intermediateToggle: [turnId: string, open: boolean];
 }>();
+
+// The revision is the explicit render clock owned by VirtualTimelineViewport. Keeping it in the
+// computed input replaces implicit subscriptions to mutable Pinia item proxies and therefore lets
+// active scrolling hold the current DOM snapshot even when the row identity itself is unchanged.
+const presentationSource = computed(() => ({
+  row: props.row,
+  revision: props.presentationRevision,
+}));
+const presentationRow = computed(() =>
+  createThreadTimelinePresentationRow(presentationSource.value.row),
+);
 </script>
 
 <template>
   <IntermediateStepsToggle
-    v-if="row.type === 'intermediateHeader'"
-    :open="row.open"
-    :count="row.count"
-    @toggle="emit('intermediateToggle', row.turnId, $event)"
+    v-if="presentationRow.type === 'intermediateHeader'"
+    :open="presentationRow.open"
+    :count="presentationRow.count"
+    @toggle="emit('intermediateToggle', presentationRow.turnId, $event)"
   />
   <ThreadItemView
     v-else
-    :item="row.item"
+    :item="presentationRow.item"
     :host-id="hostId"
     :thread-id="threadId"
-    :user-message-variant="row.userMessageVariant"
+    :user-message-variant="presentationRow.userMessageVariant"
   />
 </template>

--- a/app/components/thread/ThreadVirtualTimeline.vue
+++ b/app/components/thread/ThreadVirtualTimeline.vue
@@ -135,9 +135,10 @@ watch(
       </div>
     </template>
 
-    <template #default="{ row }">
+    <template #default="{ row, revision }">
       <ThreadTimelineRowView
         :row="timelineRow(row)"
+        :presentation-revision="revision"
         :host-id="hostId"
         :thread-id="threadId"
         @intermediate-toggle="setIntermediateOpen"

--- a/app/components/thread/VirtualTimelineViewport.vue
+++ b/app/components/thread/VirtualTimelineViewport.vue
@@ -7,8 +7,12 @@ import {
   useResizeObserver,
 } from "@vueuse/core";
 import type { ComponentPublicInstance } from "vue";
-import { computed, onMounted, ref, watch } from "vue";
-import { ChatVirtualScrollFrame, useChatVirtualizer } from "@/components/common/chat-virtualizer";
+import { computed, onMounted, ref, shallowRef, watch } from "vue";
+import {
+  ChatVirtualScrollFrame,
+  useChatVirtualizer,
+  useScrollBufferedPresentation,
+} from "@/components/common/chat-virtualizer";
 
 interface TimelineViewportRow {
   key: string;
@@ -30,13 +34,15 @@ const emit = defineEmits<{
 const scrollFrameRef = ref<InstanceType<typeof ChatVirtualScrollFrame> | null>(null);
 const threshold = 80;
 const startControlsVisible = ref(false);
+const presentedRows = shallowRef<TimelineViewportRow[]>([...props.rows]);
+const presentationRevision = shallowRef(0);
 
 const chatVirtualizer = useChatVirtualizer({
-  count: () => props.rows.length,
+  count: () => presentedRows.value.length,
   threshold,
   getViewport: scrollViewport,
-  getItemKey: (index: number) => props.rows[index]?.key ?? index,
-  estimateSize: (index: number) => props.estimateSize(props.rows[index], index),
+  getItemKey: (index: number) => presentedRows.value[index]?.key ?? index,
+  estimateSize: (index: number) => props.estimateSize(presentedRows.value[index], index),
   overscan: 6,
   onViewportScroll: (viewport) => {
     // A short chat is simultaneously at the top and bottom. Only interpret
@@ -63,6 +69,15 @@ const chatVirtualizer = useChatVirtualizer({
   },
 });
 const virtualizer = chatVirtualizer.virtualizer;
+
+useScrollBufferedPresentation({
+  source: () => props.rows,
+  sourceRevision: () => props.followKey,
+  frozen: () => chatVirtualizer.userDetached.value && chatVirtualizer.isScrolling.value,
+  presented: presentedRows,
+  presentationRevision,
+  commitPreservingViewport: chatVirtualizer.commitPreservingViewport,
+});
 
 const virtualRows = chatVirtualizer.virtualItems;
 const viewportElement = computed(() => scrollViewport());
@@ -133,7 +148,7 @@ useResizeObserver(chatVirtualizer.containerElement, () => {
 });
 
 watch(
-  () => props.rows.map((row) => row.key).join("\0"),
+  () => presentedRows.value.map((row) => row.key).join("\0"),
   () => {
     if (chatVirtualizer.followLatest.value) {
       // Prepending measured history is not an append, so followOnAppend does
@@ -155,14 +170,12 @@ watch(documentVisibility, (visibility, previous) => {
 });
 
 watch(
-  () => props.followKey,
+  presentationRevision,
   () => {
     startControlsVisible.value = false;
-    // `followKey` changes for every streamed token. It is a content-invalidating
-    // signal, not an instruction to resume following: a reader who explicitly
-    // scrolled upward must keep the exact viewport while the Agent keeps writing.
-    // Reflow/measurement for detached readers is handled by the keyed-anchor
-    // paths above, so only the already-pinned state may advance to the latest row.
+    // Presentation revision changes immediately for a pinned reader and once at scroll end for a
+    // detached moving reader. Watching the committed revision rather than live `followKey` keeps
+    // stream data reactive in Pinia without letting unpresented updates trigger DOM measurement.
     if (chatVirtualizer.followLatest.value) {
       chatVirtualizer.followContentChange();
     }
@@ -219,13 +232,18 @@ defineExpose({ resetFollowLatest });
           :key="String(virtualRow.key)"
           :ref="setRowRef"
           :data-index="virtualRow.index"
-          :data-row-key="rows[virtualRow.index]?.key"
-          :data-row-type="rows[virtualRow.index]?.type"
-          :data-row-section="rows[virtualRow.index]?.section"
+          :data-row-key="presentedRows[virtualRow.index]?.key"
+          :data-row-type="presentedRows[virtualRow.index]?.type"
+          :data-row-section="presentedRows[virtualRow.index]?.section"
           class="pb-5 md:pb-8"
           :style="rowStyle(virtualRow)"
+          v-memo="[presentationRevision, virtualRow.key]"
         >
-          <slot :row="rows[virtualRow.index]" :index="virtualRow.index" />
+          <slot
+            :row="presentedRows[virtualRow.index]"
+            :index="virtualRow.index"
+            :revision="presentationRevision"
+          />
         </div>
       </div>
     </div>

--- a/app/components/thread/timeline-rows.ts
+++ b/app/components/thread/timeline-rows.ts
@@ -1,4 +1,5 @@
 import type { ThreadTimelineItem, ThreadTimelineTurn } from "~~/shared/types";
+import { markRaw, toRaw } from "vue";
 import { itemKey, userMessageVariant, type ThreadTurnSections } from "./thread-turn-sections";
 
 export type { ThreadTimelineTurn } from "~~/shared/types";
@@ -88,6 +89,26 @@ export function estimateThreadTimelineRow(row: ThreadTimelineRow | undefined) {
   if (row === undefined) return 96;
   if (row.type === "intermediateHeader") return 48;
   return estimatedItemHeights[row.item.type] ?? 96;
+}
+
+export function createThreadTimelinePresentationRow(row: ThreadTimelineRow) {
+  if (row.type === "intermediateHeader") return row;
+
+  // App-server deltas mutate the reactive item retained by the history store. Passing that proxy
+  // directly into a row component lets it update independently of the virtual viewport, so an
+  // outer `v-memo` cannot freeze presentation during native scrolling. A shallow immutable view
+  // model snapshots scalar stream fields (notably Agent text and command output) without copying
+  // their potentially large string payloads. Nested values come from Vue's raw target and remain
+  // non-reactive; the next committed presentation revision creates the next view model.
+  //
+  // Keep this conversion beside the timeline row model rather than in the generic virtualizer:
+  // only this layer knows which field is the app-server proxy, while file trees and other virtual
+  // lists must not pay for chat-specific snapshots.
+  const rawItem = toRaw(row.item);
+  return markRaw({
+    ...row,
+    item: markRaw({ ...rawItem }) as ThreadTimelineItem,
+  }) satisfies ThreadTimelineRow;
 }
 
 function appendItemRows(

--- a/tests/e2e/helpers/gateway-store.ts
+++ b/tests/e2e/helpers/gateway-store.ts
@@ -132,6 +132,32 @@ export async function appendAgentStreamLines(
   }, input);
 }
 
+export async function appendAgentTimelineItem(
+  page: Page,
+  input: { turnId: string; itemId: string; text: string },
+) {
+  await page.evaluate((input) => {
+    const views = window.__codexGatewayE2e?.views;
+    if (!views) throw new Error("Gateway E2E driver is unavailable");
+    const history = views.history;
+    if (!history) throw new Error("Gateway thread history is unavailable");
+    const turn = history.thread.turns.find((candidate) => candidate.id === input.turnId);
+    if (!turn) throw new Error(`Missing turn ${input.turnId}`);
+    turn.items = [
+      ...(turn.items ?? []),
+      {
+        id: input.itemId,
+        type: "agentMessage",
+        status: "inProgress",
+        text: input.text,
+      },
+    ];
+    views.history = {
+      thread: { ...history.thread, turns: [...history.thread.turns] },
+    };
+  }, input);
+}
+
 export async function appendFileDiffLines(
   page: Page,
   input: { itemId: string; path: string; prefix: string; count: number },

--- a/tests/e2e/helpers/scroll.ts
+++ b/tests/e2e/helpers/scroll.ts
@@ -244,6 +244,31 @@ export async function scrollChatViewportBy(page: Page, deltaY: number) {
   return { before, after: await chatViewportScrollTop(page) };
 }
 
+export async function startChatWheelScrollUp(page: Page, distance = 240) {
+  const viewport = page
+    .getByTestId(chatScrollAreaTestId)
+    .locator('[data-slot="scroll-area-viewport"]');
+  const before = await captureVisibleTimelineRowAnchor(page);
+
+  // Use Playwright's trusted wheel input for the active-scroll contract. TanStack may compensate
+  // `scrollTop` while replacing estimates even though the visible virtual window moved, so raw
+  // offsets are not a valid movement oracle here; compare the user-visible keyed row instead.
+  await viewport.hover();
+  await page.mouse.wheel(0, -distance);
+  await expect(page.getByTestId(chatScrollAreaTestId)).toHaveAttribute(
+    "data-follow-latest",
+    "false",
+  );
+  await expect
+    .poll(async () => {
+      const after = await captureVisibleTimelineRowAnchor(page);
+      return after.key !== before.key || Math.abs(after.top - before.top) > 2;
+    })
+    .toBe(true);
+
+  return { before, after: await captureVisibleTimelineRowAnchor(page) };
+}
+
 export async function startChatTouchScrollUp(page: Page, distance: number) {
   return await page.getByTestId(chatScrollAreaTestId).evaluate((root: HTMLElement, distance) => {
     const viewport = root.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -318,6 +318,10 @@ test("mobile touch scrolling stays anchored while Agent output streams", async (
     });
     await waitForAnimationFrames(page, 2);
 
+    await expect(
+      page.getByText(`touch stream batch ${batch + 1} 008`, { exact: true }),
+    ).toHaveCount(0);
+
     // Do not assert an exact anchor while the finger is down. WebKit owns the viewport during
     // this phase and TanStack deliberately queues measurement compensation so it does not cancel
     // native scrolling. The critical contract during the gesture is that streaming never takes
@@ -329,6 +333,7 @@ test("mobile touch scrolling stays anchored while Agent output streams", async (
   }
   await endChatTouchScroll(page);
   await waitForChatScrollToSettle(page);
+  await expect(page.getByText("touch stream batch 3 008", { exact: true })).toBeAttached();
   expect(finalAnchor).not.toBeNull();
   if (testInfo.project.name === "mobile-webkit-core-scroll") {
     await expectSyntheticWebKitTouchToRemainReadable(page);
@@ -396,6 +401,10 @@ test("mobile momentum scrolling stays anchored after touchend while output strea
     });
     await waitForAnimationFrames(page, 2);
 
+    await expect(
+      page.getByText(`momentum stream frame ${frame + 1} 008`, { exact: true }),
+    ).toHaveCount(0);
+
     // Momentum is still browser-owned scrolling. Exact compensation is expected only once the
     // scroll-end debounce fires; forcing it per frame would hide the iOS regression by replacing
     // native behavior with a test-only scroll state machine.
@@ -405,6 +414,7 @@ test("mobile momentum scrolling stays anchored after touchend while output strea
     );
   }
   await waitForChatScrollToSettle(page);
+  await expect(page.getByText("momentum stream frame 3 008", { exact: true })).toBeAttached();
   expect(finalAnchor).not.toBeNull();
   if (testInfo.project.name === "mobile-webkit-core-scroll") {
     // Playwright cannot synthesize a native WebKit swipe/momentum gesture. This test models the

--- a/tests/e2e/thread-scroll-behavior.spec.ts
+++ b/tests/e2e/thread-scroll-behavior.spec.ts
@@ -4,6 +4,7 @@ import type { ThreadViewState } from "../../app/stores/gateway/types";
 import { openApp } from "./helpers/app";
 import {
   appendAgentStreamLines,
+  appendAgentTimelineItem,
   appendCommandOutputLines,
   appendFileDiffLines,
   completeTurnWithFinalAgentMessage,
@@ -24,8 +25,10 @@ import {
   scrollChatViewportBy,
   scrollChatViewportToBottom,
   scrollChatViewportToTop,
+  startChatWheelScrollUp,
   visibleAgentLineTop,
   visibleTextTop,
+  waitForChatScrollToSettle,
   waitForScrollableChatViewportAtBottom,
 } from "./helpers/scroll";
 import {
@@ -199,6 +202,9 @@ test("streaming output stays pinned when the user is already at the latest conte
       prefix: `pinned appended batch ${batch + 1}`,
       count: 8,
     });
+    await expect(
+      page.getByText(`pinned appended batch ${batch + 1} 008`, { exact: true }),
+    ).toBeVisible();
     await expect.poll(() => chatViewportBottomDistance(page)).toBeLessThanOrEqual(2);
   }
 });
@@ -254,6 +260,7 @@ test("streaming Agent output keeps a manually detached reader in place", async (
   });
 
   await page.waitForTimeout(300);
+  await expect(page.getByText("detached incoming line 040", { exact: true })).toBeAttached();
   await expect.poll(() => chatViewportScrollTop(page)).toBeGreaterThanOrEqual(scrollTop - 2);
   await expect.poll(() => chatViewportScrollTop(page)).toBeLessThanOrEqual(scrollTop + 2);
   await expect.poll(() => visibleTextTop(page, anchor.text)).toBeGreaterThanOrEqual(anchor.top - 2);
@@ -368,19 +375,31 @@ test("streaming output does not drift the viewport during upward wheel scrolling
 
   await expect(page.getByText("wheel stream initial output")).toBeVisible();
   await waitForScrollableChatViewportAtBottom(page);
+  // Let the initial overscan window replace estimates before beginning the gesture. The product
+  // contract starts with user movement; an estimate correction that consumes a same-frame
+  // synthetic scrollTop write is browser setup noise, not an active-scroll scenario.
+  await waitForAnimationFrames(page, 4);
 
-  // The setup guarantees at least 400px of upward range. Keep the full gesture sequence inside
-  // that range so every batch models active scrolling rather than asking a viewport already at
-  // its top boundary to move farther.
+  // One browser wheel gesture owns a short active-scroll window. Stream several deltas inside that
+  // window instead of repeatedly assigning scrollTop: a later synthetic assignment can be exactly
+  // cancelled when TanStack replaces newly overscanned estimates, even though a real wheel gesture
+  // already happened. Touch continuation and momentum are covered separately on mobile.
+  await startChatWheelScrollUp(page);
+  const anchor = await captureVisibleTextAnchor(page, "wheel scroll history");
   for (let batch = 0; batch < 3; batch += 1) {
-    await scrollChatViewportBy(page, -100);
-    const anchor = await captureVisibleTextAnchor(page, "wheel scroll history");
     await appendAgentStreamLines(page, {
       itemId: "agent-wheel-streaming",
       prefix: `wheel stream batch ${batch + 1}`,
       count: 8,
     });
-    await waitForAnimationFrames(page, 2);
+    await waitForAnimationFrames(page, 1);
+
+    // The store already contains this delta, but a detached reader's mounted timeline snapshot
+    // must stay unchanged until TanStack reports scroll end. This assertion is intentionally about
+    // DOM presence rather than visibility: the streaming row remains inside overscan here.
+    await expect(
+      page.getByText(`wheel stream batch ${batch + 1} 008`, { exact: true }),
+    ).toHaveCount(0);
 
     await expect
       .poll(() => visibleTextTop(page, anchor.text))
@@ -391,6 +410,64 @@ test("streaming output does not drift the viewport during upward wheel scrolling
       "false",
     );
   }
+
+  await waitForChatScrollToSettle(page);
+  await expect(page.getByText("wheel stream batch 3 008", { exact: true })).toBeAttached();
+});
+
+test("new timeline rows commit once after active scrolling stops", async ({ page }) => {
+  await openApp(page);
+  const threadId = "e2e-scroll-buffered-structural-row";
+  const activeTurnId = "turn-buffered-structural-row";
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Buffered Structural Row" },
+    status: "running",
+    history: {
+      thread: {
+        id: threadId,
+        turns: [
+          ...buildVariableHeightTurns(threadId, 36, "buffered row history"),
+          {
+            id: activeTurnId,
+            status: "running",
+            items: [
+              {
+                id: "agent-buffered-existing",
+                type: "agentMessage",
+                status: "inProgress",
+                text: "existing active output",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await expect(page.getByText("existing active output")).toBeVisible();
+  await waitForScrollableChatViewportAtBottom(page);
+  await waitForAnimationFrames(page, 4);
+  await startChatWheelScrollUp(page);
+  const anchor = await captureVisibleTextAnchor(page, "buffered row history");
+
+  await appendAgentTimelineItem(page, {
+    turnId: activeTurnId,
+    itemId: "agent-buffered-new-row",
+    text: "new row buffered during scroll",
+  });
+  await waitForAnimationFrames(page, 2);
+
+  await expect(page.getByText("new row buffered during scroll", { exact: true })).toHaveCount(0);
+  await expect.poll(() => visibleTextTop(page, anchor.text)).toBeGreaterThanOrEqual(anchor.top - 2);
+  await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+
+  await waitForChatScrollToSettle(page);
+  await expect(page.getByText("new row buffered during scroll", { exact: true })).toBeAttached();
+  await expect.poll(() => visibleTextTop(page, anchor.text)).toBeGreaterThanOrEqual(anchor.top - 2);
+  await expect.poll(() => visibleTextTop(page, anchor.text)).toBeLessThanOrEqual(anchor.top + 2);
+  await expect(page.getByTestId("chat-scroll-area")).toHaveAttribute("data-follow-latest", "false");
 });
 
 test("downward wheel scrolling stays detached until the reader reaches latest", async ({


### PR DESCRIPTION
## Summary
- buffer Agent timeline presentation while a detached reader is actively scrolling
- flush the latest immutable presentation snapshot once TanStack reports scroll end while preserving the visible keyed anchor
- keep bottom-pinned streaming live and retain outer virtualization during wheel, touch, and momentum scrolling
- use trusted Playwright wheel input and add desktop/mobile regression coverage

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`79 passed`)
