### PR TITLE
fix: sync thread status across browsers

### DIFF
--- a/app/stores/gateway-realtime/handlers/thread.ts
+++ b/app/stores/gateway-realtime/handlers/thread.ts
@@ -1,10 +1,18 @@
 import type { GatewayEvent } from "~~/shared/types";
 import { gatewayDomainEvents } from "@/stores/gateway/domain-events";
-import type { RealtimeHandlers, RealtimeServerMessageHandlerContext } from "./types";
+import type {
+  RealtimeHandlers,
+  RealtimeServerMessageHandlerContext,
+  RealtimeServerMessageMap,
+} from "./types";
 
 export function createThreadRealtimeHandlers(ctx: RealtimeServerMessageHandlerContext) {
   return {
     "thread.event": ({ event }) => handleThreadEvent(ctx, event),
+    "thread.runtime.snapshot": ({ statuses }) => {
+      for (const update of statuses) projectThreadRuntimeStatus(update);
+    },
+    "thread.runtime.updated": ({ update }) => projectThreadRuntimeStatus(update),
     "thread.events.gap": ({ hostId, threadId }) =>
       gatewayDomainEvents.emit("realtime-thread-events-gap", { hostId, threadId }),
     "thread.goal.updated": (message) => {
@@ -20,6 +28,12 @@ export function createThreadRealtimeHandlers(ctx: RealtimeServerMessageHandlerCo
       ctx.resolveRequest(message);
     },
   } satisfies RealtimeHandlers;
+}
+
+function projectThreadRuntimeStatus(
+  update: RealtimeServerMessageMap["thread.runtime.updated"]["update"],
+) {
+  gatewayDomainEvents.emit("thread-status-detected", update);
 }
 
 function handleThreadEvent(ctx: RealtimeServerMessageHandlerContext, event: GatewayEvent) {

--- a/app/stores/gateway-realtime/server-message-handlers.ts
+++ b/app/stores/gateway-realtime/server-message-handlers.ts
@@ -32,6 +32,8 @@ export function createRealtimeServerMessageDispatcher(ctx: RealtimeServerMessage
   return (message: RealtimeServerMessage) =>
     match(message)
       .with({ type: "thread.event" }, thread["thread.event"])
+      .with({ type: "thread.runtime.snapshot" }, thread["thread.runtime.snapshot"])
+      .with({ type: "thread.runtime.updated" }, thread["thread.runtime.updated"])
       .with({ type: "thread.events.gap" }, thread["thread.events.gap"])
       .with({ type: "thread.goal.updated" }, thread["thread.goal.updated"])
       .with({ type: "thread.goal.cleared" }, thread["thread.goal.cleared"])

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "prebuild": "pnpm build:dependencies",
     "predev": "pnpm build:dependencies",
     "dev": "nuxt dev",
-    "format:check": "oxfmt --check app packages scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts '!third_party/**'",
+    "format:check": "oxfmt --check app scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts '!third_party/**'",
     "lint": "pnpm typecheck && pnpm lint:ox && pnpm format:check",
-    "lint:fix": "oxlint app packages scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts --ignore-pattern 'third_party/**' --fix && oxfmt --write app packages scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts '!third_party/**'",
-    "lint:ox": "oxlint app packages scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts --ignore-pattern 'third_party/**'",
-    "typecheck": "pnpm build:dependencies && turbo run typecheck --filter=@codex-gateway/browser-runtime --filter=@codex-gateway/ui --filter=@codex-gateway/ai-elements && nuxt typecheck && vue-tsc -p tests/e2e/tsconfig.json --noEmit",
+    "lint:fix": "oxlint app scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts --ignore-pattern 'third_party/**' --fix && oxfmt --write app scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts '!third_party/**'",
+    "lint:ox": "oxlint app scripts server shared tests nuxt.config.ts playwright.config.ts tailwind.config.ts --ignore-pattern 'third_party/**'",
+    "typecheck": "nuxt typecheck && vue-tsc -p tests/e2e/tsconfig.json --noEmit",
+    "typecheck:dependencies": "pnpm --filter '@codex-gateway/*' --recursive typecheck",
     "user:create": "node scripts/create-user.mjs",
     "test:e2e": "tests/e2e/run-in-containers.sh",
-    "postinstall": "pnpm build:dependencies && nuxt prepare"
+    "postinstall": "pnpm build:dependencies && pnpm typecheck:dependencies && nuxt prepare"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/server/utils/gateway/realtime/connection.ts
+++ b/server/utils/gateway/realtime/connection.ts
@@ -65,6 +65,8 @@ export function cleanupRealtimePeer(peer: RealtimePeer) {
   state.notificationUnsubscribe = undefined;
   state.pinnedThreadsUnsubscribe?.();
   state.pinnedThreadsUnsubscribe = undefined;
+  state.threadRuntimeStatusUnsubscribe?.();
+  state.threadRuntimeStatusUnsubscribe = undefined;
   state.browserPreviewUnsubscribe?.();
   state.browserPreviewUnsubscribe = undefined;
   if (state.browserOwnerId !== undefined) browserPreviewManager.closeOwner(state.browserOwnerId);

--- a/server/utils/gateway/realtime/handlers/auth.ts
+++ b/server/utils/gateway/realtime/handlers/auth.ts
@@ -8,6 +8,7 @@ import { hashToken } from "../../storage/crypto";
 import { subscribeTerminalEvents } from "./terminal";
 import { subscribeBrowserPreviewEvents } from "./browser-preview";
 import { sendRealtimePeerMessage, stateFor, type RealtimePeer } from "../peer-state";
+import { threadRuntimeStatusHub } from "../../runtime/thread-runtime-status-hub";
 
 export function authenticatePeer(
   peer: RealtimePeer,
@@ -42,8 +43,15 @@ export function authenticatePeer(
     pinnedThreadsUnsubscribe: pinnedThreadEvents.subscribe(user.id, () => {
       sendRealtimePeerMessage(peer, { type: "config.pinnedThreads.changed" });
     }),
+    threadRuntimeStatusUnsubscribe: threadRuntimeStatusHub.subscribe(user.id, (update) => {
+      sendRealtimePeerMessage(peer, { type: "thread.runtime.updated", update });
+    }),
   });
   sendRealtimePeerMessage(peer, { type: "ready", connectionId });
+  sendRealtimePeerMessage(peer, {
+    type: "thread.runtime.snapshot",
+    statuses: threadRuntimeStatusHub.snapshot(user.id),
+  });
   subscribeTerminalEvents(peer);
   subscribeBrowserPreviewEvents(peer);
 }

--- a/server/utils/gateway/realtime/peer-state.ts
+++ b/server/utils/gateway/realtime/peer-state.ts
@@ -15,6 +15,7 @@ export interface RealtimePeerState {
   terminalUnsubscribe?: () => void;
   notificationUnsubscribe?: () => void;
   pinnedThreadsUnsubscribe?: () => void;
+  threadRuntimeStatusUnsubscribe?: () => void;
   browserPreviewUnsubscribe?: () => void;
   browserOwnerId?: string;
   sessionRevocationUnsubscribe?: () => void;

--- a/server/utils/gateway/runtime/host-resource-lifecycle.ts
+++ b/server/utils/gateway/runtime/host-resource-lifecycle.ts
@@ -12,6 +12,7 @@ import { activeMainThreadMonitor } from "./active-main-thread-monitor";
 import { threadProjectDiscovery } from "./thread-project-discovery";
 import { pendingServerRequests } from "./pending-server-requests";
 import { hostMetricsManager } from "../infra/host-services";
+import { threadRuntimeStatusHub } from "./thread-runtime-status-hub";
 
 export const hostResourceLifecycle = {
   changed(userId: number, previous: StoredHostRecord, next: StoredHostRecord) {
@@ -19,7 +20,7 @@ export const hostResourceLifecycle = {
     closeEphemeralResources(userId, previous.id);
     if (remoteIdentityFingerprint(previous) !== remoteIdentityFingerprint(next)) {
       threadProjectDiscovery.invalidateHost(userId, previous.id);
-      clearThreadRuntime(previous.id);
+      clearThreadRuntime(userId, previous.id);
       tmuxMonitorService.removeHost(userId, previous.id);
       hostMetricsManager.removeHost(userId, previous.id);
     }
@@ -30,7 +31,7 @@ export const hostResourceLifecycle = {
     // This hook is deliberately limited to ephemeral resources so it cannot create a
     // memory/SQLite split after the durable commit has already succeeded.
     threadProjectDiscovery.invalidateHost(userId, hostId);
-    clearThreadRuntime(hostId);
+    clearThreadRuntime(userId, hostId);
     closeEphemeralResources(userId, hostId);
     tmuxMonitorService.removeHost(userId, hostId);
     hostMetricsManager.removeHost(userId, hostId);
@@ -45,7 +46,8 @@ function closeEphemeralResources(userId: number, hostId: number) {
   browserPreviewManager.closeHost(userId, hostId);
 }
 
-function clearThreadRuntime(hostId: number) {
+function clearThreadRuntime(userId: number, hostId: number) {
+  threadRuntimeStatusHub.deleteHost(userId, hostId);
   threadMetadataStore.deleteForHost(hostId);
   threadSnapshotStore.deleteForHost(hostId);
   subAgentThreadStore.deleteForHost(hostId);

--- a/server/utils/gateway/runtime/thread-runtime-events.ts
+++ b/server/utils/gateway/runtime/thread-runtime-events.ts
@@ -6,6 +6,9 @@ import { subAgentThreadStore } from "../state/sub-agent-threads";
 import { threadSnapshotStore } from "../state/thread-snapshots";
 import { dispatchThreadRuntimeNotification } from "../notifications/thread-notification-dispatcher";
 import { applyEventToOpenSnapshot } from "./open-snapshot-events";
+import { runtimeStatusFromEvent } from "~~/shared/thread-runtime-status";
+import { idFromUnknown, recordFromUnknown } from "~~/shared/utils/records";
+import { threadRuntimeStatusHub } from "./thread-runtime-status-hub";
 
 type ThreadEventSubscriber = (event: GatewayEvent) => void;
 export type ThreadGoalResolver = () => Promise<unknown>;
@@ -28,6 +31,7 @@ class ThreadRuntimeEventBus {
       applyEventToOpenSnapshot(snapshot, method, envelope, event.createdAt),
     );
     this.publish(event);
+    this.publishRuntimeStatus(event);
     dispatchThreadRuntimeNotification(event, options);
     return event;
   }
@@ -54,6 +58,20 @@ class ThreadRuntimeEventBus {
     ) ?? []) {
       subscriber(event);
     }
+  }
+
+  private publishRuntimeStatus(event: GatewayEvent) {
+    const status = runtimeStatusFromEvent(event);
+    if (status === null) return;
+    const params = recordFromUnknown(event.payload.params);
+    const turn = recordFromUnknown(params?.turn);
+    const turnId = idFromUnknown(turn?.id);
+    threadRuntimeStatusHub.publish(currentUserId(), {
+      hostId: event.hostId,
+      threadId: event.threadId,
+      status,
+      turnId: status === "running" && turnId !== null ? String(turnId) : null,
+    });
   }
 
   private key(userId: number, hostId: number, threadId: string) {

--- a/server/utils/gateway/runtime/thread-runtime-status-hub.ts
+++ b/server/utils/gateway/runtime/thread-runtime-status-hub.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from "@posva/event-emitter";
+import type { ThreadRuntimeStatusUpdate } from "~~/shared/types";
+
+type ThreadRuntimeStatusEvents = Record<PropertyKey, unknown> & {
+  updated: ThreadRuntimeStatusUpdate;
+};
+
+/**
+ * User-scoped fan-out for sidebar runtime state.
+ *
+ * Full app-server events remain thread-scoped because broadcasting token, diff, and command
+ * output to every browser would waste memory and bandwidth. This hub retains only concurrently
+ * running identities so a newly connected browser can restore its sidebar without subscribing
+ * to every thread. Terminal updates are emitted once and immediately removed from the snapshot.
+ */
+class ThreadRuntimeStatusHub {
+  private readonly emitters = new Map<number, EventEmitter<ThreadRuntimeStatusEvents>>();
+  private readonly runningByUser = new Map<number, Map<string, ThreadRuntimeStatusUpdate>>();
+
+  publish(userId: number, update: ThreadRuntimeStatusUpdate) {
+    const running = this.runningByUser.get(userId) ?? new Map<string, ThreadRuntimeStatusUpdate>();
+    const key = statusKey(update.hostId, update.threadId);
+    if (update.status === "running") {
+      running.set(key, update);
+      this.runningByUser.set(userId, running);
+    } else {
+      running.delete(key);
+      if (running.size === 0) this.runningByUser.delete(userId);
+    }
+    this.emitters.get(userId)?.emit("updated", update);
+  }
+
+  subscribe(userId: number, listener: (update: ThreadRuntimeStatusUpdate) => void) {
+    let emitter = this.emitters.get(userId);
+    if (emitter === undefined) {
+      emitter = new EventEmitter<ThreadRuntimeStatusEvents>();
+      this.emitters.set(userId, emitter);
+    }
+    const unsubscribe = emitter.on("updated", listener);
+    return () => {
+      unsubscribe();
+      if (emitter.all.size === 0) this.emitters.delete(userId);
+    };
+  }
+
+  snapshot(userId: number) {
+    return [...(this.runningByUser.get(userId)?.values() ?? [])];
+  }
+
+  deleteHost(userId: number, hostId: number) {
+    const running = this.runningByUser.get(userId);
+    if (running === undefined) return;
+    for (const [key, update] of running) {
+      if (update.hostId === hostId) running.delete(key);
+    }
+    if (running.size === 0) this.runningByUser.delete(userId);
+  }
+}
+
+function statusKey(hostId: number, threadId: string) {
+  return `${hostId}:${threadId}`;
+}
+
+export const threadRuntimeStatusHub = new ThreadRuntimeStatusHub();

--- a/shared/runtime/realtime/server-message-schema.ts
+++ b/shared/runtime/realtime/server-message-schema.ts
@@ -95,6 +95,14 @@ const threadSettingsSchema = z
     approvalPolicy: z.enum(["untrusted", "on-request", "never"]).nullable().optional(),
   })
   .strict();
+const threadRuntimeStatusUpdateSchema = z
+  .object({
+    hostId: positiveId,
+    threadId: nonEmptyString,
+    status: z.enum(["idle", "running", "completed", "failed", "interrupted"]),
+    turnId: z.string().nullable().optional(),
+  })
+  .strict();
 const tokenUsageBreakdownSchema = z
   .object({
     totalTokens: nonNegativeId,
@@ -276,6 +284,18 @@ export const realtimeServerMessageSchema: z.ZodType<RealtimeServerMessage> = z.d
       .object({ type: z.literal("notification.published"), notification: notificationSchema })
       .strict(),
     z.object({ type: z.literal("config.pinnedThreads.changed") }).strict(),
+    z
+      .object({
+        type: z.literal("thread.runtime.snapshot"),
+        statuses: z.array(threadRuntimeStatusUpdateSchema),
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("thread.runtime.updated"),
+        update: threadRuntimeStatusUpdateSchema,
+      })
+      .strict(),
     z
       .object({
         type: z.literal("host.lifecycle"),

--- a/shared/thread-runtime-status.ts
+++ b/shared/thread-runtime-status.ts
@@ -192,7 +192,9 @@ function runtimeStatusFromEvents(events: GatewayEvent[]): ThreadRuntimeStatus | 
   return null;
 }
 
-function runtimeStatusFromEvent(event: GatewayEvent | undefined): ThreadRuntimeStatus | null {
+export function runtimeStatusFromEvent(
+  event: GatewayEvent | undefined,
+): ThreadRuntimeStatus | null {
   if (!event) {
     return null;
   }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -24,6 +24,7 @@ export type {
   ThreadGoalTimelineItem,
   ThreadOpenResult,
   ThreadRuntimeStatus,
+  ThreadRuntimeStatusUpdate,
   ThreadSettingsState,
   ThreadTokenUsageState,
   ThreadTurnsPageResult,

--- a/shared/types/realtime.ts
+++ b/shared/types/realtime.ts
@@ -4,6 +4,7 @@ import type {
   ThreadGoal,
   ThreadGoalStatus,
   ThreadOpenResult,
+  ThreadRuntimeStatusUpdate,
   ThreadTurnsPageResult,
 } from "./thread";
 import type { ApprovalPolicy, ReasoningEffort } from "./thread";
@@ -200,6 +201,14 @@ export type RealtimeServerMessage =
     }
   | {
       type: "config.pinnedThreads.changed";
+    }
+  | {
+      type: "thread.runtime.snapshot";
+      statuses: ThreadRuntimeStatusUpdate[];
+    }
+  | {
+      type: "thread.runtime.updated";
+      update: ThreadRuntimeStatusUpdate;
     }
   | {
       type: "host.lifecycle";

--- a/shared/types/thread.ts
+++ b/shared/types/thread.ts
@@ -2,6 +2,13 @@ import type { GatewayEvent, ProjectRecord } from "./records";
 import type { ThreadHistoryItem, ThreadTimelineHistoryState } from "../thread-history/types";
 
 export type ThreadRuntimeStatus = "idle" | "running" | "completed" | "failed" | "interrupted";
+
+export interface ThreadRuntimeStatusUpdate {
+  hostId: number;
+  threadId: string;
+  status: ThreadRuntimeStatus;
+  turnId?: string | null;
+}
 export type ThreadGoalStatus =
   | "active"
   | "paused"

--- a/tests/e2e/realtime-multi-client.spec.ts
+++ b/tests/e2e/realtime-multi-client.spec.ts
@@ -119,14 +119,50 @@ test("fans out a real remote app-server thread to multiple browser clients acros
       .getByText(steerMarker),
   );
 
+  const backgroundThreadId = await remoteWorkspace.startThread(project.id);
   const secondContext = await browser.newContext({
     storageState: await page.context().storageState(),
   });
+  await openThreadFromProjectOrRestoredState(page, project.id, threadId);
   const secondPage = await secondContext.newPage();
   await installRealtimeSocketProbe(secondPage);
   await openApp(secondPage, { resetConfig: false });
   try {
     await expect.poll(() => activeRealtimeSocketCount(secondPage), { timeout: 10_000 }).toBe(1);
+    await expect
+      .poll(async () => currentSelectedThreadId(secondPage), { timeout: 30_000 })
+      .toBe(backgroundThreadId);
+    const backgroundStatusMarker = `E2E 跨浏览器侧边栏状态 ${Date.now()}`;
+    await page
+      .getByPlaceholder("输入后续修改要求")
+      .fill(
+        [
+          `请执行较长命令后回复：${backgroundStatusMarker}`,
+          "运行 python - <<'PY'",
+          "import time",
+          "time.sleep(8)",
+          `print('${backgroundStatusMarker}')`,
+          "PY",
+        ].join("\n"),
+      );
+    await page.getByTestId("send-turn-button").click();
+    await expect(page.getByTestId("send-turn-button")).toHaveAttribute("aria-label", "停止生成");
+    await expect(
+      secondPage.getByTestId(`thread-button-${threadId}`).getByLabel("运行中"),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      secondPage.getByTestId(`recent-thread-button-${threadId}`).getByLabel("运行中"),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(() => threadRuntimeStatus(secondPage, host.id, threadId), { timeout: 30_000 })
+      .toBe("running");
+    await expect(page.getByTestId("send-turn-button")).toHaveAttribute("aria-label", "已完成", {
+      timeout: 120_000,
+    });
+    await expect
+      .poll(() => threadRuntimeStatus(secondPage, host.id, threadId), { timeout: 30_000 })
+      .toBe("completed");
+
     await openThreadFromProjectOrRestoredState(secondPage, project.id, threadId);
     await expect(secondPage.getByPlaceholder("输入后续修改要求")).toBeEnabled();
     await expect
@@ -324,4 +360,12 @@ async function activeRemoteTurnId(page: Page) {
         : "";
     return String(runtime.activeTerminalProcessByThreadKey[key]?.turnId ?? "");
   });
+}
+
+async function threadRuntimeStatus(page: Page, hostId: number, threadId: string) {
+  return page.evaluate(
+    ({ hostId, threadId }) =>
+      window.__codexGatewayE2e?.runtime.threadStatuses[`${hostId}:${threadId}`] ?? "idle",
+    { hostId, threadId },
+  );
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,10 +12,6 @@
         "rolldown.config.ts"
       ],
       "outputs": ["dist/**"]
-    },
-    "typecheck": {
-      "dependsOn": ["^typecheck"],
-      "inputs": ["src/**", "package.json", "tsconfig.json"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- fan out lightweight app-server thread runtime status to every authenticated browser for the same user
- reuse the existing sidebar and recently-running thread projection without broadcasting full thread payloads or creating extra SSH/RPC sessions
- keep root lint focused on application code while typechecking all `@codex-gateway/*` workspaces during postinstall

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`80 passed`)
- real two-browser E2E verifies running and completed status without opening the active thread in the second browser