### PR TITLE
fix: edit goals inline in details

### DIFF
--- a/app/components/chat/ChatComposer.vue
+++ b/app/components/chat/ChatComposer.vue
@@ -13,7 +13,6 @@ const {
   canUsePrimaryAction,
   composerInputEnabled,
   deactivatePlanMode,
-  editSelectedThreadGoal,
   effortOptions,
   filteredSlashCommands,
   goalActionPending,
@@ -41,6 +40,7 @@ const {
   selectedThreadStatus,
   selectedThreadTokenUsage,
   sendButtonLabel,
+  saveSelectedThreadGoal,
   stopSelectedThreadGoal,
   clearSelectedThreadGoal,
   setSelectedApprovalMode,
@@ -87,7 +87,7 @@ const {
     :selected-thread-status="selectedThreadStatus"
     :send-button-label="sendButtonLabel"
     @deactivate-plan="deactivatePlanMode"
-    @edit-goal="editSelectedThreadGoal"
+    @save-goal="saveSelectedThreadGoal"
     @stop-goal="stopSelectedThreadGoal"
     @clear-goal="clearSelectedThreadGoal"
     @hover-slash-command="selectSlashCommandIndex"

--- a/app/components/chat/composer/ComposerGoalDetailsDialog.vue
+++ b/app/components/chat/composer/ComposerGoalDetailsDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { LoaderCircleIcon, PencilIcon, SquareIcon, Trash2Icon } from "@lucide/vue";
-import { ref } from "vue";
+import { LoaderCircleIcon, PencilIcon, SaveIcon, SquareIcon, Trash2Icon } from "@lucide/vue";
+import { computed, ref, watch } from "vue";
 import type { ThreadGoal } from "~~/shared/types";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import type { ComposerGoalPendingAction } from "@/composables/composer/useComposerGoalControls";
@@ -15,8 +15,9 @@ import {
   DialogTrigger,
 } from "@codex-gateway/ui/dialog";
 import { ScrollArea } from "@codex-gateway/ui/scroll-area";
+import { Textarea } from "@codex-gateway/ui/textarea";
 
-defineProps<{
+const props = defineProps<{
   goal: ThreadGoal;
   elapsedLabel: string;
   tokensLabel: string;
@@ -25,17 +26,51 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  edit: [];
+  save: [objective: string];
   stop: [];
   clear: [];
 }>();
 
 const open = ref(false);
+const editing = ref(false);
+const objectiveDraft = ref("");
+const normalizedObjective = computed(() => objectiveDraft.value.trim());
+const canSave = computed(
+  () =>
+    props.pendingAction === null &&
+    normalizedObjective.value.length > 0 &&
+    normalizedObjective.value !== props.goal.objective.trim(),
+);
 
-function editGoal() {
-  open.value = false;
-  emit("edit");
+function beginEditing() {
+  objectiveDraft.value = props.goal.objective;
+  editing.value = true;
 }
+
+function cancelEditing() {
+  objectiveDraft.value = props.goal.objective;
+  editing.value = false;
+}
+
+function saveGoal() {
+  if (!canSave.value) return;
+  emit("save", normalizedObjective.value);
+}
+
+watch(open, (isOpen) => {
+  if (isOpen) objectiveDraft.value = props.goal.objective;
+  else editing.value = false;
+});
+
+watch(
+  () => props.goal.objective,
+  (objective) => {
+    objectiveDraft.value = objective;
+    // The store updates the Goal while the shared mutation guard still reports `set`. Closing the
+    // editor on that semantic commit keeps a failed request editable and avoids timing assumptions.
+    if (props.pendingAction === "set") editing.value = false;
+  },
+);
 </script>
 
 <template>
@@ -74,7 +109,15 @@ function editGoal() {
           >
             {{ $t("app.goalObjective") }}
           </div>
-          <ScrollArea class="min-h-0 flex-1">
+          <Textarea
+            v-if="editing"
+            v-model="objectiveDraft"
+            data-testid="goal-details-objective-input"
+            :aria-label="$t('app.goalObjective')"
+            class="h-full min-h-0 flex-1 resize-none rounded-none border-0 bg-transparent p-4 text-sm shadow-none focus-visible:ring-0"
+            :disabled="pendingAction !== null"
+          />
+          <ScrollArea v-else class="min-h-0 flex-1">
             <div class="p-4 pr-6">
               <MarkdownContent :content="goal.objective" compact />
             </div>
@@ -112,26 +155,49 @@ function editGoal() {
           {{ $t("app.slashGoalClearTitle") }}
         </Button>
         <div class="flex flex-col-reverse gap-2 sm:flex-row">
-          <Button
-            type="button"
-            variant="outline"
-            data-testid="goal-details-stop"
-            :disabled="pendingAction !== null"
-            @click="emit('stop')"
-          >
-            <LoaderCircleIcon v-if="pendingAction === 'pause'" class="size-4 animate-spin" />
-            <SquareIcon v-else class="size-4" />
-            {{ $t("app.goalStop") }}
-          </Button>
-          <Button
-            type="button"
-            data-testid="goal-details-edit"
-            :disabled="pendingAction !== null"
-            @click="editGoal"
-          >
-            <PencilIcon class="size-4" />
-            {{ $t("app.slashGoalEditTitle") }}
-          </Button>
+          <template v-if="editing">
+            <Button
+              type="button"
+              variant="outline"
+              data-testid="goal-details-edit-cancel"
+              :disabled="pendingAction !== null"
+              @click="cancelEditing"
+            >
+              {{ $t("app.cancel") }}
+            </Button>
+            <Button
+              type="button"
+              data-testid="goal-details-edit-save"
+              :disabled="!canSave"
+              @click="saveGoal"
+            >
+              <LoaderCircleIcon v-if="pendingAction === 'set'" class="size-4 animate-spin" />
+              <SaveIcon v-else class="size-4" />
+              {{ $t("app.save") }}
+            </Button>
+          </template>
+          <template v-else>
+            <Button
+              type="button"
+              variant="outline"
+              data-testid="goal-details-stop"
+              :disabled="pendingAction !== null"
+              @click="emit('stop')"
+            >
+              <LoaderCircleIcon v-if="pendingAction === 'pause'" class="size-4 animate-spin" />
+              <SquareIcon v-else class="size-4" />
+              {{ $t("app.goalStop") }}
+            </Button>
+            <Button
+              type="button"
+              data-testid="goal-details-edit"
+              :disabled="pendingAction !== null"
+              @click="beginEditing"
+            >
+              <PencilIcon class="size-4" />
+              {{ $t("app.slashGoalEditTitle") }}
+            </Button>
+          </template>
         </div>
       </DialogFooter>
     </DialogContent>

--- a/app/components/chat/composer/ComposerModeStrip.vue
+++ b/app/components/chat/composer/ComposerModeStrip.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   deactivatePlan: [];
-  editGoal: [];
+  saveGoal: [objective: string];
   stopGoal: [];
   clearGoal: [];
 }>();
@@ -90,7 +90,7 @@ watch(visibleGoal, (goal) => (goal ? resume() : pause()), { immediate: true });
       :tokens-label="goalTokensLabel"
       :budget-label="goalBudgetLabel"
       :pending-action="goalActionPending"
-      @edit="emit('editGoal')"
+      @save="emit('saveGoal', $event)"
       @stop="emit('stopGoal')"
       @clear="emit('clearGoal')"
     />

--- a/app/components/chat/composer/ComposerShell.vue
+++ b/app/components/chat/composer/ComposerShell.vue
@@ -55,7 +55,7 @@ defineProps<{
 const emit = defineEmits<{
   "update:modelValue": [value: string];
   deactivatePlan: [];
-  editGoal: [];
+  saveGoal: [objective: string];
   stopGoal: [];
   clearGoal: [];
   hoverSlashCommand: [index: number];
@@ -90,7 +90,7 @@ function openAttachmentPicker() {
         :goal-observed-at="goalObservedAt"
         :goal-action-pending="goalActionPending"
         @deactivate-plan="emit('deactivatePlan')"
-        @edit-goal="emit('editGoal')"
+        @save-goal="emit('saveGoal', $event)"
         @stop-goal="emit('stopGoal')"
         @clear-goal="emit('clearGoal')"
       />

--- a/app/components/common/chat-virtualizer/direct-dom-virtualizer.ts
+++ b/app/components/common/chat-virtualizer/direct-dom-virtualizer.ts
@@ -29,11 +29,12 @@ type DirectDomVirtualizerOptions<
   "observeElementRect" | "observeElementOffset" | "scrollToFn"
 >;
 
-type DirectDomState = {
+type DirectDomState<TItemElement extends Element> = {
   container: HTMLElement | null;
   lastPositions: WeakMap<HTMLElement, number>;
   lastSize: number | null;
   mode: DirectDomMode;
+  pendingMeasurements: Set<TItemElement>;
   prevRange: { startIndex: number; endIndex: number; isScrolling: boolean } | null;
 };
 
@@ -49,11 +50,12 @@ export function useDirectDomVirtualizer<
   options: MaybeRef<DirectDomVirtualizerOptions<TScrollElement, TItemElement>>,
   directOptions: { mode?: DirectDomMode } = {},
 ) {
-  const directState: DirectDomState = {
+  const directState: DirectDomState<TItemElement> = {
     container: null,
     lastPositions: new WeakMap<HTMLElement, number>(),
     lastSize: null,
     mode: directOptions.mode ?? "transform",
+    pendingMeasurements: new Set<TItemElement>(),
     prevRange: null,
   };
 
@@ -241,11 +243,28 @@ export function useDirectDomVirtualizer<
       directState.lastSize = totalSize;
       const sizeAxis = instance.options.horizontal ? "width" : "height";
       element.style[sizeAxis] = `${totalSize}px`;
+
+      // Vue attaches descendant refs before the ancestor ref that owns this size container. A row
+      // therefore cannot be measured from its ref callback immediately: Core may calculate an
+      // estimate-to-real end correction while the browser still exposes the old scrollHeight and
+      // clamp that write. The container would grow afterwards, leaving the chat one row delta away
+      // from the latest edge (135px in the mobile WebKit regression).
+      //
+      // Flush the queued rows through Core only after the sizer exists. This is mount ordering, not
+      // a second anchoring policy: TanStack still performs every measurement and scroll correction.
+      for (const pendingElement of directState.pendingMeasurements) {
+        instance.measureElement(pendingElement);
+      }
+      directState.pendingMeasurements.clear();
       scheduleDomCommit();
     }
   }
 
   function measureElement(element: TItemElement) {
+    if (directState.container === null) {
+      directState.pendingMeasurements.add(element);
+      return;
+    }
     instance.measureElement(element);
     applyDirectStyles();
   }

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -150,7 +150,7 @@ export function useComposerController() {
     attachedFiles,
     goalInputActive,
     goalActionPending: goalControls.pendingAction,
-    editSelectedThreadGoal: goalControls.edit,
+    saveSelectedThreadGoal: goalControls.saveObjective,
     stopSelectedThreadGoal: goalControls.pause,
     clearSelectedThreadGoal: goalControls.clear,
     selectedThreadGoal,

--- a/app/composables/composer/useComposerGoalControls.ts
+++ b/app/composables/composer/useComposerGoalControls.ts
@@ -1,14 +1,18 @@
 import { ref, type Ref } from "vue";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
 
-export type ComposerGoalPendingAction = "pause" | "resume" | "clear";
+export type ComposerGoalPendingAction = "set" | "pause" | "resume" | "clear";
 
 export function useComposerGoalControls(text: Ref<string>) {
   const composer = useGatewayComposerStore();
   const pendingAction = ref<ComposerGoalPendingAction | null>(null);
 
-  function edit() {
+  function editInComposer() {
     text.value = `/goal ${composer.selectedThreadGoal?.objective ?? ""}`.trimEnd();
+  }
+
+  async function saveObjective(objective: string) {
+    await runMutation("set", () => composer.setSelectedThreadGoal(objective));
   }
 
   async function pause() {
@@ -33,5 +37,5 @@ export function useComposerGoalControls(text: Ref<string>) {
     }
   }
 
-  return { pendingAction, edit, pause, resume, clear };
+  return { pendingAction, editInComposer, saveObjective, pause, resume, clear };
 }

--- a/app/composables/composer/useComposerSlashActions.ts
+++ b/app/composables/composer/useComposerSlashActions.ts
@@ -54,7 +54,7 @@ export function useComposerSlashActions(input: {
     "goal-objective": () => {
       input.text.value = "/goal ";
     },
-    "goal-edit": () => input.goalControls.edit(),
+    "goal-edit": () => input.goalControls.editInComposer(),
     "goal-pause": () => {
       void runGoalCommand("pause");
     },
@@ -99,7 +99,7 @@ export function useComposerSlashActions(input: {
     input.text.value = "";
     gateway.clearError();
     if (control === "edit") {
-      input.goalControls.edit();
+      input.goalControls.editInComposer();
       return;
     }
     const controlAction = goalControlActions[control];

--- a/tests/e2e/thread-goal-plan.spec.ts
+++ b/tests/e2e/thread-goal-plan.spec.ts
@@ -109,12 +109,18 @@ test("goal controls are shared by the slash menu and details dialog", async ({ p
   await expect(goalDialog.getByTestId("goal-details-stop")).toBeVisible();
   await expect(goalDialog.getByTestId("goal-details-clear")).toBeVisible();
   await goalDialog.getByTestId("goal-details-edit").click();
-  await expect(goalDialog).toHaveCount(0);
-  await expect(composer).toHaveValue("/goal 保持目标控制清晰");
+  const objectiveInput = goalDialog.getByTestId("goal-details-objective-input");
+  await expect(objectiveInput).toHaveValue("保持目标控制清晰");
+  await objectiveInput.fill("在目标详情中直接编辑");
+  await goalDialog.getByTestId("goal-details-edit-save").click();
+  await expect
+    .poll(() => page.evaluate(() => window.__codexGatewayE2e?.captures.goalObjective))
+    .toBe("在目标详情中直接编辑");
+  await expect(objectiveInput).toHaveCount(0);
+  await expect(goalDialog.getByText("在目标详情中直接编辑")).toBeVisible();
+  await expect(composer).toHaveValue("");
 
-  await composer.fill("");
-  await page.getByTestId("composer-goal-summary").click();
-  await page.getByRole("dialog").getByTestId("goal-details-stop").click();
+  await goalDialog.getByTestId("goal-details-stop").click();
   await expect
     .poll(() => page.evaluate(() => window.__codexGatewayE2e?.captures.goalControls))
     .toEqual([


### PR DESCRIPTION
## Summary

- edit and save the active Goal directly inside the Goal details dialog
- preserve slash-command Goal editing in the main composer
- defer initial virtual row measurements until the Vue sizer ref is bound, preventing clipped end anchoring on mobile WebKit

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (80 passed)