### PR TITLE
fix: stabilize agent footer and restored dock layout

### DIFF
--- a/app/components/chat/workspace-dock/useWorkspaceDockLifecycle.ts
+++ b/app/components/chat/workspace-dock/useWorkspaceDockLifecycle.ts
@@ -123,6 +123,20 @@ export function useWorkspaceDockLifecycle(options: {
     }
     options.reconcile(api.value);
     activate(workspaceLayout.activePanelFor(scopeKey));
+    void layoutRestoredScope(scopeKey);
+  }
+
+  async function layoutRestoredScope(scopeKey: string) {
+    await nextTick();
+    const currentApi = api.value;
+    if (currentApi === null || activeScopeKey !== scopeKey) return;
+    // fromJSON(reuseExistingPanels) moves Dockview's always-mounted Agent renderer between groups.
+    // The outer element may keep the same dimensions, so Dockview's ResizeObserver has no reason
+    // to fire even when the reused panel inherited the previous group's stale content height.
+    // Re-run Dockview's documented layout transaction after Vue commits the move; do not add a
+    // competing ResizeObserver or patch the Agent timeline's height, because Dockview already owns
+    // group geometry and the timeline must only measure rows inside the size it receives.
+    currentApi.layout(currentApi.width, currentApi.height, true);
   }
 
   function switchScope(scopeKey: string) {

--- a/app/components/common/chat-virtualizer/useChatVirtualizer.ts
+++ b/app/components/common/chat-virtualizer/useChatVirtualizer.ts
@@ -53,6 +53,11 @@ export function useChatVirtualizer(options: ChatVirtualizerOptions) {
     (event) => {
       const viewport = event.currentTarget;
       if (!(viewport instanceof HTMLElement)) return;
+      // Diff and command output own bounded nested scrollports. Ignore their scroll events at the
+      // outer Chat boundary just as stick-to-bottom-state does; only geometry changes reported by
+      // the outer viewport may change followLatest. Do not infer this from item types or stop
+      // nested scrolling in each card, because scroll ownership belongs to the two viewports.
+      if (event.target !== viewport) return;
       const distanceFromEnd = Math.max(
         0,
         viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight,

--- a/app/components/thread/ThreadItemView.vue
+++ b/app/components/thread/ThreadItemView.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
   threadId: string | null;
   userMessageVariant?: "normal" | "steer";
   turnTiming?: DisplayedTurnTiming | null;
+  agentActionsAvailable?: boolean;
 }>();
 
 const itemComponent = computed(() => componentForThreadItem(props.item.type));
@@ -23,5 +24,6 @@ const itemComponent = computed(() => componentForThreadItem(props.item.type));
     :thread-id="threadId"
     :variant="userMessageVariant"
     :turn-timing="item.type === 'agentMessage' ? turnTiming : undefined"
+    :agent-actions-available="item.type === 'agentMessage' && agentActionsAvailable"
   />
 </template>

--- a/app/components/thread/ThreadTimelineRowView.vue
+++ b/app/components/thread/ThreadTimelineRowView.vue
@@ -33,6 +33,7 @@ const emit = defineEmits<{
     :thread-id="threadId"
     :user-message-variant="props.row.userMessageVariant"
     :turn-timing="props.row.turnTiming"
+    :agent-actions-available="props.row.agentActionsAvailable"
   />
   <TurnDurationLabel v-else :timing="props.row" />
 </template>

--- a/app/components/thread/ThreadVirtualTimeline.vue
+++ b/app/components/thread/ThreadVirtualTimeline.vue
@@ -65,13 +65,22 @@ const { isIntermediateOpen, setIntermediateOpen } = useIntermediateStepsDisclosu
   autoCollapseIntermediate,
 });
 const rows = computed<ThreadTimelineRow[]>((previous) => {
+  const timelineTurns = turnStates.value.map(({ turn, sections }) => ({
+    turn,
+    sections,
+    intermediateOpen: isIntermediateOpen(turn.id),
+  }));
+  // The disclosure controller already owns the Agent-loop lifecycle: active work stays open and
+  // the whole intermediate process collapses only after the thread settles. Footer actions must
+  // consume that result instead of treating one turn/completed event as the end of a Goal or an
+  // automatic continuation. Requiring every disclosure to be closed also keeps the actions hidden
+  // while a reader has explicitly reopened historical intermediate work.
+  const agentActionsAvailable =
+    !threadIsRunning.value && timelineTurns.every((turn) => !turn.intermediateOpen);
   const next = buildThreadTimelineRows({
     threadId: props.threadId,
-    turns: turnStates.value.map(({ turn, sections }) => ({
-      turn,
-      sections,
-      intermediateOpen: isIntermediateOpen(turn.id),
-    })),
+    turns: timelineTurns,
+    agentActionsAvailable,
   });
   // A streaming delta invalidates the row list but normally changes only one item. Preserve all
   // other row identities so Vue and Markdown renderers do not repeat work inside the virtual

--- a/app/components/thread/items/AgentMessageActions.vue
+++ b/app/components/thread/items/AgentMessageActions.vue
@@ -34,11 +34,13 @@ async function copyText() {
 </script>
 
 <template>
-  <div data-testid="agent-message-actions" class="mt-2 flex items-center gap-2">
+  <!-- The parent mounts actions only after the existing intermediate-process disclosure closes. -->
+  <div
+    data-testid="agent-message-actions"
+    class="mt-2 flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+  >
     <TurnDurationLabel v-if="turnTiming" :timing="turnTiming" />
-    <span
-      class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-    >
+    <span>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger as-child>

--- a/app/components/thread/items/AgentMessageItem.vue
+++ b/app/components/thread/items/AgentMessageItem.vue
@@ -9,18 +9,19 @@ import type { DisplayedTurnTiming } from "@/utils/turn-timing";
 const props = defineProps<{
   item: ThreadHistoryItem;
   turnTiming?: DisplayedTurnTiming | null;
+  agentActionsAvailable?: boolean;
 }>();
 
 const text = computed(() => threadItemText(props.item));
 const inProgress = computed(() => isItemInProgress(props.item));
-const showFooter = computed(
-  () => Boolean(text.value) && !inProgress.value && props.turnTiming?.active === false,
+const hasFooter = computed(
+  () => Boolean(text.value) && props.turnTiming != null && props.agentActionsAvailable === true,
 );
 </script>
 
 <template>
   <div class="group min-w-0 max-w-full text-[0.9375rem] leading-8 text-ink lg:max-w-4xl">
     <MarkdownContent :content="text" :streaming="inProgress" />
-    <AgentMessageActions v-if="showFooter" :text="text" :turn-timing="turnTiming" />
+    <AgentMessageActions v-if="hasFooter" :text="text" :turn-timing="turnTiming" />
   </div>
 </template>

--- a/app/components/thread/timeline-rows.ts
+++ b/app/components/thread/timeline-rows.ts
@@ -30,6 +30,7 @@ export type ThreadTimelineRow =
       item: ThreadTimelineItem;
       userMessageVariant: "normal" | "steer";
       turnTiming: DisplayedTurnTiming | null;
+      agentActionsAvailable: boolean;
     }
   | {
       key: string;
@@ -53,6 +54,7 @@ export interface ThreadTimelineTurnState {
 export function buildThreadTimelineRows(input: {
   threadId: string | null;
   turns: ThreadTimelineTurnState[];
+  agentActionsAvailable: boolean;
 }) {
   return input.turns.flatMap(({ turn, sections, intermediateOpen }) => {
     const rows: ThreadTimelineRow[] = [];
@@ -89,10 +91,11 @@ export function buildThreadTimelineRows(input: {
       sections,
       timingTarget,
       timing,
+      input.agentActionsAvailable,
     );
     // Completed turns normally render timing beside the final answer's copy action. Keep a
     // standalone row only for interrupted/error turns that never produced an Agent answer.
-    if (hasTimingValue(timing) && timingTarget === undefined) {
+    if (input.agentActionsAvailable && hasTimingValue(timing) && timingTarget === undefined) {
       rows.push({
         key: `${input.threadId}:turn-${turn.id}:duration`,
         type: "turnDuration",
@@ -132,6 +135,7 @@ function appendItemRows(
   sections: ThreadTurnSections,
   timingTarget?: ThreadTimelineItem,
   timing: DisplayedTurnTiming | null = null,
+  agentActionsAvailable = false,
 ) {
   items.forEach((item, index) => {
     rows.push({
@@ -142,6 +146,7 @@ function appendItemRows(
       item,
       userMessageVariant: userMessageVariant(item, sections),
       turnTiming: item === timingTarget ? timing : null,
+      agentActionsAvailable: item === timingTarget && agentActionsAvailable,
     });
   });
 }
@@ -174,6 +179,7 @@ function sameTimelineRow(left: ThreadTimelineRow, right: ThreadTimelineRow) {
       left.turnId === right.turnId &&
       left.section === right.section &&
       left.userMessageVariant === right.userMessageVariant &&
+      left.agentActionsAvailable === right.agentActionsAvailable &&
       sameTurnTiming(left.turnTiming, right.turnTiming)
     );
   }

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -493,6 +493,14 @@ done
   });
   await expect(page.getByTestId("chat-main-pane")).toBeVisible();
   await expect(panel).toBeVisible();
+  const [returnedAgentBox, returnedFilesBox] = await Promise.all([
+    page.getByTestId("chat-main-pane").boundingBox(),
+    panel.boundingBox(),
+  ]);
+  // Both panels belong to the restored horizontal split. A reused Agent renderer must be laid out
+  // again after fromJSON; otherwise it can retain a previous group's partial height until reload
+  // while the adjacent Files panel already occupies the full Dockview height.
+  expect(Math.abs(returnedAgentBox!.height - returnedFilesBox!.height)).toBeLessThan(2);
   await page.waitForTimeout(300);
   expect(reopenedPopouts).toBe(0);
 });

--- a/tests/e2e/thread-runtime-state.spec.ts
+++ b/tests/e2e/thread-runtime-state.spec.ts
@@ -47,6 +47,12 @@ test("opening completed history does not show fake thinking", async ({ page }) =
         content: [{ type: "text", text: "completed history" }],
       },
       {
+        id: "reasoning-1",
+        type: "reasoning",
+        status: "completed",
+        summary: ["intermediate work"],
+      },
+      {
         id: "agent-1",
         type: "agentMessage",
         phase: "final_answer",
@@ -79,11 +85,25 @@ test("opening completed history does not show fake thinking", async ({ page }) =
   });
 
   await expect(page.getByText("completed history")).toBeVisible();
-  await expect(page.getByTestId("agent-message-actions")).toBeHidden();
+  await expect(page.getByRole("button", { name: /中间过程/ })).toHaveAttribute(
+    "data-state",
+    "open",
+  );
+  await expect(page.getByTestId("agent-message-actions")).toHaveCount(0);
+  await expect(page.getByText(/本轮用时/)).toHaveCount(0);
 
   await applyGatewayLiveEvent(page, completedEvent);
 
+  await expect(page.getByRole("button", { name: /中间过程/ })).toHaveAttribute(
+    "data-state",
+    "closed",
+  );
   const agentActions = page.getByTestId("agent-message-actions");
+  await expect(agentActions).toBeAttached();
+  await page.getByText("done", { exact: true }).hover();
+  await expect
+    .poll(() => agentActions.evaluate((element) => getComputedStyle(element).opacity))
+    .toBe("1");
   await expect(agentActions.getByText("本轮用时 2.50s")).toBeVisible();
   await expect(agentActions.getByRole("button", { name: "复制输出" })).toBeAttached();
   await expect(page.getByText("思考中")).toBeHidden();


### PR DESCRIPTION
## Summary

- show Agent timing/copy actions only after the whole intermediate process settles and auto-collapses
- force Dockview to recompute reused panel geometry after restoring a per-thread split layout
- keep nested diff/command scroll events from changing the outer Agent timeline follow state
- extend existing E2E coverage for footer lifecycle and restored split-panel height

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`79 passed`)
- targeted scroll suite (`16 passed`)
