### PR TITLE
fix: make turn duration props build-safe

### DIFF
--- a/app/components/thread/TurnDurationRow.vue
+++ b/app/components/thread/TurnDurationRow.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { Clock3Icon } from "@lucide/vue";
 import { useTimestamp } from "@vueuse/core";
-import { computed, watch } from "vue";
+import { computed, watch, type PropType } from "vue";
 import { formatDurationMs } from "@/utils/item-timing";
-import { resolvedTurnDurationMs, type TurnTiming } from "@/utils/turn-timing";
+import { resolvedTurnDurationMs } from "@/utils/turn-timing";
 
-const props = defineProps<TurnTiming & { active: boolean }>();
+const props = defineProps({
+  startedAt: { type: Number as PropType<number | null>, default: null },
+  completedAt: { type: Number as PropType<number | null>, default: null },
+  durationMs: { type: Number as PropType<number | null>, default: null },
+  active: Boolean,
+});
 const { t } = useI18n();
 const { timestamp: now, pause, resume } = useTimestamp({ controls: true, interval: 1000 });
 const duration = computed(() => resolvedTurnDurationMs(props, now.value));


### PR DESCRIPTION
## Summary
- replace the imported `defineProps` intersection with explicit nullable Vue runtime props
- avoid compiler-sfc alias type resolution failures with the persistent production Nuxt cache

## Verification
- `pnpm lint`
- `git diff --check`
- `docker compose build codex-gateway`
