### PR TITLE
fix: show agent footer after turn completion

### DIFF
--- a/app/components/thread/items/AgentMessageActions.vue
+++ b/app/components/thread/items/AgentMessageActions.vue
@@ -35,6 +35,7 @@ async function copyText() {
 
 <template>
   <div data-testid="agent-message-actions" class="mt-2 flex items-center gap-2">
+    <TurnDurationLabel v-if="turnTiming" :timing="turnTiming" />
     <span
       class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
     >
@@ -57,6 +58,5 @@ async function copyText() {
         </Tooltip>
       </TooltipProvider>
     </span>
-    <TurnDurationLabel v-if="turnTiming" :timing="turnTiming" />
   </div>
 </template>

--- a/app/components/thread/items/AgentMessageItem.vue
+++ b/app/components/thread/items/AgentMessageItem.vue
@@ -13,11 +13,14 @@ const props = defineProps<{
 
 const text = computed(() => threadItemText(props.item));
 const inProgress = computed(() => isItemInProgress(props.item));
+const showFooter = computed(
+  () => Boolean(text.value) && !inProgress.value && props.turnTiming?.active === false,
+);
 </script>
 
 <template>
   <div class="group min-w-0 max-w-full text-[0.9375rem] leading-8 text-ink lg:max-w-4xl">
     <MarkdownContent :content="text" :streaming="inProgress" />
-    <AgentMessageActions v-if="text" :text="text" :turn-timing="turnTiming" />
+    <AgentMessageActions v-if="showFooter" :text="text" :turn-timing="turnTiming" />
   </div>
 </template>

--- a/app/components/thread/timeline-rows.ts
+++ b/app/components/thread/timeline-rows.ts
@@ -92,7 +92,7 @@ export function buildThreadTimelineRows(input: {
     );
     // Completed turns normally render timing beside the final answer's copy action. Keep a
     // standalone row only for interrupted/error turns that never produced an Agent answer.
-    if (timing !== null && timingTarget === undefined) {
+    if (hasTimingValue(timing) && timingTarget === undefined) {
       rows.push({
         key: `${input.threadId}:turn-${turn.id}:duration`,
         type: "turnDuration",
@@ -146,14 +146,17 @@ function appendItemRows(
   });
 }
 
-function displayedTurnTiming(turn: ThreadTimelineTurn): DisplayedTurnTiming | null {
-  if (typeof turn.startedAt !== "number" && typeof turn.durationMs !== "number") return null;
+function displayedTurnTiming(turn: ThreadTimelineTurn): DisplayedTurnTiming {
   return {
     startedAt: typeof turn.startedAt === "number" ? turn.startedAt : null,
     completedAt: typeof turn.completedAt === "number" ? turn.completedAt : null,
     durationMs: turn.durationMs ?? null,
     active: turn.status === "inProgress",
   };
+}
+
+function hasTimingValue(timing: DisplayedTurnTiming) {
+  return timing.startedAt !== null || timing.durationMs !== null;
 }
 
 function sameTimelineRow(left: ThreadTimelineRow, right: ThreadTimelineRow) {

--- a/tests/e2e/thread-runtime-state.spec.ts
+++ b/tests/e2e/thread-runtime-state.spec.ts
@@ -6,7 +6,6 @@ import {
   installRealtimeThreadSnapshotMock,
   openThreadInStore,
   receiveRealtimeThreadEvent,
-  replayGatewayLiveEvents,
   seedGatewayThread,
   selectedThreadStatusInStore,
 } from "./helpers/gateway-store";
@@ -63,18 +62,27 @@ test("opening completed history does not show fake thinking", async ({ page }) =
     payload: { method: "turn/completed", params: { threadId, turn: completedTurn } },
     createdAt: "2026-07-02T10:00:01.000Z",
   };
+  const activeTurn = appServerTurnFixture({
+    ...completedTurn,
+    status: "inProgress",
+    completedAt: null,
+    durationMs: null,
+  });
   await seedGatewayThread(page, {
     projectId: 1,
     threadId,
     currentThread: { id: threadId, name: "Completed UI", status: { type: "idle" } },
-    history: { thread: { id: threadId, turns: [completedTurn] } },
-    events: [startedEvent, completedEvent],
+    history: { thread: { id: threadId, turns: [activeTurn] } },
+    events: [startedEvent],
     loading: true,
-    status: "completed",
+    status: "running",
   });
-  await replayGatewayLiveEvents(page, [startedEvent, completedEvent]);
 
   await expect(page.getByText("completed history")).toBeVisible();
+  await expect(page.getByTestId("agent-message-actions")).toBeHidden();
+
+  await applyGatewayLiveEvent(page, completedEvent);
+
   const agentActions = page.getByTestId("agent-message-actions");
   await expect(agentActions.getByText("本轮用时 2.50s")).toBeVisible();
   await expect(agentActions.getByRole("button", { name: "复制输出" })).toBeAttached();


### PR DESCRIPTION
## Summary
- place turn duration before the copy action in the final Agent footer
- mount the footer only after both Agent streaming and the owning Turn complete
- keep intermediate Agent messages free of final-answer actions

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e -- tests/e2e/thread-runtime-state.spec.ts (8 passed)