### PR TITLE
fix: preserve mobile thread reasoning settings

### DIFF
--- a/app/components/chat/composer/ComposerToolbar.vue
+++ b/app/components/chat/composer/ComposerToolbar.vue
@@ -45,9 +45,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div
-    class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 pt-1.5 sm:flex sm:flex-row sm:flex-wrap sm:justify-between sm:gap-2"
-  >
+  <div class="flex min-w-0 items-center gap-1.5 pt-1.5 sm:flex-wrap sm:justify-between sm:gap-2">
     <div class="flex min-w-0 items-center gap-1 text-base text-ink-muted">
       <Button
         type="button"
@@ -61,14 +59,16 @@ const emit = defineEmits<{
         <Loader2Icon v-if="uploadingAttachments" class="size-5 animate-spin" />
         <PlusIcon v-else class="size-5" />
       </Button>
-      <ApprovalPolicyPicker
-        :model-value="selectedApprovalMode"
-        @update:model-value="emit('updateSelectedApprovalMode', $event)"
-      />
+      <div class="hidden sm:block">
+        <ApprovalPolicyPicker
+          :model-value="selectedApprovalMode"
+          @update:model-value="emit('updateSelectedApprovalMode', $event)"
+        />
+      </div>
     </div>
-    <div class="contents sm:flex sm:min-w-0 sm:items-center sm:justify-end sm:gap-2">
+    <div class="ml-auto flex min-w-0 items-center justify-end gap-1.5 sm:gap-2">
       <ContextUsageMeter :token-usage="selectedThreadTokenUsage" />
-      <div class="min-w-0 justify-self-center sm:contents">
+      <div class="min-w-0">
         <ModelEffortPicker
           :models="models"
           :loading-models="loadingModels"

--- a/app/components/chat/composer/ContextUsageMeter.vue
+++ b/app/components/chat/composer/ContextUsageMeter.vue
@@ -25,17 +25,25 @@ const contextUsageStyle = computed(() => {
 const contextUsageLabel = computed(() =>
   contextUsedPercent.value == null ? null : `${contextUsedPercent.value}%`,
 );
+const accessibleLabel = computed(() =>
+  contextUsedPercent.value === null
+    ? t("app.contextUsageUnavailable")
+    : t("app.contextUsage", { percent: contextUsedPercent.value }),
+);
 </script>
 
 <template>
   <div
     v-if="contextUsageLabel"
-    class="hidden items-center gap-2 text-base text-ink-muted sm:flex"
-    :title="t('app.contextUsage', { percent: contextUsedPercent })"
+    data-testid="context-usage-meter"
+    class="flex shrink-0 items-center gap-2 text-base text-ink-muted"
+    :title="accessibleLabel"
+    role="img"
+    :aria-label="accessibleLabel"
   >
     <div class="flex size-6 items-center justify-center rounded-full" :style="contextUsageStyle">
       <div class="size-3.5 rounded-full bg-surface" />
     </div>
-    <span>{{ contextUsageLabel }}</span>
+    <span class="hidden sm:inline">{{ contextUsageLabel }}</span>
   </div>
 </template>

--- a/app/components/chat/composer/ModelEffortPicker.vue
+++ b/app/components/chat/composer/ModelEffortPicker.vue
@@ -45,7 +45,8 @@ const { t } = useI18n();
         data-testid="model-select"
         :disabled="loadingModels || !models.length"
       >
-        <span class="truncate text-ink">{{
+        <span class="truncate text-ink sm:hidden">{{ activeEffortCompactLabel }}</span>
+        <span class="hidden truncate text-ink sm:inline">{{
           loadingModels ? t("app.loadingModels") : activeModelLabel
         }}</span>
         <span v-if="activeEffortCompactLabel" class="hidden shrink-0 text-ink-muted sm:inline">{{

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -47,7 +47,10 @@ export function useComposerController() {
     const effort =
       settings.selectedEffort.value === "default" ? undefined : settings.selectedEffort.value;
     return {
-      model: settings.activeModel.value === "" ? undefined : settings.activeModel.value,
+      // activeModel may contain a presentation fallback while thread/read settings are unknown.
+      // Only an explicit per-thread/new-thread selection may override app-server persistence;
+      // passing the display fallback also resets the persisted reasoning effort to model default.
+      model: settings.selectedModel.value === "" ? undefined : settings.selectedModel.value,
       effort,
       approvalPolicy:
         settings.selectedApprovalMode.value === "custom"
@@ -61,6 +64,7 @@ export function useComposerController() {
     clearDraft,
     selectedTurnOptions,
     activeModel: settings.activeModel,
+    selectedModel: settings.selectedModel,
     selectedEffort: settings.selectedEffort,
     fileReferencesLabel: computed(() => t("app.attachedFileReferences")),
   });

--- a/app/composables/composer/useComposerTurnSubmit.ts
+++ b/app/composables/composer/useComposerTurnSubmit.ts
@@ -20,6 +20,7 @@ export function useComposerTurnSubmit(input: {
   clearDraft: () => void;
   selectedTurnOptions: () => ComposerTurnOptions;
   activeModel: Ref<string | null>;
+  selectedModel: Ref<string>;
   selectedEffort: Ref<string>;
   fileReferencesLabel: Ref<string>;
 }) {
@@ -83,14 +84,22 @@ export function useComposerTurnSubmit(input: {
   }
 
   function planCollaborationMode() {
-    if (input.activeModel.value === null || input.activeModel.value === "") {
-      return undefined;
-    }
     const mode = planModeActive.value ? "plan" : "default";
+    // An existing metadata-only thread may have no selectedModel even though activeModel contains
+    // a catalog fallback for display. Omitting default collaboration mode in that state lets the
+    // resumed app-server thread retain its persisted model and effort. Plan mode is an explicit
+    // user override, so it may intentionally use the displayed catalog fallback.
+    const model =
+      input.selectedModel.value !== ""
+        ? input.selectedModel.value
+        : mode === "plan"
+          ? input.activeModel.value
+          : null;
+    if (model === null || model === "") return undefined;
     return {
       mode,
       settings: {
-        model: input.activeModel.value,
+        model,
         reasoningEffort:
           input.selectedEffort.value === "default" ? null : input.selectedEffort.value,
         developerInstructions: null,

--- a/app/composables/composer/useThreadSettingsControls.ts
+++ b/app/composables/composer/useThreadSettingsControls.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, ref } from "vue";
 
 import { storeToRefs } from "pinia";
 import type { ApprovalPolicy, ReasoningEffort } from "~~/shared/types";
@@ -15,12 +15,65 @@ export function useThreadSettingsControls() {
   const { selectedThreadSettings } = storeToRefs(composer);
   const { selectedThreadId } = storeToRefs(navigation);
   const { t } = useI18n();
-  const selectedModel = ref("");
-  const selectedEffort = ref<ReasoningEffort>("default");
-  const selectedApprovalMode = ref<ApprovalPolicy | "custom">("custom");
-  let syncingSettings = false;
+  const newThreadModel = ref("");
+  const newThreadEffort = ref<ReasoningEffort>("default");
+  const newThreadApprovalMode = ref<ApprovalPolicy | "custom">("custom");
+
+  // Existing-thread controls are computed proxies over the per-thread Pinia state. Do not mirror
+  // them into local refs with bidirectional watchers: thread selection, snapshot hydration, and the
+  // model catalog arrive independently, and a transient model default can otherwise be written
+  // back as the thread's setting. Local refs are retained only for the pre-thread composer, where
+  // no app-server thread identity exists yet.
+  const selectedModel = computed({
+    get: () =>
+      selectedThreadId.value === null
+        ? (firstNonEmptyString([
+            newThreadModel.value,
+            defaultModel.value?.model,
+            defaultModel.value?.id,
+          ]) ?? "")
+        : (trimmedOrNull(selectedThreadSettings.value.model) ?? ""),
+    set: (model: string) => {
+      if (selectedThreadId.value === null) {
+        newThreadModel.value = model;
+        return;
+      }
+      void composer.saveSelectedThreadSettings({ model: trimmedOrNull(model) });
+    },
+  });
+  const selectedEffort = computed<ReasoningEffort>({
+    get: () =>
+      selectedThreadId.value === null
+        ? newThreadEffort.value
+        : (selectedThreadSettings.value.effort ?? "default"),
+    set: (effort) => {
+      if (selectedThreadId.value === null) {
+        newThreadEffort.value = effort;
+        return;
+      }
+      void composer.saveSelectedThreadSettings({ effort: effort === "default" ? null : effort });
+    },
+  });
+  const selectedApprovalMode = computed<ApprovalPolicy | "custom">({
+    get: () =>
+      selectedThreadId.value === null
+        ? newThreadApprovalMode.value
+        : (selectedThreadSettings.value.approvalPolicy ?? "custom"),
+    set: (approvalPolicy) => {
+      if (selectedThreadId.value === null) {
+        newThreadApprovalMode.value = approvalPolicy;
+        return;
+      }
+      void composer.saveSelectedThreadSettings({
+        approvalPolicy: approvalPolicy === "custom" ? null : approvalPolicy,
+      });
+    },
+  });
 
   const activeModel = computed(
+    // This fallback is presentation-only for an existing thread whose metadata-only read cannot
+    // expose persisted settings. Turn submission uses selectedModel instead, because explicitly
+    // sending this catalog default makes app-server discard the thread's persisted model/effort.
     () =>
       firstNonEmptyString([
         selectedModel.value,
@@ -38,9 +91,14 @@ export function useThreadSettingsControls() {
     return firstNonEmptyString([model?.displayName, model?.model, activeModel.value]) ?? "模型";
   });
   const activeEffortValue = computed(() => {
-    return selectedEffort.value !== "default"
-      ? selectedEffort.value
-      : (activeModelRecord.value?.defaultReasoningEffort ?? "");
+    if (selectedEffort.value !== "default") return selectedEffort.value;
+    // A new thread genuinely inherits the selected model's default. For an existing thread,
+    // "default" can also mean that a metadata-only thread/read could not expose persisted effort;
+    // displaying the catalog default as if it were authoritative is what produced the false Light
+    // state on mobile.
+    return selectedThreadId.value === null
+      ? (activeModelRecord.value?.defaultReasoningEffort ?? "")
+      : "";
   });
   const effortOptions = computed(() => {
     const supportedEfforts = activeModelRecord.value?.supportedReasoningEfforts ?? [];
@@ -59,7 +117,11 @@ export function useThreadSettingsControls() {
   const activeEffortLabel = computed(() =>
     labelEffortOption(effortOptions.value.find((option) => option.value === selectedEffort.value)),
   );
-  const activeEffortCompactLabel = computed(() => compactEffortLabel(activeEffortValue.value));
+  const activeEffortCompactLabel = computed(() =>
+    activeEffortValue.value === ""
+      ? t("app.reasoningDefault")
+      : compactEffortLabel(activeEffortValue.value),
+  );
 
   function compactEffortLabel(value: string) {
     if (value === "") return "";
@@ -103,57 +165,6 @@ export function useThreadSettingsControls() {
   function setSelectedApprovalMode(value: ApprovalPolicy | "custom") {
     selectedApprovalMode.value = value;
   }
-
-  function syncComposerFromThreadSettings() {
-    syncingSettings = true;
-    selectedModel.value =
-      firstNonEmptyString([
-        selectedThreadSettings.value.model,
-        defaultModel.value?.model,
-        defaultModel.value?.id,
-      ]) ?? "";
-    selectedEffort.value = selectedThreadSettings.value.effort ?? "default";
-    selectedApprovalMode.value = selectedThreadSettings.value.approvalPolicy ?? "custom";
-    void nextTick(() => {
-      syncingSettings = false;
-    });
-  }
-
-  watch(
-    () => [
-      selectedThreadId.value,
-      selectedThreadSettings.value.model,
-      selectedThreadSettings.value.effort,
-      selectedThreadSettings.value.approvalPolicy,
-      defaultModel.value?.model,
-      defaultModel.value?.id,
-    ],
-    syncComposerFromThreadSettings,
-    { immediate: true },
-  );
-
-  watch(selectedModel, (model) => {
-    if (syncingSettings || selectedThreadId.value === null || selectedThreadId.value === "") {
-      return;
-    }
-    void composer.saveSelectedThreadSettings({ model: trimmedOrNull(model) });
-  });
-
-  watch(selectedEffort, (effort) => {
-    if (syncingSettings || selectedThreadId.value === null || selectedThreadId.value === "") {
-      return;
-    }
-    void composer.saveSelectedThreadSettings({ effort: effort === "default" ? null : effort });
-  });
-
-  watch(selectedApprovalMode, (approvalPolicy) => {
-    if (syncingSettings || selectedThreadId.value === null || selectedThreadId.value === "") {
-      return;
-    }
-    void composer.saveSelectedThreadSettings({
-      approvalPolicy: approvalPolicy === "custom" ? null : approvalPolicy,
-    });
-  });
 
   return {
     selectedModel,

--- a/app/stores/gateway/thread-open/hydration.ts
+++ b/app/stores/gateway/thread-open/hydration.ts
@@ -91,7 +91,12 @@ function applyCommonThreadResult(
   views.newerTurnsCursor = result.turnsPage.backwardsCursor;
   views.lastEventId = explicitLastEventId ?? result.recentEvents.at(-1)?.id ?? 0;
   views.eventEpoch = result.eventEpoch;
-  composer.setThreadSettings(hostId, threadId, result.threadSettings);
+  // A metadata-only thread/read does not expose persisted model/effort. Null means unknown, not
+  // "reset to model defaults", so a same-page thread switch must retain the last authoritative
+  // thread/settings/updated projection already held by Pinia.
+  if (result.threadSettings !== null && result.threadSettings !== undefined) {
+    composer.setThreadSettings(hostId, threadId, result.threadSettings);
+  }
   if (result.tokenUsage !== null && result.tokenUsage !== undefined) {
     runtime.setThreadTokenUsage(hostId, threadId, result.tokenUsage);
   } else syncTokenUsageFromRecentEvents(result.recentEvents);

--- a/server/utils/gateway/protocol/thread-payload.ts
+++ b/server/utils/gateway/protocol/thread-payload.ts
@@ -77,6 +77,17 @@ export function extractThreadSettings(source: unknown): ThreadSettingsState {
   };
 }
 
+export function latestThreadSettingsFromEvents(events: GatewayEvent[]): ThreadSettingsState | null {
+  for (const event of [...events].sort((left, right) => right.id - left.id)) {
+    if (event.method !== "thread/settings/updated") continue;
+    const params = recordFromUnknown(event.payload.params);
+    const settings = recordFromUnknown(params?.threadSettings);
+    if (settings === null) continue;
+    return extractThreadSettings({ threadSettings: settings });
+  }
+  return null;
+}
+
 export function latestTokenUsageFromEvents(events: GatewayEvent[]): ThreadTokenUsageState | null {
   for (const event of [...events].sort((left, right) => right.id - left.id)) {
     if (event.method !== "thread/tokenUsage/updated") {

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -6,7 +6,11 @@ import {
   runtimeStatusFromSnapshotState,
   runtimeStatusFromThreadState,
 } from "~~/shared/thread-runtime-status";
-import { extractThreadSettings, latestTokenUsageFromEvents } from "../protocol/thread-payload";
+import {
+  extractThreadSettings,
+  latestThreadSettingsFromEvents,
+  latestTokenUsageFromEvents,
+} from "../protocol/thread-payload";
 import { gatewayEventStore } from "../state/gateway-events";
 import { projectStore } from "../state/projects";
 import { threadMetadataStore } from "../state/thread-metadata";
@@ -278,7 +282,11 @@ export class ThreadOpenService {
       history: projectThreadTimelineHistory(pageToFullHistory(thread, initialTurnsPage)),
       projectId: resolvedProjectId,
       turnsPage: pageCursorState(initialTurnsPage),
-      threadSettings: extractThreadSettings(read.raw),
+      // thread/read intentionally returns only Thread metadata, not the persisted model/effort
+      // exposed by thread/resume. Preserve a setting observed from Gateway events when available;
+      // otherwise report unknown instead of projecting null fields that erase the browser's
+      // page-level per-thread setting cache.
+      threadSettings: latestThreadSettingsFromEvents(recentEvents),
       tokenUsage: latestTokenUsageFromEvents(recentEvents),
     };
     threadSnapshotStore.set(host.id, threadId, snapshot);

--- a/server/utils/gateway/runtime/types.ts
+++ b/server/utils/gateway/runtime/types.ts
@@ -28,7 +28,8 @@ export interface ThreadOpenSnapshot {
     nextCursor: string | null;
     backwardsCursor: string | null;
   };
-  threadSettings: ThreadSettingsState;
+  /** Null when a metadata-only thread/read cannot expose persisted model settings. */
+  threadSettings: ThreadSettingsState | null;
   tokenUsage: ThreadTokenUsageState | null;
 }
 

--- a/tests/e2e/helpers/gateway-store.ts
+++ b/tests/e2e/helpers/gateway-store.ts
@@ -6,7 +6,9 @@ import type {
   ProjectRecord,
   ThreadGoalStatus,
   ThreadHistoryState,
+  ThreadSettingsState,
   ThreadTimelineTurn,
+  ThreadTokenUsageState,
 } from "../../../shared/types";
 import { projectThreadTimelineHistory } from "../../../shared/thread-history/timeline";
 import type { ThreadViewState } from "../../../app/stores/gateway/types";
@@ -40,6 +42,8 @@ interface SeedGatewayThreadInput {
   olderTurnsCursor?: string | null;
   newerTurnsCursor?: string | null;
   events?: GatewayEvent[];
+  threadSettings?: ThreadSettingsState;
+  tokenUsage?: ThreadTokenUsageState;
   lastEventId?: number;
   eventEpoch?: string;
   threadViews?: Record<
@@ -98,7 +102,7 @@ export async function seedGatewayThread(page: Page, input: SeedGatewayThreadInpu
   await page.evaluate((input: SeedGatewayThreadRuntimeInput) => {
     const driver = window.__codexGatewayE2e;
     if (!driver) throw new Error("Gateway E2E driver is unavailable");
-    const { bootstrap, catalog, navigation, runtime, views } = driver;
+    const { bootstrap, catalog, composer, navigation, runtime, views } = driver;
     const hostId = input.hostId ?? 1;
     const projectId = input.projectId ?? null;
     const threadId = input.threadId ?? null;
@@ -126,6 +130,12 @@ export async function seedGatewayThread(page: Page, input: SeedGatewayThreadInpu
     views.loading = input.loading ?? false;
     if (hasThread && input.status !== undefined) {
       runtime.setThreadStatus(hostId, threadId, input.status);
+    }
+    if (hasThread && input.threadSettings !== undefined) {
+      composer.setThreadSettings(hostId, threadId, input.threadSettings);
+    }
+    if (hasThread && input.tokenUsage !== undefined) {
+      runtime.setThreadTokenUsage(hostId, threadId, input.tokenUsage);
     }
   }, runtimeInput);
 }

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -52,6 +52,39 @@ test("uses the mobile layout with hidden sidebar and usable composer shell", asy
   await expect(page.getByText("先选择一个项目")).toBeVisible();
 });
 
+test("shows effort and compact context usage without mobile approval controls", async ({
+  page,
+}) => {
+  await openApp(page);
+  const threadId = "mobile-composer-settings";
+  const tokenBreakdown = {
+    totalTokens: 50_000,
+    inputTokens: 45_000,
+    cachedInputTokens: 20_000,
+    cacheWriteInputTokens: 0,
+    outputTokens: 5_000,
+    reasoningOutputTokens: 2_000,
+  };
+  await seedGatewayThread(page, {
+    projectId: 1,
+    threadId,
+    currentThread: { id: threadId, name: "Mobile composer settings" },
+    threadSettings: { effort: "medium", approvalPolicy: "never" },
+    tokenUsage: {
+      total: tokenBreakdown,
+      last: tokenBreakdown,
+      modelContextWindow: 100_000,
+    },
+  });
+
+  await expect(page.getByTestId("model-select")).toContainText("Medium");
+  await expect(page.getByText("完全访问", { exact: true })).toBeHidden();
+  const contextMeter = page.getByTestId("context-usage-meter");
+  await expect(contextMeter).toBeVisible();
+  await expect(contextMeter).toHaveAttribute("aria-label", "上下文用量 50%");
+  await expect(contextMeter.getByText("50%", { exact: true })).toBeHidden();
+});
+
 test("virtualizes a large running turn in one agent timeline", async ({ page }, testInfo) => {
   await openApp(page);
   // openApp may reset persisted E2E config by navigating once. WebKit reports an HTTP request


### PR DESCRIPTION
## Summary

- preserve known per-thread model and reasoning settings across metadata-only cold reads
- stop presentation model defaults from overriding app-server persisted reasoning effort
- replace bidirectional composer setting watchers with computed per-thread state proxies
- show reasoning effort and compact context usage on mobile while hiding approval policy

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`80 passed`)
- mobile Chrome and WebKit scroll suites passed