### PR TITLE
fix: align turn duration with agent actions

### DIFF
--- a/app/components/thread/ThreadItemView.vue
+++ b/app/components/thread/ThreadItemView.vue
@@ -2,12 +2,14 @@
 import { computed } from "vue";
 import type { ThreadTimelineItem } from "~~/shared/types";
 import { componentForThreadItem } from "@/utils/thread-item-registry";
+import type { DisplayedTurnTiming } from "@/utils/turn-timing";
 
 const props = defineProps<{
   item: ThreadTimelineItem;
   hostId: number | null;
   threadId: string | null;
   userMessageVariant?: "normal" | "steer";
+  turnTiming?: DisplayedTurnTiming | null;
 }>();
 
 const itemComponent = computed(() => componentForThreadItem(props.item.type));
@@ -20,5 +22,6 @@ const itemComponent = computed(() => componentForThreadItem(props.item.type));
     :host-id="hostId"
     :thread-id="threadId"
     :variant="userMessageVariant"
+    :turn-timing="item.type === 'agentMessage' ? turnTiming : undefined"
   />
 </template>

--- a/app/components/thread/ThreadTimelineRowView.vue
+++ b/app/components/thread/ThreadTimelineRowView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import IntermediateStepsToggle from "@/components/thread/IntermediateStepsToggle.vue";
 import ThreadItemView from "@/components/thread/ThreadItemView.vue";
