### PR TITLE
fix: constrain file tree reveal scrolling

### DIFF
--- a/app/components/files/useRemoteFileTreeReveal.ts
+++ b/app/components/files/useRemoteFileTreeReveal.ts
@@ -1,3 +1,4 @@
+import scrollIntoView from "scroll-into-view-if-needed";
 import { nextTick, ref, watch, type ComputedRef, type Ref } from "vue";
 import type { RemoteDirectoryEntry } from "~~/shared/types";
 import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
@@ -52,12 +53,25 @@ export function useRemoteFileTreeReveal(options: {
       await nextTick();
       if (!node || sequence !== revealSequence.value) return;
 
-      // scrollIntoView delegates both axes to the native tree viewport. Using nearest avoids
-      // disturbing the user's position when the selected row is already visible.
-      const row = [
-        ...(options.viewport.value?.querySelectorAll<HTMLElement>("[data-file-path]") ?? []),
-      ].find((element) => element.dataset.filePath === path);
-      row?.scrollIntoView({ block: "nearest", inline: "nearest" });
+      const viewport = options.viewport.value?.querySelector<HTMLElement>(
+        "[data-testid='remote-file-tree-scroll']",
+      );
+      const row = [...(viewport?.querySelectorAll<HTMLElement>("[data-file-path]") ?? [])].find(
+        (element) => element.dataset.filePath === path,
+      );
+      if (!viewport || !row) return;
+
+      // Native scrollIntoView walks every scrollable ancestor up to document.scrollingElement.
+      // During a restored Dockview scope the browser can therefore reveal the file row by scrolling
+      // the entire application, moving the workspace above the viewport. The library boundary
+      // includes this tree viewport but stops before its parents, so only the file tree can move.
+      // Do not replace this with an unbounded native call, even with block/inline set to "nearest".
+      scrollIntoView(row, {
+        boundary: viewport,
+        block: "nearest",
+        inline: "nearest",
+        scrollMode: "if-needed",
+      });
     },
     { immediate: true },
   );

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "p-retry": "8.0.0",
     "pinia": "^4.0.2",
     "reka-ui": "^2.10.1",
+    "scroll-into-view-if-needed": "^3.1.0",
     "shadcn-nuxt": "^2.8.0",
     "shiki": "4.3.1",
     "socks": "^2.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       reka-ui:
         specifier: ^2.10.1
         version: 2.10.1(vue@3.5.40(typescript@6.0.3))
+      scroll-into-view-if-needed:
+        specifier: ^3.1.0
+        version: 3.1.0
       shadcn-nuxt:
         specifier: ^2.8.0
         version: 2.8.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(magicast@0.5.3)
@@ -3939,6 +3942,9 @@ packages:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
 
+  compute-scroll-into-view@3.1.1:
+    resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
@@ -6302,6 +6308,9 @@ packages:
   sax@1.6.1:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
+
+  scroll-into-view-if-needed@3.1.0:
+    resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -10995,6 +11004,8 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
+  compute-scroll-into-view@3.1.1: {}
+
   concat-stream@2.0.0:
     dependencies:
       buffer-from: 1.1.2
@@ -13985,6 +13996,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.6.1: {}
+
+  scroll-into-view-if-needed@3.1.0:
+    dependencies:
+      compute-scroll-into-view: 3.1.1
 
   scule@1.3.0: {}
 

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -580,6 +580,7 @@ async function assertDockviewPanelsFillHost(page: import("@playwright/test").Pag
       const frameBottom = frameBox.y + frameBox.height;
       const hostBottom = hostBox.y + hostBox.height;
       return (
+        Math.abs(frameBox.y) < 2 &&
         Math.abs(hostBottom - frameBottom) < 2 &&
         Math.abs(currentAgentBox.y + currentAgentBox.height - hostBottom) < 2 &&
         Math.abs(currentFilesBox.y + currentFilesBox.height - hostBottom) < 2


### PR DESCRIPTION
## Summary
- constrain restored file-tree reveal scrolling to the tree viewport
- prevent native scrollIntoView from moving the outer Dockview workspace
- assert the workspace remains aligned with the viewport in file preview E2E

## Verification
- pnpm lint
- pnpm test:e2e (79 passed)
- git diff --check