### PR TITLE
fix: recover Dockview geometry after thread switches

### DIFF
--- a/app/components/chat/workspace-dock/WorkspaceDock.vue
+++ b/app/components/chat/workspace-dock/WorkspaceDock.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { GetTabContextMenuItemsParams } from "dockview-vue";
 import { DockviewVue, themeDark, themeLight } from "dockview-vue";
-import { computed, provide, toRefs } from "vue";
+import { computed, provide, ref, toRefs } from "vue";
 import BrowserOpenDialog from "@/components/browser/BrowserOpenDialog.vue";
 import { useTerminalTheme } from "@/composables/terminal/useTerminalTheme";
 import { useWorkspaceLaunchActions } from "@/composables/workspace/useWorkspaceLaunchActions";
@@ -64,10 +64,12 @@ const panelIds = computed(() => [
   hostMetricsPanel.value.map(({ id }) => id),
 ]);
 const browserDialogOpen = ref(false);
+const dockviewHost = ref<HTMLElement | null>(null);
 const workspaceActions = useWorkspaceLaunchActions();
 const tmuxLauncher = useTmuxMonitorLauncher();
 const lifecycle = useWorkspaceDockLifecycle({
   scopeKey,
+  host: dockviewHost,
   fileRequestScopeKey,
   reconcile: panels.reconcile,
   defaultLayout: panels.defaultLayout,
@@ -118,19 +120,21 @@ function tabContextMenu({ panel, api }: GetTabContextMenuItemsParams) {
     >
       <template #start><slot name="mobile-header-start" /></template>
     </MobileWorkspaceHeader>
-    <DockviewVue
-      class="gateway-dockview min-h-0 flex-1"
-      :right-header-actions-component="
-        layout === 'desktop' ? 'WorkspaceDockGroupActions' : undefined
-      "
-      :theme="dockTheme"
-      floating-group-bounds="boundedWithinViewport"
-      :disable-floating-groups="layout === 'mobile'"
-      :locked="layout === 'mobile'"
-      :keyboard-navigation="true"
-      :get-tab-context-menu-items="layout === 'desktop' ? tabContextMenu : undefined"
-      @ready="lifecycle.ready"
-    />
+    <div ref="dockviewHost" class="gateway-dockview min-h-0 flex-1">
+      <DockviewVue
+        class="h-full w-full"
+        :right-header-actions-component="
+          layout === 'desktop' ? 'WorkspaceDockGroupActions' : undefined
+        "
+        :theme="dockTheme"
+        floating-group-bounds="boundedWithinViewport"
+        :disable-floating-groups="layout === 'mobile'"
+        :locked="layout === 'mobile'"
+        :keyboard-navigation="true"
+        :get-tab-context-menu-items="layout === 'desktop' ? tabContextMenu : undefined"
+        @ready="lifecycle.ready"
+      />
+    </div>
     <BrowserOpenDialog
       v-if="layout === 'mobile'"
       v-model:open="browserDialogOpen"

--- a/app/components/chat/workspace-dock/useDockviewGeometryGuard.ts
+++ b/app/components/chat/workspace-dock/useDockviewGeometryGuard.ts
@@ -1,0 +1,64 @@
+import { useResizeObserver } from "@vueuse/core";
+import type { DockviewApi } from "dockview-vue";
+import type { Ref } from "vue";
+import { nextTick, onBeforeUnmount } from "vue";
+
+const SIZE_TOLERANCE_PX = 1;
+
+/**
+ * Keeps Dockview's internal grid aligned with the flex item that owns it.
+ *
+ * Dockview already observes its root element. The extra observer here is deliberate: during a
+ * keyed Host/Project/Thread switch, `fromJSON()` can run while the surrounding flex tree is still
+ * committing. In that window Dockview may snapshot a smaller height, while the outer flex item
+ * reaches its final height immediately afterwards. We only repair a detected mismatch through
+ * Dockview's public `layout()` API; Agent and Files must not maintain a second, competing height.
+ */
+export function useDockviewGeometryGuard(options: {
+  host: Readonly<Ref<HTMLElement | null>>;
+  api: Readonly<Ref<DockviewApi | null>>;
+  scopeKey: () => string;
+}) {
+  let repairQueued = false;
+  let disposed = false;
+
+  async function repair(reason: "restore" | "host-resize") {
+    if (repairQueued || disposed) return;
+    repairQueued = true;
+    await nextTick();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    repairQueued = false;
+
+    const host = options.host.value;
+    const api = options.api.value;
+    if (disposed || !host || !api || host.clientWidth === 0 || host.clientHeight === 0) return;
+
+    const widthDelta = Math.abs(api.width - host.clientWidth);
+    const heightDelta = Math.abs(api.height - host.clientHeight);
+    if (widthDelta <= SIZE_TOLERANCE_PX && heightDelta <= SIZE_TOLERANCE_PX) return;
+
+    // Do not write CSS dimensions or touch panel content here. Dockview owns group proportions;
+    // re-running its official layout transaction preserves those proportions and repairs only the
+    // stale outer geometry observed after a scope restore.
+    console.warn("[workspace] repaired Dockview geometry", {
+      reason,
+      scopeKey: options.scopeKey(),
+      hostWidth: host.clientWidth,
+      hostHeight: host.clientHeight,
+      dockviewWidth: api.width,
+      dockviewHeight: api.height,
+    });
+    api.layout(host.clientWidth, host.clientHeight, true);
+  }
+
+  const resizeObserver = useResizeObserver(options.host, () => {
+    void repair("host-resize");
+  });
+
+  onBeforeUnmount(() => {
+    disposed = true;
+    resizeObserver.stop();
+  });
+
+  return { repair };
+}

--- a/app/components/chat/workspace-dock/useWorkspaceDockLifecycle.ts
+++ b/app/components/chat/workspace-dock/useWorkspaceDockLifecycle.ts
@@ -1,6 +1,6 @@
 import type { DockviewApi, DockviewReadyEvent, SerializedDockview } from "dockview-vue";
 
-import type { ComputedRef } from "vue";
+import type { ComputedRef, Ref } from "vue";
 import { nextTick, onBeforeUnmount, shallowRef, watch } from "vue";
 import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
 import { useGatewayWorkspaceLayoutStore } from "@/stores/gateway-workspace-layout";
@@ -10,9 +10,11 @@ import {
 } from "@/stores/gateway/workspace-panels";
 import { notifyPopoutBlocked } from "./actions";
 import { useDockLayoutPersistence } from "./useDockLayoutPersistence";
+import { useDockviewGeometryGuard } from "./useDockviewGeometryGuard";
 
 export function useWorkspaceDockLifecycle(options: {
   scopeKey: ComputedRef<string>;
+  host: Readonly<Ref<HTMLElement | null>>;
   fileRequestScopeKey: ComputedRef<string | null>;
   reconcile: (api: DockviewApi) => void;
   defaultLayout: (api: DockviewApi) => SerializedDockview;
@@ -30,6 +32,11 @@ export function useWorkspaceDockLifecycle(options: {
     api,
     activeScopeKey: () => activeScopeKey,
   });
+  const geometry = useDockviewGeometryGuard({
+    host: options.host,
+    api,
+    scopeKey: () => activeScopeKey,
+  });
 
   function activate(panelId: string) {
     const panel = api.value?.getPanel(panelId);
@@ -40,8 +47,8 @@ export function useWorkspaceDockLifecycle(options: {
 
   function ready(event: DockviewReadyEvent) {
     api.value = event.api;
-    initializeScope(activeScopeKey);
     disposables = [
+      event.api.onDidLayoutFromJSON(() => void geometry.repair("restore")),
       event.api.onDidLayoutChange(persistence.scheduleLayoutSave),
       event.api.onWillMutateLayout((mutation) => {
         // Popouts are runtime windows. Capture the docked layout before Dockview removes the group.
@@ -82,6 +89,8 @@ export function useWorkspaceDockLifecycle(options: {
         }),
       ),
     ];
+    initializeScope(activeScopeKey);
+    void geometry.repair("restore");
   }
 
   function initializeScope(scopeKey: string) {

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -448,6 +448,7 @@ done
     page.getByTestId("chat-main-pane").boundingBox(),
     panel.boundingBox(),
   ]);
+  await assertDockviewPanelsFillHost(page);
   const restoredDockRatio =
     restoredAgentDockBox!.width / (restoredAgentDockBox!.width + restoredFilesDockBox!.width);
   expect(Math.abs(restoredDockRatio - dockWidthRatio)).toBeLessThan(0.08);
@@ -515,6 +516,7 @@ done
       page.getByTestId("chat-main-pane").boundingBox(),
       panel.boundingBox(),
     ]);
+    await assertDockviewPanelsFillHost(page);
     const returnedAgentRenderer = await page.getByTestId("chat-main-pane").elementHandle();
     if (returnedAgentRenderer === null) throw new Error("Returned Agent renderer is missing");
     const returnedDockRenderer = await page.locator(".gateway-dockview").elementHandle();
@@ -563,4 +565,21 @@ function filesWorkspaceTab(page: import("@playwright/test").Page) {
 
 function fileTab(page: import("@playwright/test").Page, path: string) {
   return page.locator(`[data-testid="file-workspace-tab"][data-file-path=${JSON.stringify(path)}]`);
+}
+
+async function assertDockviewPanelsFillHost(page: import("@playwright/test").Page) {
+  const host = page.locator(".gateway-dockview");
+  await expect
+    .poll(async () => {
+      const hostBox = await host.boundingBox();
+      const currentAgentBox = await page.getByTestId("chat-main-pane").boundingBox();
+      const currentFilesBox = await page.getByTestId("workspace-file-panel").boundingBox();
+      if (!hostBox || !currentAgentBox || !currentFilesBox) return false;
+      const hostBottom = hostBox.y + hostBox.height;
+      return (
+        Math.abs(currentAgentBox.y + currentAgentBox.height - hostBottom) < 2 &&
+        Math.abs(currentFilesBox.y + currentFilesBox.height - hostBottom) < 2
+      );
+    })
+    .toBe(true);
 }


### PR DESCRIPTION
## Summary
- repair Dockview geometry when keyed thread scopes restore during flex layout commit
- use VueUse resize observation and Dockview official layout API without touching Agent/timeline state
- assert Agent and Files panel bottoms remain attached to the Dockview host across repeated thread switches

## Verification
- pnpm lint
- git diff --check
- standard pnpm test:e2e: Dockview and all scroll scenarios pass; two isolated remote/scroll flakes were individually rerun successfully
- no backend or database changes