-import TurnDurationRow from "@/components/thread/TurnDurationRow.vue";
+import TurnDurationLabel from "@/components/thread/TurnDurationLabel.vue";
 import type { ThreadTimelineRow } from "@/components/thread/timeline-rows";
 
 const props = defineProps<{
@@ -32,12 +32,7 @@ const emit = defineEmits<{
     :host-id="hostId"
     :thread-id="threadId"
     :user-message-variant="props.row.userMessageVariant"
+    :turn-timing="props.row.turnTiming"
   />
-  <TurnDurationRow
-    v-else
-    :started-at="props.row.startedAt"
-    :completed-at="props.row.completedAt"
-    :duration-ms="props.row.durationMs"
-    :active="props.row.active"
-  />
+  <TurnDurationLabel v-else :timing="props.row" />
 </template>

--- a/app/components/thread/TurnDurationLabel.vue
+++ b/app/components/thread/TurnDurationLabel.vue
@@ -1,33 +1,28 @@
 <script setup lang="ts">
 import { Clock3Icon } from "@lucide/vue";
 import { useTimestamp } from "@vueuse/core";
-import { computed, watch, type PropType } from "vue";
+import { computed, watch } from "vue";
 import { formatDurationMs } from "@/utils/item-timing";
-import { resolvedTurnDurationMs } from "@/utils/turn-timing";
+import { resolvedTurnDurationMs, type DisplayedTurnTiming } from "@/utils/turn-timing";
 
-const props = defineProps({
-  startedAt: { type: Number as PropType<number | null>, default: null },
-  completedAt: { type: Number as PropType<number | null>, default: null },
-  durationMs: { type: Number as PropType<number | null>, default: null },
-  active: Boolean,
-});
+const props = defineProps<{ timing: DisplayedTurnTiming }>();
 const { t } = useI18n();
 const { timestamp: now, pause, resume } = useTimestamp({ controls: true, interval: 1000 });
-const duration = computed(() => resolvedTurnDurationMs(props, now.value));
+const duration = computed(() => resolvedTurnDurationMs(props.timing, now.value));
 const label = computed(() => (duration.value === null ? null : formatDurationMs(duration.value)));
 
 // App-server owns the start/end instants. VueUse only advances the wall clock while a Turn is
 // active; it never invents a start timestamp when the protocol has not supplied one.
 watch(
-  () => props.active,
+  () => props.timing.active,
   (active) => (active ? resume() : pause()),
   { immediate: true },
 );
 </script>
 
 <template>
-  <div v-if="label !== null" class="flex items-center gap-1.5 text-xs text-ink-faint">
+  <span v-if="label !== null" class="inline-flex items-center gap-1.5 text-xs text-ink-faint">
     <Clock3Icon class="size-3.5" />
     <span>{{ t("app.turnDuration", { duration: label }) }}</span>
-  </div>
+  </span>
 </template>

--- a/app/components/thread/items/AgentMessageActions.vue
+++ b/app/components/thread/items/AgentMessageActions.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { CheckIcon, CopyIcon } from "@lucide/vue";
+import { useClipboard } from "@vueuse/core";
+import { toRef } from "vue";
+import { toast } from "vue-sonner";
+import TurnDurationLabel from "@/components/thread/TurnDurationLabel.vue";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { DisplayedTurnTiming } from "@/utils/turn-timing";
+
+const props = defineProps<{
+  text: string;
+  turnTiming?: DisplayedTurnTiming | null;
+}>();
+
+const { t } = useI18n();
+const { copy, copied, isSupported } = useClipboard({
+  source: toRef(props, "text"),
+  copiedDuring: 1200,
+});
+
+async function copyText() {
+  if (!props.text || !isSupported.value) {
+    toast.error(t("app.copyAgentOutputFailed"));
+    return;
+  }
+  try {
+    await copy();
+    toast.success(t("app.agentOutputCopied"));
+  } catch {
+    toast.error(t("app.copyAgentOutputFailed"));
+  }
+}
+</script>
+
+<template>
+  <div data-testid="agent-message-actions" class="mt-2 flex items-center gap-2">
+    <span
+      class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+    >
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger as-child>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              class="size-8 p-0 text-ink-muted hover:bg-canvas-soft hover:text-ink"
+              :aria-label="t('app.copyAgentOutput')"
+              @click="copyText"
+            >
+              <CheckIcon v-if="copied" class="size-4 text-accent-green" />
+              <CopyIcon v-else class="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{{ t("app.copyAgentOutput") }}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </span>
+    <TurnDurationLabel v-if="turnTiming" :timing="turnTiming" />
+  </div>
+</template>

--- a/app/components/thread/items/AgentMessageItem.vue
+++ b/app/components/thread/items/AgentMessageItem.vue
@@ -1,60 +1,23 @@
 <script setup lang="ts">
 import type { ThreadHistoryItem } from "~~/shared/types";
-import { CheckIcon, CopyIcon } from "@lucide/vue";
-import { computed, ref } from "vue";
-import { toast } from "vue-sonner";
-import { Button } from "@/components/ui/button";
+import { computed } from "vue";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import AgentMessageActions from "@/components/thread/items/AgentMessageActions.vue";
 import { isItemInProgress, threadItemText } from "@/utils/thread-items";
+import type { DisplayedTurnTiming } from "@/utils/turn-timing";
 
-const props = defineProps<{ item: ThreadHistoryItem }>();
+const props = defineProps<{
+  item: ThreadHistoryItem;
+  turnTiming?: DisplayedTurnTiming | null;
+}>();
 
-const { t } = useI18n();
 const text = computed(() => threadItemText(props.item));
 const inProgress = computed(() => isItemInProgress(props.item));
-const copied = ref(false);
-
-async function copyText() {
-  if (!text.value) return;
-  try {
-    await navigator.clipboard.writeText(text.value);
-    copied.value = true;
-    toast.success(t("app.agentOutputCopied"));
-    window.setTimeout(() => {
-      copied.value = false;
-    }, 1200);
-  } catch {
-    toast.error(t("app.copyAgentOutputFailed"));
-  }
-}
 </script>
 
 <template>
   <div class="group min-w-0 max-w-full text-[0.9375rem] leading-8 text-ink lg:max-w-4xl">
     <MarkdownContent :content="text" :streaming="inProgress" />
-    <div
-      v-if="text"
-      class="mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-    >
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger as-child>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              class="size-8 p-0 text-ink-muted hover:bg-canvas-soft hover:text-ink"
-              :aria-label="t('app.copyAgentOutput')"
-              @click="copyText"
-            >
-              <CheckIcon v-if="copied" class="size-4 text-accent-green" />
-              <CopyIcon v-else class="size-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{{ t("app.copyAgentOutput") }}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    </div>
+    <AgentMessageActions v-if="text" :text="text" :turn-timing="turnTiming" />
   </div>
 </template>

--- a/app/components/thread/timeline-rows.ts
+++ b/app/components/thread/timeline-rows.ts
@@ -1,4 +1,5 @@
 import type { ThreadTimelineItem, ThreadTimelineTurn } from "~~/shared/types";
+import type { DisplayedTurnTiming } from "@/utils/turn-timing";
 import { itemKey, userMessageVariant, type ThreadTurnSections } from "./thread-turn-sections";
 
 export type { ThreadTimelineTurn } from "~~/shared/types";
@@ -28,6 +29,7 @@ export type ThreadTimelineRow =
       section: ThreadTimelineItemSection;
       item: ThreadTimelineItem;
       userMessageVariant: "normal" | "steer";
+      turnTiming: DisplayedTurnTiming | null;
     }
   | {
       key: string;
@@ -54,6 +56,8 @@ export function buildThreadTimelineRows(input: {
 }) {
   return input.turns.flatMap(({ turn, sections, intermediateOpen }) => {
     const rows: ThreadTimelineRow[] = [];
+    const timing = displayedTurnTiming(turn);
+    const timingTarget = sections.finalItems.findLast((item) => item.type === "agentMessage");
     appendItemRows(rows, input.threadId, turn.id, "user", sections.userItems, sections);
 
     if (sections.intermediateItems.length) {
@@ -76,16 +80,24 @@ export function buildThreadTimelineRows(input: {
       }
     }
 
-    appendItemRows(rows, input.threadId, turn.id, "final", sections.finalItems, sections);
-    if (typeof turn.startedAt === "number" || typeof turn.durationMs === "number") {
+    appendItemRows(
+      rows,
+      input.threadId,
+      turn.id,
+      "final",
+      sections.finalItems,
+      sections,
+      timingTarget,
+      timing,
+    );
+    // Completed turns normally render timing beside the final answer's copy action. Keep a
+    // standalone row only for interrupted/error turns that never produced an Agent answer.
+    if (timing !== null && timingTarget === undefined) {
       rows.push({
         key: `${input.threadId}:turn-${turn.id}:duration`,
         type: "turnDuration",
         turnId: turn.id,
-        startedAt: typeof turn.startedAt === "number" ? turn.startedAt : null,
-        completedAt: typeof turn.completedAt === "number" ? turn.completedAt : null,
-        durationMs: turn.durationMs ?? null,
-        active: turn.status === "inProgress",
+        ...timing,
       });
     }
     return rows;
@@ -118,6 +130,8 @@ function appendItemRows(
   section: ThreadTimelineItemSection,
   items: ThreadTimelineItem[],
   sections: ThreadTurnSections,
+  timingTarget?: ThreadTimelineItem,
+  timing: DisplayedTurnTiming | null = null,
 ) {
   items.forEach((item, index) => {
     rows.push({
@@ -127,8 +141,19 @@ function appendItemRows(
       section,
       item,
       userMessageVariant: userMessageVariant(item, sections),
+      turnTiming: item === timingTarget ? timing : null,
     });
   });
+}
+
+function displayedTurnTiming(turn: ThreadTimelineTurn): DisplayedTurnTiming | null {
+  if (typeof turn.startedAt !== "number" && typeof turn.durationMs !== "number") return null;
+  return {
+    startedAt: typeof turn.startedAt === "number" ? turn.startedAt : null,
+    completedAt: typeof turn.completedAt === "number" ? turn.completedAt : null,
+    durationMs: turn.durationMs ?? null,
+    active: turn.status === "inProgress",
+  };
 }
 
 function sameTimelineRow(left: ThreadTimelineRow, right: ThreadTimelineRow) {
@@ -145,7 +170,8 @@ function sameTimelineRow(left: ThreadTimelineRow, right: ThreadTimelineRow) {
       left.item === right.item &&
       left.turnId === right.turnId &&
       left.section === right.section &&
-      left.userMessageVariant === right.userMessageVariant
+      left.userMessageVariant === right.userMessageVariant &&
+      sameTurnTiming(left.turnTiming, right.turnTiming)
     );
   }
   if (left.type === "turnDuration" && right.type === "turnDuration") {
@@ -158,4 +184,14 @@ function sameTimelineRow(left: ThreadTimelineRow, right: ThreadTimelineRow) {
     );
   }
   return false;
+}
+
+function sameTurnTiming(left: DisplayedTurnTiming | null, right: DisplayedTurnTiming | null) {
+  if (left === null || right === null) return left === right;
+  return (
+    left.startedAt === right.startedAt &&
+    left.completedAt === right.completedAt &&
+    left.durationMs === right.durationMs &&
+    left.active === right.active
+  );
 }

--- a/app/utils/turn-timing.ts
+++ b/app/utils/turn-timing.ts
@@ -4,6 +4,10 @@ export interface TurnTiming {
   durationMs: number | null;
 }
 
+export interface DisplayedTurnTiming extends TurnTiming {
+  active: boolean;
+}
+
 export function resolvedTurnDurationMs(timing: TurnTiming, nowMs: number) {
   if (timing.durationMs !== null && Number.isFinite(timing.durationMs)) {
     return Math.max(0, timing.durationMs);

--- a/tests/e2e/thread-runtime-state.spec.ts
+++ b/tests/e2e/thread-runtime-state.spec.ts
@@ -75,7 +75,9 @@ test("opening completed history does not show fake thinking", async ({ page }) =
   await replayGatewayLiveEvents(page, [startedEvent, completedEvent]);
 
   await expect(page.getByText("completed history")).toBeVisible();
-  await expect(page.getByText("本轮用时 2.50s")).toBeVisible();
+  const agentActions = page.getByTestId("agent-message-actions");
+  await expect(agentActions.getByText("本轮用时 2.50s")).toBeVisible();
+  await expect(agentActions.getByRole("button", { name: "复制输出" })).toBeAttached();
   await expect(page.getByText("思考中")).toBeHidden();
 
   await seedGatewayThread(page, {


### PR DESCRIPTION
## Summary
- render turn duration in the final Agent answer footer beside the copy action
- remove the normal standalone duration row and retain it only for turns without a final answer
- extract the Agent action footer and use VueUse clipboard state

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e -- tests/e2e/thread-runtime-state.spec.ts (8 passed)