### PR TITLE
feat: add goal controls to details dialog

### DIFF
--- a/app/components/chat/ChatComposer.vue
+++ b/app/components/chat/ChatComposer.vue
@@ -13,8 +13,10 @@ const {
   canUsePrimaryAction,
   composerInputEnabled,
   deactivatePlanMode,
+  editSelectedThreadGoal,
   effortOptions,
   filteredSlashCommands,
+  goalActionPending,
   goalInputActive,
   handleAttachmentChange,
   handleComposerKeydown,
@@ -39,6 +41,8 @@ const {
   selectedThreadStatus,
   selectedThreadTokenUsage,
   sendButtonLabel,
+  stopSelectedThreadGoal,
+  clearSelectedThreadGoal,
   setSelectedApprovalMode,
   setSelectedEffort,
   setSelectedModel,
@@ -57,6 +61,7 @@ const {
     :goal-input-active="goalInputActive"
     :goal="selectedThreadGoal"
     :goal-observed-at="selectedThreadGoalObservedAt"
+    :goal-action-pending="goalActionPending"
     :slash-menu-open="slashMenuOpen"
     :filtered-slash-commands="filteredSlashCommands"
     :selected-slash-command-index="selectedSlashCommandIndex"
@@ -82,6 +87,9 @@ const {
     :selected-thread-status="selectedThreadStatus"
     :send-button-label="sendButtonLabel"
     @deactivate-plan="deactivatePlanMode"
+    @edit-goal="editSelectedThreadGoal"
+    @stop-goal="stopSelectedThreadGoal"
+    @clear-goal="clearSelectedThreadGoal"
     @hover-slash-command="selectSlashCommandIndex"
     @select-slash-command="runSlashCommand"
     @attachment-change="handleAttachmentChange"

--- a/app/components/chat/composer/ComposerGoalDetailsDialog.vue
+++ b/app/components/chat/composer/ComposerGoalDetailsDialog.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
+import { LoaderCircleIcon, PencilIcon, SquareIcon, Trash2Icon } from "@lucide/vue";
+import { ref } from "vue";
 import type { ThreadGoal } from "~~/shared/types";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
+import type { ComposerGoalPendingAction } from "@/composables/composer/useComposerGoalControls";
+import { Button } from "@codex-gateway/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -16,11 +21,25 @@ defineProps<{
   elapsedLabel: string;
   tokensLabel: string;
   budgetLabel: string;
+  pendingAction: ComposerGoalPendingAction | null;
 }>();
+
+const emit = defineEmits<{
+  edit: [];
+  stop: [];
+  clear: [];
+}>();
+
+const open = ref(false);
+
+function editGoal() {
+  open.value = false;
+  emit("edit");
+}
 </script>
 
 <template>
-  <Dialog>
+  <Dialog v-model:open="open">
     <DialogTrigger as-child>
       <button
         type="button"
@@ -77,6 +96,44 @@ defineProps<{
           </div>
         </dl>
       </div>
+
+      <DialogFooter
+        class="shrink-0 border-t border-hairline px-6 py-4 sm:items-center sm:justify-between"
+      >
+        <Button
+          type="button"
+          variant="destructive"
+          data-testid="goal-details-clear"
+          :disabled="pendingAction !== null"
+          @click="emit('clear')"
+        >
+          <LoaderCircleIcon v-if="pendingAction === 'clear'" class="size-4 animate-spin" />
+          <Trash2Icon v-else class="size-4" />
+          {{ $t("app.slashGoalClearTitle") }}
+        </Button>
+        <div class="flex flex-col-reverse gap-2 sm:flex-row">
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="goal-details-stop"
+            :disabled="pendingAction !== null"
+            @click="emit('stop')"
+          >
+            <LoaderCircleIcon v-if="pendingAction === 'pause'" class="size-4 animate-spin" />
+            <SquareIcon v-else class="size-4" />
+            {{ $t("app.goalStop") }}
+          </Button>
+          <Button
+            type="button"
+            data-testid="goal-details-edit"
+            :disabled="pendingAction !== null"
+            @click="editGoal"
+          >
+            <PencilIcon class="size-4" />
+            {{ $t("app.slashGoalEditTitle") }}
+          </Button>
+        </div>
+      </DialogFooter>
     </DialogContent>
   </Dialog>
 </template>

--- a/app/components/chat/composer/ComposerModeStrip.vue
+++ b/app/components/chat/composer/ComposerModeStrip.vue
@@ -4,6 +4,7 @@ import { XIcon } from "@lucide/vue";
 import { computed, watch } from "vue";
 import type { ThreadGoal } from "~~/shared/types";
 import ComposerGoalDetailsDialog from "@/components/chat/composer/ComposerGoalDetailsDialog.vue";
+import type { ComposerGoalPendingAction } from "@/composables/composer/useComposerGoalControls";
 import { Button } from "@codex-gateway/ui/button";
 import { formatGoalElapsed } from "@/utils/thread-goal-display";
 
@@ -13,10 +14,14 @@ const props = defineProps<{
   goalInputActive: boolean;
   goal: ThreadGoal | null;
   goalObservedAt: number | null;
+  goalActionPending: ComposerGoalPendingAction | null;
 }>();
 
 const emit = defineEmits<{
   deactivatePlan: [];
+  editGoal: [];
+  stopGoal: [];
+  clearGoal: [];
 }>();
 
 const { timestamp: now, pause, resume } = useTimestamp({ controls: true, interval: 250 });
@@ -84,6 +89,10 @@ watch(visibleGoal, (goal) => (goal ? resume() : pause()), { immediate: true });
       :elapsed-label="goalElapsedLabel"
       :tokens-label="goalTokensLabel"
       :budget-label="goalBudgetLabel"
+      :pending-action="goalActionPending"
+      @edit="emit('editGoal')"
+      @stop="emit('stopGoal')"
+      @clear="emit('clearGoal')"
     />
   </div>
 </template>

--- a/app/components/chat/composer/ComposerShell.vue
+++ b/app/components/chat/composer/ComposerShell.vue
@@ -9,6 +9,7 @@ import type {
   ThreadTokenUsageState,
 } from "~~/shared/types";
 import type { ComposerAttachment } from "@/composables/composer/useComposerDraft";
+import type { ComposerGoalPendingAction } from "@/composables/composer/useComposerGoalControls";
 import type { SlashMenuItem } from "@/composables/composer/useSlashCommands";
 import AttachmentChips from "@/components/chat/composer/AttachmentChips.vue";
 import ComposerModeStrip from "@/components/chat/composer/ComposerModeStrip.vue";
@@ -24,6 +25,7 @@ defineProps<{
   goalInputActive: boolean;
   goal: ThreadGoal | null;
   goalObservedAt: number | null;
+  goalActionPending: ComposerGoalPendingAction | null;
   slashMenuOpen: boolean;
   filteredSlashCommands: SlashMenuItem[];
   selectedSlashCommandIndex: number;
@@ -53,6 +55,9 @@ defineProps<{
 const emit = defineEmits<{
   "update:modelValue": [value: string];
   deactivatePlan: [];
+  editGoal: [];
+  stopGoal: [];
+  clearGoal: [];
   hoverSlashCommand: [index: number];
   selectSlashCommand: [command: SlashMenuItem];
   attachmentChange: [event: Event];
@@ -83,7 +88,11 @@ function openAttachmentPicker() {
         :goal-input-active="goalInputActive"
         :goal="goal"
         :goal-observed-at="goalObservedAt"
+        :goal-action-pending="goalActionPending"
         @deactivate-plan="emit('deactivatePlan')"
+        @edit-goal="emit('editGoal')"
+        @stop-goal="emit('stopGoal')"
+        @clear-goal="emit('clearGoal')"
       />
       <div
         class="relative rounded-[1.35rem] border border-hairline bg-surface p-2 shadow-lg shadow-ink/10 md:rounded-3xl md:p-[clamp(0.45rem,1vw,0.7rem)]"

--- a/app/components/common/chat-virtualizer/direct-dom-virtualizer.ts
+++ b/app/components/common/chat-virtualizer/direct-dom-virtualizer.ts
@@ -60,7 +60,23 @@ export function useDirectDomVirtualizer<
   const resolvedOptions = computed(() => ({
     observeElementRect,
     observeElementOffset,
-    scrollToFn: elementScroll,
+    scrollToFn: (
+      offset: number,
+      scrollOptions: { adjustments?: number; behavior?: ScrollBehavior },
+      changedInstance: Virtualizer<TScrollElement, TItemElement>,
+    ) => {
+      // Virtual Core updates its size cache before applying an end-anchor correction. Because this
+      // adapter owns the sizer directly, the browser would otherwise receive the new scrollTop
+      // while the DOM still exposes the old maximum and clamp the write. The final measured row
+      // then leaves exactly its estimate-to-real delta below a supposedly pinned chat.
+      //
+      // Keep this ordering at the adapter boundary, where every Core-driven scroll passes through;
+      // a component ResizeObserver or repeated scrollToEnd would create a second scroll owner and
+      // race native iOS momentum. This mirrors the official React direct-DOM adapter requirement
+      // that the size container commit before Core synchronizes the scroll position.
+      applyContainerSize(changedInstance);
+      elementScroll(offset, scrollOptions, changedInstance);
+    },
     ...unref(options),
   }));
 
@@ -147,7 +163,7 @@ export function useDirectDomVirtualizer<
     return should;
   }
 
-  function applyDirectStyles(
+  function applyContainerSize(
     changedInstance: Virtualizer<TScrollElement, TItemElement> = instance,
   ) {
     const container = directState.container;
@@ -161,6 +177,17 @@ export function useDirectDomVirtualizer<
       const sizeAxis = changedInstance.options.horizontal ? "width" : "height";
       container.style[sizeAxis] = `${totalSize}px`;
     }
+  }
+
+  function applyDirectStyles(
+    changedInstance: Virtualizer<TScrollElement, TItemElement> = instance,
+  ) {
+    const container = directState.container;
+    if (!container) {
+      return;
+    }
+
+    applyContainerSize(changedInstance);
 
     const horizontal = Boolean(changedInstance.options.horizontal);
     const positionAxis = horizontal ? "left" : "top";

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -2,6 +2,7 @@ import { computed } from "vue";
 import { storeToRefs } from "pinia";
 import { useAttachmentUpload } from "./useAttachmentUpload";
 import { useComposerDraft } from "./useComposerDraft";
+import { useComposerGoalControls } from "./useComposerGoalControls";
 import { useComposerSlashActions } from "./useComposerSlashActions";
 import { useComposerTurnSubmit } from "./useComposerTurnSubmit";
 import { useThreadSettingsControls } from "./useThreadSettingsControls";
@@ -32,6 +33,7 @@ export function useComposerController() {
   );
 
   const { turnText, attachedFiles, clearDraft } = useComposerDraft();
+  const goalControls = useComposerGoalControls(turnText);
   const settings = useThreadSettingsControls();
   const attachmentUpload = useAttachmentUpload(selectedHostId, attachedFiles);
   const selectedRuntime = computed(() =>
@@ -100,6 +102,7 @@ export function useComposerController() {
     startNewThread: submit.startNewThread,
     activatePlanMode: submit.activatePlanMode,
     missingGoalObjectiveMessage: computed(() => t("app.goalObjectiveRequired")),
+    goalControls,
   });
   const slashCommandsState = useComposerSlashMenu({
     text: turnText,
@@ -146,6 +149,10 @@ export function useComposerController() {
     activePlanSummary,
     attachedFiles,
     goalInputActive,
+    goalActionPending: goalControls.pendingAction,
+    editSelectedThreadGoal: goalControls.edit,
+    stopSelectedThreadGoal: goalControls.pause,
+    clearSelectedThreadGoal: goalControls.clear,
     selectedThreadGoal,
     selectedThreadGoalObservedAt,
     turnText,

--- a/app/composables/composer/useComposerGoalControls.ts
+++ b/app/composables/composer/useComposerGoalControls.ts
@@ -1,0 +1,37 @@
+import { ref, type Ref } from "vue";
+import { useGatewayComposerStore } from "@/stores/gateway-composer";
+
+export type ComposerGoalPendingAction = "pause" | "resume" | "clear";
+
+export function useComposerGoalControls(text: Ref<string>) {
+  const composer = useGatewayComposerStore();
+  const pendingAction = ref<ComposerGoalPendingAction | null>(null);
+
+  function edit() {
+    text.value = `/goal ${composer.selectedThreadGoal?.objective ?? ""}`.trimEnd();
+  }
+
+  async function pause() {
+    await runMutation("pause", () => composer.setSelectedThreadGoalStatus("paused"));
+  }
+
+  async function resume() {
+    await runMutation("resume", () => composer.setSelectedThreadGoalStatus("active"));
+  }
+
+  async function clear() {
+    await runMutation("clear", () => composer.clearSelectedThreadGoal());
+  }
+
+  async function runMutation(action: ComposerGoalPendingAction, mutation: () => Promise<void>) {
+    if (pendingAction.value !== null) return;
+    pendingAction.value = action;
+    try {
+      await mutation();
+    } finally {
+      pendingAction.value = null;
+    }
+  }
+
+  return { pendingAction, edit, pause, resume, clear };
+}

--- a/app/composables/composer/useComposerSlashActions.ts
+++ b/app/composables/composer/useComposerSlashActions.ts
@@ -1,6 +1,7 @@
 import type { Ref } from "vue";
 import { z } from "zod";
 import type { SlashMenuItem } from "./useSlashCommands";
+import type { useComposerGoalControls } from "./useComposerGoalControls";
 import { useGatewayBootstrapStore } from "@/stores/gateway-bootstrap";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
 
@@ -11,6 +12,7 @@ type GoalMenuCommand = Extract<
 >;
 type SlashCommandAction = (args: string) => Promise<void> | void;
 type GoalControlAction = () => Promise<void>;
+type ComposerGoalControls = ReturnType<typeof useComposerGoalControls>;
 
 export function useComposerSlashActions(input: {
   text: Ref<string>;
@@ -18,6 +20,7 @@ export function useComposerSlashActions(input: {
   startNewThread: () => Promise<void>;
   activatePlanMode: () => void;
   missingGoalObjectiveMessage: Ref<string>;
+  goalControls: ComposerGoalControls;
 }) {
   const gateway = useGatewayBootstrapStore();
   const composer = useGatewayComposerStore();
@@ -32,9 +35,9 @@ export function useComposerSlashActions(input: {
   };
 
   const goalControlActions: Record<string, GoalControlAction> = {
-    clear: () => composer.clearSelectedThreadGoal(),
-    pause: () => composer.setSelectedThreadGoalStatus("paused"),
-    resume: () => composer.setSelectedThreadGoalStatus("active"),
+    clear: input.goalControls.clear,
+    pause: input.goalControls.pause,
+    resume: input.goalControls.resume,
   };
 
   const selectedCommandMenuActions: Record<
@@ -51,11 +54,7 @@ export function useComposerSlashActions(input: {
     "goal-objective": () => {
       input.text.value = "/goal ";
     },
-    "goal-edit": (command) => {
-      input.text.value = `${command.command.replace(/\s+edit$/i, "")} ${
-        composer.selectedThreadGoal?.objective ?? ""
-      }`.trimEnd();
-    },
+    "goal-edit": () => input.goalControls.edit(),
     "goal-pause": () => {
       void runGoalCommand("pause");
     },
@@ -100,7 +99,7 @@ export function useComposerSlashActions(input: {
     input.text.value = "";
     gateway.clearError();
     if (control === "edit") {
-      input.text.value = `/goal ${composer.selectedThreadGoal?.objective ?? ""}`.trimEnd();
+      input.goalControls.edit();
       return;
     }
     const controlAction = goalControlActions[control];

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -230,6 +230,7 @@
     "goalModeActive": "Goal",
     "threadGoal": "Goal",
     "goalInputHint": "Enter an objective and press Enter",
+    "goalStop": "Stop goal",
     "goalDetailsTitle": "Goal details",
     "goalDetailsDescription": "Current goal progress is synchronized from app-server.",
     "goalObjective": "Objective",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -230,6 +230,7 @@
     "goalModeActive": "目标",
     "threadGoal": "Goal",
     "goalInputHint": "输入目标后回车",
+    "goalStop": "停止目标",
     "goalDetailsTitle": "目标详情",
     "goalDetailsDescription": "当前目标的推进状态由 app-server 同步。",
     "goalObjective": "目标内容",

--- a/tests/e2e/thread-goal-plan.spec.ts
+++ b/tests/e2e/thread-goal-plan.spec.ts
@@ -57,9 +57,7 @@ test("goal slash input derives the goal tag and requires an objective before sub
   );
 });
 
-test("goal slash menu exposes official app-server controls for an existing goal", async ({
-  page,
-}) => {
+test("goal controls are shared by the slash menu and details dialog", async ({ page }) => {
   await openApp(page);
   const threadId = "e2e-goal-controls-thread";
   await seedGatewayThread(page, {
@@ -104,19 +102,42 @@ test("goal slash menu exposes official app-server controls for an existing goal"
       { type: "status", status: "active" },
     ]);
 
-  await composer.fill("/goal");
-  await page.getByTestId("slash-command-goal-edit").click();
+  await composer.fill("");
+  await page.getByTestId("composer-goal-summary").click();
+  const goalDialog = page.getByRole("dialog");
+  await expect(goalDialog.getByTestId("goal-details-edit")).toBeVisible();
+  await expect(goalDialog.getByTestId("goal-details-stop")).toBeVisible();
+  await expect(goalDialog.getByTestId("goal-details-clear")).toBeVisible();
+  await goalDialog.getByTestId("goal-details-edit").click();
+  await expect(goalDialog).toHaveCount(0);
   await expect(composer).toHaveValue("/goal 保持目标控制清晰");
 
-  await composer.fill("/goal");
-  await page.getByTestId("slash-command-goal-clear").click();
+  await composer.fill("");
+  await page.getByTestId("composer-goal-summary").click();
+  await page.getByRole("dialog").getByTestId("goal-details-stop").click();
   await expect
     .poll(() => page.evaluate(() => window.__codexGatewayE2e?.captures.goalControls))
     .toEqual([
       { type: "status", status: "paused" },
       { type: "status", status: "active" },
+      { type: "status", status: "paused" },
+    ]);
+  await expect(page.getByTestId("composer-mode-strip")).toHaveCount(0);
+
+  await composer.fill("/goal");
+  await page.getByTestId("slash-command-goal-resume").click();
+  await page.getByTestId("composer-goal-summary").click();
+  await page.getByRole("dialog").getByTestId("goal-details-clear").click();
+  await expect
+    .poll(() => page.evaluate(() => window.__codexGatewayE2e?.captures.goalControls))
+    .toEqual([
+      { type: "status", status: "paused" },
+      { type: "status", status: "active" },
+      { type: "status", status: "paused" },
+      { type: "status", status: "active" },
       { type: "clear" },
     ]);
+  await expect(page.getByTestId("composer-mode-strip")).toHaveCount(0);
 });
 
 test("goal progress updates the composer status strip without flooding the agent loop", async ({


### PR DESCRIPTION
## Summary

- add edit, stop, and clear actions to the Goal details dialog
- share Goal set/paused/clear controls with the existing slash command path
- keep initially pinned virtual chats at the bottom when dynamic measurements settle

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`80 passed`)

## Protocol

- edit uses `thread/goal/set`
- stop sets Goal status to `paused`
- clear uses `thread/goal/clear`
- no backend API or schema changes