### PR TITLE
fix: simplify command execution status

### DIFF
--- a/app/components/thread/items/CommandExecutionItem.vue
+++ b/app/components/thread/items/CommandExecutionItem.vue
@@ -4,6 +4,7 @@ import {
   CheckCircle2Icon,
   ChevronDownIcon,
   ChevronRightIcon,
+  LoaderCircleIcon,
   TerminalIcon,
   XCircleIcon,
 } from "@lucide/vue";
@@ -45,6 +46,18 @@ const isInProgress = computed(() => {
   const value = commandStatus.value;
   return value === "inProgress" || value === "running" || value === "active";
 });
+const visualStatus = computed<"running" | "completed" | "failed" | null>(() => {
+  if (isInProgress.value) return "running";
+  if (
+    commandStatus.value === "failed" ||
+    commandStatus.value === "interrupted" ||
+    (typeof props.item.exitCode === "number" && props.item.exitCode !== 0)
+  ) {
+    return "failed";
+  }
+  if (commandStatus.value === "completed" || props.item.exitCode === 0) return "completed";
+  return null;
+});
 
 async function respond(decision: "accept" | "decline") {
   await respondToRequest({ decision });
@@ -58,11 +71,34 @@ async function respond(decision: "accept" | "decline") {
     >
       <TerminalIcon class="size-4 shrink-0" />
       <span class="min-w-0 flex-1 truncate">{{ title }}</span>
-      <Badge v-if="commandStatus" variant="secondary">{{ commandStatus }}</Badge>
       <Badge v-if="pendingApproval" variant="outline">{{ t("app.waitingApproval") }}</Badge>
-      <Badge v-if="isInProgress" variant="outline">{{ t("app.running") }}</Badge>
-      <CheckCircle2Icon v-if="item.exitCode === 0" class="size-4 shrink-0 text-accent-green" />
-      <XCircleIcon v-else-if="item.exitCode" class="size-4 shrink-0 text-destructive" />
+      <!-- The icon is the complete command lifecycle indicator. Do not add a status badge beside
+           it: app-server's raw status repeats the same information and needlessly truncates long
+           commands. Keep the translated label available to assistive technology and hover. -->
+      <LoaderCircleIcon
+        v-if="visualStatus === 'running'"
+        data-testid="command-status-running"
+        class="size-4 shrink-0 animate-spin text-accent"
+        role="img"
+        :aria-label="t('app.running')"
+        :title="t('app.running')"
+      />
+      <CheckCircle2Icon
+        v-else-if="visualStatus === 'completed'"
+        data-testid="command-status-completed"
+        class="size-4 shrink-0 text-accent-green"
+        role="img"
+        :aria-label="t('app.completed')"
+        :title="t('app.completed')"
+      />
+      <XCircleIcon
+        v-else-if="visualStatus === 'failed'"
+        data-testid="command-status-failed"
+        class="size-4 shrink-0 text-destructive"
+        role="img"
+        :aria-label="t('app.failed')"
+        :title="t('app.failed')"
+      />
       <span class="rounded-full p-0.5">
         <ChevronDownIcon v-if="open" class="size-4 shrink-0 text-ink-faint" />
         <ChevronRightIcon v-else class="size-4 shrink-0 text-ink-faint" />

--- a/app/stores/gateway/event-handlers/notification-formatters/terminal.ts
+++ b/app/stores/gateway/event-handlers/notification-formatters/terminal.ts
@@ -12,6 +12,7 @@ import {
   type TranslationFunction,
 } from "./common";
 import { firstNonEmptyString } from "~~/shared/utils/strings";
+import { commandDisplayLabel } from "@/utils/thread-item-display";
 
 export function terminalInteractionNotification(
   t: TranslationFunction,
@@ -56,7 +57,9 @@ function commandForTerminalInteraction(
     if (command !== "") break;
   }
   return truncate(
-    command === "" ? t("app.notifications.terminalProcessFallback", { processId }) : command,
+    command === ""
+      ? t("app.notifications.terminalProcessFallback", { processId })
+      : commandDisplayLabel(command),
     140,
   );
 }

--- a/tests/e2e/thread-diff-rendering.spec.ts
+++ b/tests/e2e/thread-diff-rendering.spec.ts
@@ -111,9 +111,17 @@ test("command labels unwrap official shell invocations and short output uses nat
               {
                 id: "command-plain-1",
                 type: "commandExecution",
-                status: "completed",
-                command: "git status --short",
+                status: "inProgress",
+                command: "sleep 10",
                 aggregatedOutput: "",
+              },
+              {
+                id: "command-failed-1",
+                type: "commandExecution",
+                status: "failed",
+                command: "false",
+                aggregatedOutput: "",
+                exitCode: 1,
               },
             ],
           },
@@ -124,8 +132,15 @@ test("command labels unwrap official shell invocations and short output uses nat
 
   await openIntermediateSteps(page);
   await expect(page.getByRole("button", { name: /pwd && printf "done"/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /git status --short/ })).toBeVisible();
-  await page.getByRole("button", { name: /pwd && printf "done"/ }).click();
+  const completedCommand = page.getByRole("button", { name: /pwd && printf "done"/ });
+  const runningCommand = page.getByRole("button", { name: /sleep 10/ });
+  const failedCommand = page.getByRole("button", { name: /false/ });
+  await expect(runningCommand).toBeVisible();
+  await expect(failedCommand).toBeVisible();
+  await expect(completedCommand.getByTestId("command-status-completed")).toBeVisible();
+  await expect(runningCommand.getByTestId("command-status-running")).toBeVisible();
+  await expect(failedCommand.getByTestId("command-status-failed")).toBeVisible();
+  await completedCommand.click();
   const commandOutput = page.getByTestId("chat-scroll-area").getByText("/tmp/e2e");
   await expect(commandOutput).toBeVisible();
   await expect

--- a/tests/e2e/thread-request-notifications.spec.ts
+++ b/tests/e2e/thread-request-notifications.spec.ts
@@ -208,7 +208,7 @@ test("terminal wait notifications mention the command being watched", async ({ p
         item: {
           id: "cmd-watch",
           type: "commandExecution",
-          command: "pnpm dev",
+          command: "/bin/bash -lc 'pnpm dev'",
           cwd: "/workspace/codex-gateway",
           processId: "proc-123",
           status: "inProgress",
@@ -239,7 +239,9 @@ test("terminal wait notifications mention the command being watched", async ({ p
   });
 
   const chatScrollArea = page.getByTestId("chat-scroll-area");
-  await expect(chatScrollArea.getByText("agent 正在等待命令：pnpm dev")).toBeVisible();
+  await expect(
+    chatScrollArea.getByText("agent 正在等待命令：pnpm dev", { exact: true }),
+  ).toBeVisible();
 
   await installRealtimeInterruptMock(page);
 


### PR DESCRIPTION
## Summary
- reuse shell invocation formatting for terminal-wait notifications
- replace duplicate command status badges with one running/success/failure icon
- preserve translated accessibility labels and approval state

## Verification
- `pnpm lint`
- `pnpm test:e2e -- tests/e2e/thread-request-notifications.spec.ts tests/e2e/thread-diff-rendering.spec.ts --grep "terminal wait notifications|command labels unwrap"` (2 passed)
- `git diff --check`