### PR TITLE
fix: bound gateway runtime memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,6 @@ COPY --from=build /app/.output ./.output
 COPY --from=build /app/scripts ./scripts
 EXPOSE 3000
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["node", ".output/server/index.mjs"]
+# The 1 GiB container also hosts SSH/TLS/native buffers. Keep V8 old-space bounded to leave room
+# for those allocations, and expose GC only for Nitro's five-minute housekeeping service.
+CMD ["node", "--expose-gc", "--max-old-space-size=512", ".output/server/index.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     container_name: codex-gateway
     restart: unless-stopped
     logging: *default-logging
+    mem_limit: 1g
+    memswap_limit: 1g
     expose:
       - "3000"
     environment:
@@ -23,6 +25,20 @@ services:
       CODEX_GATEWAY_CONFIG_SECRET: ${CODEX_GATEWAY_CONFIG_SECRET:?CODEX_GATEWAY_CONFIG_SECRET is required}
     volumes:
       - ./data:/data
+    # Keep liveness probes side-effect free. Nitro owns periodic GC so probe retries or Docker
+    # daemon pauses cannot change application memory lifecycle.
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "const s=require('node:net').connect(3000,'127.0.0.1',()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     networks:
       - web-common
 

--- a/server/plugins/memory-housekeeping.ts
+++ b/server/plugins/memory-housekeeping.ts
@@ -1,0 +1,8 @@
+import { memoryHousekeepingService } from "../utils/gateway/infra/background/memory-housekeeping";
+
+export default defineNitroPlugin((nitroApp) => {
+  memoryHousekeepingService.start();
+  nitroApp.hooks.hook("close", () => {
+    memoryHousekeepingService.stop();
+  });
+});

--- a/server/utils/gateway/infra/background/memory-housekeeping.ts
+++ b/server/utils/gateway/infra/background/memory-housekeeping.ts
@@ -1,0 +1,61 @@
+const MEBIBYTE = 1024 * 1024;
+const COLLECTION_INTERVAL_MS = 5 * 60_000;
+const COLLECTION_RSS_THRESHOLD = 384 * MEBIBYTE;
+
+type GarbageCollector = () => void;
+
+export class MemoryHousekeepingService {
+  private timer: NodeJS.Timeout | null = null;
+  private warnedUnavailable = false;
+
+  start() {
+    if (this.timer !== null) return;
+    this.timer = setInterval(() => this.collectIfNeeded(), COLLECTION_INTERVAL_MS);
+    // Housekeeping must never keep a shutting-down Nitro process alive.
+    this.timer.unref();
+  }
+
+  stop() {
+    if (this.timer === null) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  private collectIfNeeded() {
+    const before = process.memoryUsage();
+    if (before.rss < COLLECTION_RSS_THRESHOLD) return;
+
+    const collect = exposedGarbageCollector();
+    if (collect === null) {
+      if (!this.warnedUnavailable) {
+        console.warn(
+          "[gateway-memory] periodic collection unavailable; start Node with --expose-gc",
+        );
+        this.warnedUnavailable = true;
+      }
+      return;
+    }
+
+    collect();
+    const after = process.memoryUsage();
+    console.info("[gateway-memory] periodic collection completed", {
+      rssBeforeMiB: toMebibytes(before.rss),
+      rssAfterMiB: toMebibytes(after.rss),
+      heapBeforeMiB: toMebibytes(before.heapUsed),
+      heapAfterMiB: toMebibytes(after.heapUsed),
+    });
+  }
+}
+
+function exposedGarbageCollector(): GarbageCollector | null {
+  if (typeof globalThis.gc !== "function") return null;
+  return () => {
+    globalThis.gc?.();
+  };
+}
+
+function toMebibytes(bytes: number) {
+  return Math.round((bytes / MEBIBYTE) * 10) / 10;
+}
+
+export const memoryHousekeepingService = new MemoryHousekeepingService();

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -78,7 +78,9 @@ services:
     volumes:
       - build-output:/e2e-output:ro
       - e2e-data:/workspace/codex-gateway/.data-e2e
-    command: ["node", "/e2e-output/server/index.mjs"]
+    # Exercise the same V8 memory policy as production; the wider 2 GiB cgroup remains available
+    # to Playwright's shared test topology and native browser/runtime allocations.
+    command: ["node", "--expose-gc", "--max-old-space-size=512", "/e2e-output/server/index.mjs"]
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Summary
- cap the production Gateway container at 1 GiB with no additional swap
- reserve native-memory headroom by limiting V8 old-space to 512 MiB
- add a side-effect-free Docker healthcheck and thresholded five-minute Nitro GC housekeeping
- exercise the production Node memory flags in the containerized E2E gateway

## Verification
- `pnpm lint` passed
- `git diff --check` passed
- `pnpm test:e2e`: 78 passed, 1 existing WebKit mobile momentum initialization timeout (Chromium equivalent passed; failure occurs before streaming assertions)