### PR TITLE
fix: restore thread model settings on mobile

### DIFF
--- a/app/components/chat/composer/ComposerShell.vue
+++ b/app/components/chat/composer/ComposerShell.vue
@@ -39,7 +39,7 @@ defineProps<{
   activeEffortValue: string;
   activeEffortCompactLabel: string;
   effortOptions: Array<{ value: ReasoningEffort; label?: string }>;
-  labelEffortOption: (option: { value: ReasoningEffort; label?: string } | undefined) => string;
+  labelEffortOption: (option: { value: ReasoningEffort; label?: string }) => string;
   modelOptionValue: (modelOption: { model?: string; id: string }) => string;
   hasComposerInput: boolean;
   isThreadRunning: boolean;

--- a/app/components/chat/composer/ComposerToolbar.vue
+++ b/app/components/chat/composer/ComposerToolbar.vue
@@ -24,7 +24,7 @@ defineProps<{
   activeEffortValue: string;
   activeEffortCompactLabel: string;
   effortOptions: Array<{ value: ReasoningEffort; label?: string }>;
-  labelEffortOption: (option: { value: ReasoningEffort; label?: string } | undefined) => string;
+  labelEffortOption: (option: { value: ReasoningEffort; label?: string }) => string;
   modelOptionValue: (modelOption: { model?: string; id: string }) => string;
   hasComposerInput: boolean;
   isThreadRunning: boolean;

--- a/app/components/chat/composer/ModelEffortPicker.vue
+++ b/app/components/chat/composer/ModelEffortPicker.vue
@@ -22,7 +22,7 @@ defineProps<{
   activeEffortValue: string;
   activeEffortCompactLabel: string;
   effortOptions: Array<{ value: ReasoningEffort; label?: string }>;
-  labelEffortOption: (option: { value: ReasoningEffort; label?: string } | undefined) => string;
+  labelEffortOption: (option: { value: ReasoningEffort; label?: string }) => string;
   modelOptionValue: (modelOption: { model?: string; id: string }) => string;
 }>();
 
@@ -45,7 +45,14 @@ const { t } = useI18n();
         data-testid="model-select"
         :disabled="loadingModels || !models.length"
       >
-        <span class="truncate text-ink sm:hidden">{{ activeEffortCompactLabel }}</span>
+        <span class="flex min-w-0 items-center gap-1.5 sm:hidden">
+          <span class="truncate text-ink">{{
+            loadingModels ? t("app.loadingModels") : activeModelLabel
+          }}</span>
+          <span v-if="activeEffortCompactLabel" class="shrink-0 text-ink-muted">
+            {{ activeEffortCompactLabel }}
+          </span>
+        </span>
         <span class="hidden truncate text-ink sm:inline">{{
           loadingModels ? t("app.loadingModels") : activeModelLabel
         }}</span>

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -47,9 +47,8 @@ export function useComposerController() {
     const effort =
       settings.selectedEffort.value === "default" ? undefined : settings.selectedEffort.value;
     return {
-      // activeModel may contain a presentation fallback while thread/read settings are unknown.
-      // Only an explicit per-thread/new-thread selection may override app-server persistence;
-      // passing the display fallback also resets the persisted reasoning effort to model default.
+      // Only an explicit per-thread/new-thread selection may override app-server persistence.
+      // Existing-thread settings are projected from thread/resume instead of inferred here.
       model: settings.selectedModel.value === "" ? undefined : settings.selectedModel.value,
       effort,
       approvalPolicy:

--- a/app/composables/composer/useThreadSettingsControls.ts
+++ b/app/composables/composer/useThreadSettingsControls.ts
@@ -14,7 +14,6 @@ export function useThreadSettingsControls() {
   const { models, defaultModel } = storeToRefs(gateway);
   const { selectedThreadSettings } = storeToRefs(composer);
   const { selectedThreadId } = storeToRefs(navigation);
-  const { t } = useI18n();
   const newThreadModel = ref("");
   const newThreadEffort = ref<ReasoningEffort>("default");
   const newThreadApprovalMode = ref<ApprovalPolicy | "custom">("custom");
@@ -70,17 +69,16 @@ export function useThreadSettingsControls() {
     },
   });
 
-  const activeModel = computed(
-    // This fallback is presentation-only for an existing thread whose metadata-only read cannot
-    // expose persisted settings. Turn submission uses selectedModel instead, because explicitly
-    // sending this catalog default makes app-server discard the thread's persisted model/effort.
-    () =>
+  const activeModel = computed(() => {
+    if (selectedThreadId.value !== null) return selectedModel.value;
+    return (
       firstNonEmptyString([
         selectedModel.value,
         defaultModel.value?.model,
         defaultModel.value?.id,
-      ]) ?? "",
-  );
+      ]) ?? ""
+    );
+  });
   const activeModelRecord = computed(() =>
     models.value.find(
       (candidate) => candidate.model === activeModel.value || candidate.id === activeModel.value,
@@ -92,10 +90,6 @@ export function useThreadSettingsControls() {
   });
   const activeEffortValue = computed(() => {
     if (selectedEffort.value !== "default") return selectedEffort.value;
-    // A new thread genuinely inherits the selected model's default. For an existing thread,
-    // "default" can also mean that a metadata-only thread/read could not expose persisted effort;
-    // displaying the catalog default as if it were authoritative is what produced the false Light
-    // state on mobile.
     return selectedThreadId.value === null
       ? (activeModelRecord.value?.defaultReasoningEffort ?? "")
       : "";
@@ -114,14 +108,7 @@ export function useThreadSettingsControls() {
     }
     return options;
   });
-  const activeEffortLabel = computed(() =>
-    labelEffortOption(effortOptions.value.find((option) => option.value === selectedEffort.value)),
-  );
-  const activeEffortCompactLabel = computed(() =>
-    activeEffortValue.value === ""
-      ? t("app.reasoningDefault")
-      : compactEffortLabel(activeEffortValue.value),
-  );
+  const activeEffortCompactLabel = computed(() => compactEffortLabel(activeEffortValue.value));
 
   function compactEffortLabel(value: string) {
     if (value === "") return "";
@@ -143,10 +130,7 @@ export function useThreadSettingsControls() {
       .join(" ");
   }
 
-  function labelEffortOption(option: { value: ReasoningEffort; label?: string } | undefined) {
-    if (option === undefined) {
-      return trimmedOrFallback(activeEffortCompactLabel.value, t("app.reasoningDefault"));
-    }
+  function labelEffortOption(option: { value: ReasoningEffort; label?: string }) {
     return compactEffortLabel(trimmedOrFallback(option.label, option.value));
   }
 
@@ -173,7 +157,6 @@ export function useThreadSettingsControls() {
     activeModel,
     activeModelLabel,
     activeEffortValue,
-    activeEffortLabel,
     activeEffortCompactLabel,
     effortOptions,
     labelEffortOption,

--- a/server/utils/gateway/realtime/handlers/thread-events.ts
+++ b/server/utils/gateway/realtime/handlers/thread-events.ts
@@ -72,6 +72,23 @@ export async function activateThread(
     eventEpoch,
     result.runtimeStatus === "running",
   );
+  if (result.threadSettings === null || result.threadSettings === undefined) {
+    // Send the paginated snapshot first so settings discovery never blocks conversation display.
+    // App-server exposes persisted model/effort only through `thread/resume`; resolve it once when
+    // this server-side snapshot is unknown, then let the ordinary event path update Pinia. The
+    // resolved value is cached in the snapshot, so subsequent same-process opens do not resume an
+    // idle thread again.
+    void runPeerScoped(peer, () =>
+      threadBroker.resolveThreadSettings(host, input.threadId).catch((error: unknown) => {
+        threadRuntimeEvents.record(input.hostId, input.threadId, "gateway/error", {
+          method: "gateway/error",
+          params: {
+            message: error instanceof Error ? error.message : "Failed to resolve thread settings",
+          },
+        });
+      }),
+    );
+  }
 }
 
 export async function startThread(

--- a/server/utils/gateway/runtime/broker.ts
+++ b/server/utils/gateway/runtime/broker.ts
@@ -59,6 +59,10 @@ class ThreadBroker {
     return this.settings.updateThreadSettings(host, threadId, input);
   }
 
+  async resolveThreadSettings(host: HostRecord, threadId: string) {
+    return this.settings.resolveThreadSettings(host, threadId);
+  }
+
   async setThreadGoal(
     host: HostRecord,
     threadId: string,

--- a/server/utils/gateway/runtime/thread-controller.ts
+++ b/server/utils/gateway/runtime/thread-controller.ts
@@ -1,5 +1,5 @@
 import type { HostRecord, RpcEnvelope } from "~~/shared/types";
-import { isAppServerSubAgentThread } from "~~/shared/runtime/app-server";
+import { isAppServerSubAgentThread, parseThreadResumeResult } from "~~/shared/runtime/app-server";
 import {
   runtimeStatusFromAppThreadStatus,
   runtimeStatusFromSnapshotState,
@@ -11,6 +11,7 @@ import { threadSnapshotStore } from "../state/thread-snapshots";
 import { threadRuntimeEvents } from "./thread-runtime-events";
 import type { ThreadOpenSnapshot } from "./types";
 import { createThreadNotificationResolvers } from "./notification-rpc-resolvers";
+import { extractThreadSettings } from "../protocol/thread-payload";
 
 export class ThreadController {
   readonly client: CodexRpcClient;
@@ -107,8 +108,25 @@ export class ThreadController {
       // Fresh threads never enter this branch: ControllerRegistry keeps thread/start's implicit
       // subscription under a bootstrap owner until turn/started. Calling thread/resume before that
       // point is invalid because app-server has not materialized a rollout yet.
-      await this.client.request("thread/resume", { threadId: this.threadId });
+      const resumed = await this.client.request(
+        "thread/resume",
+        { threadId: this.threadId },
+        120_000,
+        parseThreadResumeResult,
+      );
       this.subscribed = true;
+      // `thread/read` and paginated Turn history intentionally omit the persisted model and
+      // reasoning effort. App-server returns those authoritative values from `thread/resume`, but
+      // does not emit `thread/settings/updated` for the resume itself. Project the response through
+      // the same Gateway event path so the server snapshot and every browser use one settings
+      // source instead of guessing from the model catalog.
+      this.publish("thread/settings/updated", {
+        method: "thread/settings/updated",
+        params: {
+          threadId: this.threadId,
+          threadSettings: extractThreadSettings(resumed),
+        },
+      });
     });
   }
 

--- a/server/utils/gateway/runtime/thread-settings.ts
+++ b/server/utils/gateway/runtime/thread-settings.ts
@@ -4,6 +4,13 @@ import type { ControllerRegistry } from "./controller-registry";
 export class ThreadSettingsService {
   constructor(private readonly registry: ControllerRegistry) {}
 
+  async resolveThreadSettings(host: HostRecord, threadId: string) {
+    // Acquiring a scoped lease performs the only authoritative settings read exposed by
+    // app-server: `thread/resume`. The controller projects its response into the snapshot/event
+    // stream; no second settings state is kept here.
+    await this.registry.withScopedSubscription(host, threadId, async () => undefined);
+  }
+
   async updateThreadSettings(host: HostRecord, threadId: string, input: ThreadSettingsState) {
     const params: Record<string, unknown> = { threadId };
     if ("model" in input) params.model = input.model;

--- a/shared/runtime/app-server.ts
+++ b/shared/runtime/app-server.ts
@@ -285,3 +285,33 @@ export function parseThreadReadResult(value: unknown) {
   const result = z.object({ thread: appServerThreadSchema }).loose().parse(value);
   return { raw: result, thread: result.thread };
 }
+
+const threadResumeResultSchema = z
+  .object({
+    thread: appServerThreadSchema,
+    model: z.string().min(1),
+    reasoningEffort: z.string().nullable(),
+    approvalPolicy: z.union([
+      z.literal("untrusted"),
+      z.literal("on-request"),
+      z.literal("never"),
+      z
+        .object({
+          granular: z
+            .object({
+              sandbox_approval: z.boolean(),
+              rules: z.boolean(),
+              skill_approval: z.boolean(),
+              request_permissions: z.boolean(),
+              mcp_elicitations: z.boolean(),
+            })
+            .strict(),
+        })
+        .strict(),
+    ]),
+  })
+  .loose();
+
+export function parseThreadResumeResult(value: unknown) {
+  return threadResumeResultSchema.parse(value);
+}

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -69,7 +69,7 @@ test("shows effort and compact context usage without mobile approval controls", 
     projectId: 1,
     threadId,
     currentThread: { id: threadId, name: "Mobile composer settings" },
-    threadSettings: { effort: "medium", approvalPolicy: "never" },
+    threadSettings: { model: "gpt-5.6-luna", effort: "medium", approvalPolicy: "never" },
     tokenUsage: {
       total: tokenBreakdown,
       last: tokenBreakdown,
@@ -77,6 +77,7 @@ test("shows effort and compact context usage without mobile approval controls", 
     },
   });
 
+  await expect(page.getByTestId("model-select")).toContainText("gpt-5.6-luna");
   await expect(page.getByTestId("model-select")).toContainText("Medium");
   await expect(page.getByText("完全访问", { exact: true })).toBeHidden();
   const contextMeter = page.getByTestId("context-usage-meter");


### PR DESCRIPTION
## Summary
- project authoritative model and reasoning effort from the official thread/resume response
- remove existing-thread catalog/default-reasoning display fallbacks
- show model, reasoning effort, and compact context usage together on mobile

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e (80 passed)