### PR TITLE
fix: disable broken Nuxt build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ COPY scripts ./scripts
 COPY shared ./shared
 COPY server ./server
 COPY app ./app
-RUN --mount=type=cache,id=codex-gateway-nuxt-build,target=/app/node_modules/.cache/nuxt,sharing=locked \
-    pnpm exec nuxt build
+# Nuxt 4.5.1 buildCache can restore the Vue bundle without wiring its renderer virtual modules
+# (nuxt/nuxt#35894). Keep dependency layers cached, but always produce a complete app bundle.
+RUN pnpm exec nuxt build
 
 FROM node:${NODE_VERSION} AS runner
 ENV NODE_ENV=production

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,7 +9,6 @@ export default defineNuxtConfig({
     server: false,
   },
   experimental: {
-    buildCache: true,
     checkOutdatedBuildInterval: 5 * 60_000,
     emitRouteChunkError: "automatic-immediate",
     // Nuxt 4.5 reuses Vite's watcher instead of opening a second watcher tree.


### PR DESCRIPTION
## Summary
- disable Nuxt 4.5.1 experimental buildCache affected by nuxt/nuxt#35894
- remove the persistent Nuxt cache mount from the production Dockerfile
- retain Docker dependency layers and pnpm store caching

## Verification
- pnpm lint
- git diff --check
- two consecutive production Docker builds and container recreations
- public homepage returned HTTP 200 after both deployments
- renderer entry and precomputed modules remained complete after the second build