### PR TITLE
feat: add Codex upgrade observability

### DIFF
--- a/server/utils/gateway/infra/codex/codex-artifacts.ts
+++ b/server/utils/gateway/infra/codex/codex-artifacts.ts
@@ -30,6 +30,7 @@ interface NodeArtifact {
   directoryName: string;
   version: string;
   sha256: string;
+  size: number;
 }
 
 interface SharedBundle {
@@ -154,7 +155,14 @@ async function prepareNodeArtifact(
   if (downloadedHash !== sha256) {
     throw new Error(`Official Node.js archive checksum mismatch for ${fileName}`);
   }
-  return { localPath, fileName, directoryName, version, sha256 };
+  return {
+    localPath,
+    fileName,
+    directoryName,
+    version,
+    sha256,
+    size: (await stat(localPath)).size,
+  };
 }
 
 async function readOfficialPlatformSpec(version: string, packageName: string) {

--- a/server/utils/gateway/infra/codex/codex-upgrade-log.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-log.ts
@@ -1,0 +1,38 @@
+import { currentGatewayUserId } from "../../state/memory";
+import type { HostWithSecret } from "../ssh/ssh-types";
+
+type UpgradeLogDetails = Record<string, unknown>;
+
+export function codexUpgradeLog(
+  event: string,
+  host: HostWithSecret,
+  details: UpgradeLogDetails = {},
+) {
+  console.info("[gateway-upgrade]", upgradeLogRecord(event, host, details));
+}
+
+export function codexUpgradeError(
+  event: string,
+  host: HostWithSecret,
+  error: unknown,
+  details: UpgradeLogDetails = {},
+) {
+  console.error(
+    "[gateway-upgrade]",
+    upgradeLogRecord(event, host, {
+      ...details,
+      message: error instanceof Error ? error.message : String(error),
+    }),
+  );
+}
+
+function upgradeLogRecord(event: string, host: HostWithSecret, details: UpgradeLogDetails) {
+  return {
+    event,
+    userId: currentGatewayUserId(),
+    hostId: host.id,
+    hostName: host.name || host.sshHost,
+    sshHost: host.sshHost,
+    ...details,
+  };
+}

--- a/server/utils/gateway/infra/codex/codex-upgrade-queue.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-queue.ts
@@ -1,19 +1,44 @@
 import pLimit from "p-limit";
 import { currentGatewayUserId, runWithGatewayUser } from "../../state/memory";
+import type { HostWithSecret } from "../ssh/ssh-types";
+import { codexUpgradeError, codexUpgradeLog } from "./codex-upgrade-log";
+
+const UPGRADE_CONCURRENCY = 3;
 
 /**
  * Remote installs share the Gateway's outbound bandwidth, so only artifact preparation, transfer,
- * and installation are serialized. Version probes and normal Host traffic stay concurrent.
+ * and installation enter this bounded queue. Three slots prevent one slow Host from blocking every
+ * upgrade while keeping version probes and normal Host traffic outside the queue.
  */
 export class CodexUpgradeQueue {
-  private readonly limit = pLimit(1);
+  private readonly limit = pLimit(UPGRADE_CONCURRENCY);
 
   get busy() {
     return this.limit.activeCount > 0 || this.limit.pendingCount > 0;
   }
 
-  async run<T>(work: () => Promise<T>) {
+  async run<T>(host: HostWithSecret, work: () => Promise<T>) {
     const userId = currentGatewayUserId();
-    return await this.limit(() => (userId === null ? work() : runWithGatewayUser(userId, work)));
+    const queuedAt = Date.now();
+    codexUpgradeLog("workflow queued", host, {
+      queuePosition: this.limit.activeCount + this.limit.pendingCount + 1,
+    });
+    return await this.limit(async () => {
+      const run = async () => {
+        const startedAt = Date.now();
+        codexUpgradeLog("workflow started", host, { queueWaitMs: startedAt - queuedAt });
+        try {
+          const result = await work();
+          codexUpgradeLog("workflow completed", host, { durationMs: Date.now() - startedAt });
+          return result;
+        } catch (error: unknown) {
+          codexUpgradeError("workflow failed", host, error, {
+            durationMs: Date.now() - startedAt,
+          });
+          throw error;
+        }
+      };
+      return await (userId === null ? run() : runWithGatewayUser(userId, run));
+    });
   }
 }

--- a/server/utils/gateway/infra/codex/codex-upgrade-workflow.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-workflow.ts
@@ -5,6 +5,7 @@ import type { AppServerRuntimeProbe } from "./app-server-runtime-probe";
 import type { CodexUpgrader } from "./codex-upgrader";
 import { CodexUpgradeQueue } from "./codex-upgrade-queue";
 import type { CodexVersionChecker } from "./codex-version-checker";
+import { codexUpgradeLog } from "./codex-upgrade-log";
 
 export class CodexUpgradeWorkflow {
   private readonly queue = new CodexUpgradeQueue();
@@ -49,6 +50,12 @@ export class CodexUpgradeWorkflow {
         currentRuntimeVersion,
         supportedVersion,
       );
+      codexUpgradeLog("remote version inspected", host, {
+        observedVersion: beforeVersion,
+        appServerVersion: runtimeState.appServerVersion,
+        targetVersion: supportedVersion,
+        runtimeRunning: runtimeState.running,
+      });
 
       if (runtimeState.running && !runtimeVersionSupported) {
         if (await this.runtime.hasActiveLoadedThread(host)) {
@@ -68,6 +75,12 @@ export class CodexUpgradeWorkflow {
           message: runtimeVersionSupported
             ? `${hostDisplayName(host)} 的远端 Codex 已是最新版本 ${beforeVersion}`
             : `${hostDisplayName(host)} 的远端 Codex CLI 已是 ${beforeVersion}，正在重启旧 app-server ${currentRuntimeVersion}`,
+        });
+        codexUpgradeLog("installation skipped", host, {
+          observedVersion: beforeVersion,
+          appServerVersion: runtimeState.appServerVersion,
+          targetVersion: supportedVersion,
+          runtimeRestartRequired: runtimeState.running && !runtimeVersionSupported,
         });
         return {
           version: beforeVersion,
@@ -90,6 +103,10 @@ export class CodexUpgradeWorkflow {
   }
 
   private async install(host: HostWithSecret, supportedVersion: string, beforeVersion: string) {
+    codexUpgradeLog("upgrade required", host, {
+      observedVersion: beforeVersion,
+      targetVersion: supportedVersion,
+    });
     hostLifecycleBus.emit({
       hostId: host.id,
       status: "upgrading",
@@ -138,7 +155,7 @@ export class CodexUpgradeWorkflow {
         message: `${hostDisplayName(host)} 正在等待 Codex 升级队列`,
       });
     }
-    return await this.queue.run(work);
+    return await this.queue.run(host, work);
   }
 
   private async readVersionForRepair(host: HostWithSecret) {

--- a/server/utils/gateway/infra/codex/codex-upgrader.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrader.ts
@@ -12,6 +12,7 @@ import { parseCodexVersion } from "./codex-version";
 import { remoteLoginShellCommand } from "../ssh/remote-command";
 import type { SshConnectionPool } from "../ssh/ssh-connection";
 import type { CommandResult, HostWithSecret } from "../ssh/ssh-types";
+import { codexUpgradeError, codexUpgradeLog } from "./codex-upgrade-log";
 
 const UPGRADE_ATTEMPTS = 3;
 const UPGRADE_IDLE_TIMEOUT_MS = 90_000;
@@ -37,13 +38,41 @@ export class CodexUpgrader {
     version: string,
     callback: (install: () => Promise<string>) => Promise<T>,
   ) {
+    const platformProbeStartedAt = Date.now();
+    codexUpgradeLog("remote platform probe started", host, { targetVersion: version });
     const platform = await this.readRemotePlatform(host);
+    codexUpgradeLog("remote platform probe completed", host, {
+      targetVersion: version,
+      platformPackage: platform.packageName,
+      durationMs: Date.now() - platformProbeStartedAt,
+    });
+    const nodeProbeStartedAt = Date.now();
+    codexUpgradeLog("remote Node.js probe started", host, { targetVersion: version });
     const includeNode = await this.requiresNodeBootstrap(host);
+    codexUpgradeLog("remote Node.js probe completed", host, {
+      targetVersion: version,
+      bootstrapRequired: includeNode,
+      durationMs: Date.now() - nodeProbeStartedAt,
+    });
+    const artifactStartedAt = Date.now();
+    codexUpgradeLog("artifact preparation started", host, {
+      targetVersion: version,
+      platformPackage: platform.packageName,
+      includeNode,
+    });
     return await artifactProvider.withArtifacts(
       version,
       platform,
       { includeNode },
-      async (artifacts) => callback(() => this.installWithRetries(host, version, artifacts)),
+      async (artifacts) => {
+        codexUpgradeLog("artifact preparation completed", host, {
+          targetVersion: version,
+          durationMs: Date.now() - artifactStartedAt,
+          codexArchiveBytes: artifacts.cacheArchive.size,
+          nodeArchiveBytes: artifacts.nodeArchive?.size ?? 0,
+        });
+        return await callback(() => this.installWithRetries(host, version, artifacts));
+      },
     );
   }
 
@@ -71,38 +100,53 @@ export class CodexUpgrader {
     version: string,
     artifacts: CodexArtifactBundle,
   ) {
-    return await pRetry(() => this.installOnce(host, version, artifacts), {
-      retries: UPGRADE_ATTEMPTS - 1,
-      minTimeout: 1_000,
-      factor: 2,
-      shouldRetry: ({ error }) => isTransientUpgradeError(error),
-      onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
-        console.info("[gateway-upgrade] retrying transient Codex offline installation", {
-          hostId: host.id,
-          hostName: host.name,
-          attempt: attemptNumber,
-          retriesLeft,
-          message: error instanceof Error ? error.message : String(error),
-        });
+    return await pRetry(
+      (attemptNumber) => this.installOnce(host, version, artifacts, attemptNumber),
+      {
+        retries: UPGRADE_ATTEMPTS - 1,
+        minTimeout: 1_000,
+        factor: 2,
+        shouldRetry: ({ error }) => isTransientUpgradeError(error),
+        onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
+          codexUpgradeLog("installation retry scheduled", host, {
+            attempt: attemptNumber,
+            retriesLeft,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        },
       },
-    });
+    );
   }
 
-  private async installOnce(host: HostWithSecret, version: string, artifacts: CodexArtifactBundle) {
+  private async installOnce(
+    host: HostWithSecret,
+    version: string,
+    artifacts: CodexArtifactBundle,
+    attempt: number,
+  ) {
+    const attemptStartedAt = Date.now();
+    codexUpgradeLog("installation attempt started", host, { targetVersion: version, attempt });
     const stagePath = await this.createRemoteStage(host);
     try {
-      if (artifacts.nodeArchive !== null) {
-        await this.ssh.uploadFileResumable(
-          host,
-          artifacts.nodeArchive.localPath,
-          `${stagePath}/${artifacts.nodeArchive.fileName}`,
+      const nodeArtifact = artifacts.nodeArchive;
+      if (nodeArtifact !== null) {
+        await this.uploadArtifact(host, "node runtime", nodeArtifact.size, () =>
+          this.ssh.uploadFileResumable(
+            host,
+            nodeArtifact.localPath,
+            `${stagePath}/${nodeArtifact.fileName}`,
+          ),
         );
       }
-      await this.ssh.uploadFileResumable(
-        host,
-        artifacts.cacheArchive.localPath,
-        `${stagePath}/${artifacts.cacheArchive.fileName}`,
+      await this.uploadArtifact(host, "Codex npm cache", artifacts.cacheArchive.size, () =>
+        this.ssh.uploadFileResumable(
+          host,
+          artifacts.cacheArchive.localPath,
+          `${stagePath}/${artifacts.cacheArchive.fileName}`,
+        ),
       );
+      const remoteInstallStartedAt = Date.now();
+      codexUpgradeLog("remote npm install started", host, { targetVersion: version, attempt });
       const result = await this.execInstallCommand(
         host,
         remoteLoginShellCommand(
@@ -110,14 +154,48 @@ export class CodexUpgrader {
         ),
       );
       if (result.code !== 0) throw new Error(upgradeFailureMessage(result));
+      codexUpgradeLog("remote npm install completed", host, {
+        targetVersion: version,
+        attempt,
+        durationMs: Date.now() - remoteInstallStartedAt,
+      });
       const parsed = parseCodexVersion(result.stdout);
       if (!parsed) {
         throw new Error(`Unable to parse upgraded remote Codex version: ${result.stdout.trim()}`);
       }
+      codexUpgradeLog("installation attempt completed", host, {
+        targetVersion: version,
+        installedVersion: parsed.version,
+        attempt,
+        durationMs: Date.now() - attemptStartedAt,
+      });
       return parsed.version;
+    } catch (error: unknown) {
+      codexUpgradeError("installation attempt failed", host, error, {
+        targetVersion: version,
+        attempt,
+        durationMs: Date.now() - attemptStartedAt,
+      });
+      throw error;
     } finally {
       await this.cleanupRemoteStage(host, stagePath);
     }
+  }
+
+  private async uploadArtifact(
+    host: HostWithSecret,
+    artifact: string,
+    bytes: number,
+    upload: () => Promise<string>,
+  ) {
+    const startedAt = Date.now();
+    codexUpgradeLog("artifact upload started", host, { artifact, bytes });
+    await upload();
+    codexUpgradeLog("artifact upload completed", host, {
+      artifact,
+      bytes,
+      durationMs: Date.now() - startedAt,
+    });
   }
 
   private async createRemoteStage(host: HostWithSecret) {
@@ -141,11 +219,7 @@ export class CodexUpgrader {
         remoteLoginShellCommand(codexRemoteCleanupUpgradeStagePayload(stagePath)),
       );
     } catch (error) {
-      console.warn("[gateway-upgrade] deferred remote staging cleanup", {
-        hostId: host.id,
-        hostName: host.name,
-        message: error instanceof Error ? error.message : String(error),
-      });
+      codexUpgradeError("remote staging cleanup failed", host, error);
     }
   }
 

--- a/tests/e2e/00-codex-upgrade.spec.ts
+++ b/tests/e2e/00-codex-upgrade.spec.ts
@@ -31,7 +31,9 @@ test("parses current Codex CLI and app-server user-agent versions", () => {
   );
 });
 
-test("upgrades empty, legacy Node, and legacy Codex SSH hosts serially", async ({ page }) => {
+test("upgrades empty, legacy Node, and legacy Codex SSH hosts with bounded concurrency", async ({
+  page,
+}) => {
   test.setTimeout(10 * 60_000);
   const environments = await readUpgradeRemoteEnvs();
   const remote = environments.find(({ runtimeFixture }) => runtimeFixture === "empty-runtime")!;


### PR DESCRIPTION
## Summary
- limit remote Codex upgrades to three concurrent hosts
- emit structured host and phase logs for queueing, probes, artifact preparation, uploads, installs, retries, cleanup, and completion
- include artifact sizes and phase durations for diagnosing slow upgrades

## Verification
- pnpm lint
- git diff --check

Full E2E was intentionally deferred so the production upgrade blockage can be diagnosed with the new logs.