### PR TITLE
fix: improve running command visibility

### DIFF
--- a/app/components/thread/items/CommandExecutionItem.vue
+++ b/app/components/thread/items/CommandExecutionItem.vue
@@ -4,11 +4,11 @@ import {
   CheckCircle2Icon,
   ChevronDownIcon,
   ChevronRightIcon,
-  LoaderCircleIcon,
   TerminalIcon,
   XCircleIcon,
 } from "@lucide/vue";
 import { computed } from "vue";
+import { Loader } from "@codex-gateway/ai-elements/loader";
 import { Badge } from "@codex-gateway/ui/badge";
 import { Button } from "@codex-gateway/ui/button";
 import { Collapsible, CollapsibleTrigger } from "@codex-gateway/ui/collapsible";
@@ -72,14 +72,14 @@ async function respond(decision: "accept" | "decline") {
       <TerminalIcon class="size-4 shrink-0" />
       <span class="min-w-0 flex-1 truncate">{{ title }}</span>
       <Badge v-if="pendingApproval" variant="outline">{{ t("app.waitingApproval") }}</Badge>
-      <!-- The icon is the complete command lifecycle indicator. Do not add a status badge beside
-           it: app-server's raw status repeats the same information and needlessly truncates long
-           commands. Keep the translated label available to assistive technology and hover. -->
-      <LoaderCircleIcon
+      <!-- The icon is the complete command lifecycle indicator. AI Elements owns the spinner
+           geometry and animation; use the primary foreground token because accent is a surface
+           token in this theme and is too faint for an active command. Do not add a status badge
+           beside it: app-server's raw status repeats the same information and truncates commands. -->
+      <Loader
         v-if="visualStatus === 'running'"
         data-testid="command-status-running"
-        class="size-4 shrink-0 animate-spin text-accent"
-        role="img"
+        class="size-4 shrink-0 text-primary"
         :aria-label="t('app.running')"
         :title="t('app.running')"
       />

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
+    "@codex-gateway/ai-elements": "workspace:*",
     "@codex-gateway/browser-runtime": "workspace:*",
     "@codex-gateway/ui": "workspace:*",
     "@fastify/busboy": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.6
         version: 6.43.6
+      '@codex-gateway/ai-elements':
+        specifier: workspace:*
+        version: link:packages/gateway-ai-elements
       '@codex-gateway/browser-runtime':
         specifier: workspace:*
         version: link:packages/gateway-browser-runtime


### PR DESCRIPTION
## Summary
- replace the low-contrast command spinner with the precompiled AI Elements Loader
- use the primary theme foreground for a visible running state
- declare the AI Elements workspace dependency explicitly

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e -- tests/e2e/thread-diff-rendering.spec.ts --grep "command labels unwrap"`