### PR TITLE
fix: paginate thread activation and refine model selection

### DIFF
--- a/app/components/chat/composer/ModelEffortPicker.vue
+++ b/app/components/chat/composer/ModelEffortPicker.vue
@@ -37,12 +37,16 @@ const selectorOpen = ref(false);
 
 function selectModel(model: string) {
   emit("selectModel", model);
-  selectorOpen.value = false;
 }
 
 function selectEffort(effort: ReasoningEffort) {
   emit("selectEffort", effort);
-  selectorOpen.value = false;
+}
+
+function preventInitialFocus(event: Event) {
+  // Reka Dialog otherwise focuses the first tabbable element while CommandInput also requests
+  // autofocus. Preventing both paths keeps mobile keyboards closed until the user taps search.
+  event.preventDefault();
 }
 </script>
 
@@ -77,8 +81,11 @@ function selectEffort(effort: ReasoningEffort) {
     <ModelSelectorContent
       :title="t('app.model')"
       class="w-[min(92vw,32rem)] overflow-hidden rounded-2xl border-hairline shadow-xl shadow-ink/10"
+      close-button-test-id="model-selector-close"
+      data-testid="model-selector-dialog"
+      @open-auto-focus="preventInitialFocus"
     >
-      <ModelSelectorInput :placeholder="t('app.searchModels')" />
+      <ModelSelectorInput :auto-focus="false" :placeholder="t('app.searchModels')" />
       <ModelSelectorList class="max-h-[min(60dvh,28rem)] p-1">
         <ModelSelectorEmpty>{{ t("app.noMatchingModels") }}</ModelSelectorEmpty>
         <ModelSelectorGroup :heading="t('app.reasoningEffort')">

--- a/app/stores/gateway/thread-open/transport.ts
+++ b/app/stores/gateway/thread-open/transport.ts
@@ -35,7 +35,11 @@ export function requestActivateThreadSnapshot(input: {
       limit: input.limit ?? INITIAL_TURN_PAGE_LIMIT,
     }),
     expectThreadSnapshot,
-    30_000,
+    // Legacy app-server rollouts can take longer than 30 seconds to replay even when the first
+    // page contains only two Turns. Use the realtime broker's shared long-operation deadline,
+    // which intentionally exceeds the backend RPC timeout. A shorter transport-specific timer
+    // abandons the browser request while the server keeps loading and later attaches an orphaned
+    // subscription, causing repeated opens to amplify the original slowdown.
   );
 }
 

--- a/packages/gateway-ui/src/command/CommandInput.vue
+++ b/packages/gateway-ui/src/command/CommandInput.vue
@@ -13,11 +13,16 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = defineProps<
-  ListboxFilterProps & {
-    class?: HTMLAttributes["class"];
-  }
->();
+const props = withDefaults(
+  defineProps<
+    ListboxFilterProps & {
+      class?: HTMLAttributes["class"];
+    }
+  >(),
+  {
+    autoFocus: true,
+  },
+);
 
 const delegatedProps = reactiveOmit(props, "class");
 
@@ -33,7 +38,7 @@ const { filterState } = useCommand();
         v-bind="{ ...forwardedProps, ...$attrs }"
         v-model="filterState.search"
         data-slot="command-input"
-        auto-focus
+        :auto-focus="props.autoFocus"
         :class="
           cn(
             'w-full text-xs/relaxed outline-hidden disabled:cursor-not-allowed disabled:opacity-50',

--- a/server/utils/gateway/realtime/handlers/thread-events.ts
+++ b/server/utils/gateway/realtime/handlers/thread-events.ts
@@ -49,45 +49,52 @@ export async function activateThread(
   // snapshot with a newer cursor and permanently skip those events.
   const lastEventId = gatewayEventStore.latestId(input.hostId, input.threadId);
   const eventEpoch = gatewayEventStore.epoch(input.hostId);
-  const result = await threadBroker.openThread(
-    host,
-    input.threadId,
-    input.projectId ?? null,
-    input.limit,
-  );
-  sendRealtimePeerMessage(peer, {
-    type: "thread.snapshot",
-    requestId: message.requestId,
-    hostId: input.hostId,
-    threadId: input.threadId,
-    lastEventId,
-    eventEpoch,
-    ...result,
-  });
-  subscribeThreadEvents(
-    peer,
-    host,
-    input.threadId,
-    lastEventId,
-    eventEpoch,
-    result.runtimeStatus === "running",
-  );
-  if (result.threadSettings === null || result.threadSettings === undefined) {
-    // Send the paginated snapshot first so settings discovery never blocks conversation display.
-    // App-server exposes persisted model/effort only through `thread/resume`; resolve it once when
-    // this server-side snapshot is unknown, then let the ordinary event path update Pinia. The
-    // resolved value is cached in the snapshot, so subsequent same-process opens do not resume an
-    // idle thread again.
-    void runPeerScoped(peer, () =>
-      threadBroker.resolveThreadSettings(host, input.threadId).catch((error: unknown) => {
-        threadRuntimeEvents.record(input.hostId, input.threadId, "gateway/error", {
-          method: "gateway/error",
-          params: {
-            message: error instanceof Error ? error.message : "Failed to resolve thread settings",
-          },
-        });
-      }),
+  const activationLease = threadBroker.retainThreadActivation(host, input.threadId);
+  let leaseTransferred = false;
+  try {
+    const activationController = await activationLease.ready;
+    const result = await threadBroker.openThread(
+      host,
+      input.threadId,
+      input.projectId ?? null,
+      input.limit,
+      activationController,
     );
+    sendRealtimePeerMessage(peer, {
+      type: "thread.snapshot",
+      requestId: message.requestId,
+      hostId: input.hostId,
+      threadId: input.threadId,
+      lastEventId,
+      eventEpoch,
+      ...result,
+    });
+    subscribeThreadEvents(
+      peer,
+      host,
+      input.threadId,
+      lastEventId,
+      eventEpoch,
+      result.runtimeStatus === "running",
+      { lease: activationLease, controller: activationController },
+    );
+    leaseTransferred = true;
+    if (result.threadSettings === null || result.threadSettings === undefined) {
+      // A cache hit can predate settings hydration. Resolve only that metadata after the snapshot;
+      // cold opens already obtain it from the combined thread/resume response above.
+      void runPeerScoped(peer, () =>
+        threadBroker.resolveThreadSettings(host, input.threadId).catch((error: unknown) => {
+          threadRuntimeEvents.record(input.hostId, input.threadId, "gateway/error", {
+            method: "gateway/error",
+            params: {
+              message: error instanceof Error ? error.message : "Failed to resolve thread settings",
+            },
+          });
+        }),
+      );
+    }
+  } finally {
+    if (!leaseTransferred) activationLease.release();
   }
 }
 
@@ -146,6 +153,10 @@ function subscribeThreadEvents(
   afterId: number,
   afterEpoch?: string,
   initiallyRunning = threadBroker.isThreadRunning(host.id, threadId),
+  activation?: {
+    lease: ThreadSubscriptionLease;
+    controller: Awaited<ThreadSubscriptionLease["ready"]>;
+  },
 ) {
   const hostId = host.id;
   const eventEpoch = gatewayEventStore.epoch(hostId);
@@ -203,9 +214,28 @@ function subscribeThreadEvents(
   let replaying = true;
   const liveQueue: GatewayEvent[] = [];
   let upstreamLease: ThreadSubscriptionLease | null = null;
+  let pendingActivation = activation;
 
   const ensureUpstreamSubscription = () => {
     if (upstreamLease !== null) return;
+    if (pendingActivation !== undefined) {
+      const retained = pendingActivation;
+      pendingActivation = undefined;
+      upstreamLease = retained.lease;
+      void runPeerScoped(peer, () =>
+        retained.controller.ensureSubscribed().catch((error: unknown) => {
+          threadRuntimeEvents.record(hostId, threadId, "gateway/error", {
+            method: "gateway/error",
+            params: {
+              message:
+                error instanceof Error ? error.message : "Failed to subscribe thread upstream",
+            },
+          });
+          if (upstreamLease === retained.lease) releaseUpstreamSubscription();
+        }),
+      );
+      return;
+    }
     const lease = threadBroker.retainUpstreamSubscription(host, threadId, "browser");
     upstreamLease = lease;
     void runPeerScoped(peer, () =>
@@ -227,6 +257,13 @@ function subscribeThreadEvents(
   };
 
   if (initiallyRunning) ensureUpstreamSubscription();
+  else {
+    // A cold resume subscribes as part of returning initialTurnsPage. Idle threads do not need a
+    // retained upstream subscription, so release the activation lease after the snapshot and let
+    // the global thread/started broadcast reacquire one when work begins.
+    pendingActivation?.lease.release();
+    pendingActivation = undefined;
+  }
 
   const unsubscribe = threadRuntimeEvents.subscribe(
     hostId,
@@ -242,6 +279,8 @@ function subscribeThreadEvents(
   );
   releaseSubscription = () => {
     unsubscribe();
+    pendingActivation?.lease.release();
+    pendingActivation = undefined;
     releaseUpstreamSubscription();
     if (state.threadUnsubscribers.get(key) === releaseSubscription) {
       state.threadUnsubscribers.delete(key);

--- a/server/utils/gateway/runtime/broker.ts
+++ b/server/utils/gateway/runtime/broker.ts
@@ -1,7 +1,7 @@
 import type { HostRecord, ThreadGoalStatus, ThreadSettingsState } from "~~/shared/types";
 import { INITIAL_TURN_PAGE_LIMIT } from "~~/shared/config";
 import type { ServerRequestResponseInput, TurnStartInput, TurnSteerInput } from "./types";
-import { ControllerRegistry } from "./controller-registry";
+import { ControllerRegistry, type ThreadSubscriptionLease } from "./controller-registry";
 import { ThreadOpenService } from "./thread-open-service";
 import { ThreadTurnCommandService } from "./turn-commands";
 import { ThreadGoalService } from "./thread-goals";
@@ -23,13 +23,17 @@ class ThreadBroker {
     threadId: string,
     projectId: number | null,
     limit = INITIAL_TURN_PAGE_LIMIT,
+    controller?: Awaited<ThreadSubscriptionLease["ready"]>,
   ) {
-    return this.openService.openThread(host, threadId, projectId, limit);
+    return this.openService.openThread(host, threadId, projectId, limit, controller);
   }
 
   async startThread(host: HostRecord, params: Record<string, unknown>, projectId: number | null) {
     const client = await this.registry.getHostClient(host);
-    const result = await client.request("thread/start", params);
+    // Paginated history is the current App Server storage model that can hydrate indexed Turn
+    // pages without replaying an entire rollout JSONL. Keep this policy at the protocol boundary so
+    // every Gateway-created thread uses it and browser DTOs do not need to expose storage details.
+    const result = await client.request("thread/start", { ...params, historyMode: "paginated" });
     const started = this.openService.startedThreadResult(host, projectId, result);
     await this.registry.retainStartedThreadSubscription(host, started.threadId);
     return started.result;
@@ -121,6 +125,10 @@ class ThreadBroker {
 
   retainUpstreamSubscription(host: HostRecord, threadId: string, owner: "browser" | "scoped") {
     return this.registry.retainSubscription(host, threadId, owner);
+  }
+
+  retainThreadActivation(host: HostRecord, threadId: string) {
+    return this.registry.retainActivationController(host, threadId);
   }
 
   isThreadRunning(hostId: number, threadId: string) {

--- a/server/utils/gateway/runtime/controller-registry.ts
+++ b/server/utils/gateway/runtime/controller-registry.ts
@@ -15,6 +15,7 @@ export interface ThreadSubscriptionLease {
 
 interface RetainSubscriptionOptions {
   upstreamAlreadySubscribed?: boolean;
+  deferUpstreamSubscription?: boolean;
 }
 
 interface SubscriptionLeases {
@@ -74,7 +75,7 @@ export class ControllerRegistry {
         // `thread/start` subscribes the same shared Host RPC connection before a controller exists.
         // Adopt that protocol-owned subscription instead of issuing a redundant thread/resume.
         controller.adoptExistingSubscription();
-      } else {
+      } else if (options.deferUpstreamSubscription !== true) {
         await controller.ensureSubscribed();
       }
       return controller;
@@ -111,6 +112,15 @@ export class ControllerRegistry {
         });
       },
     };
+  }
+
+  retainActivationController(host: HostRecord, threadId: string) {
+    // Activation may satisfy a cold open with thread/resume.initialTurnsPage. Reserve the browser
+    // lease before issuing that RPC, but let ThreadOpenService decide whether a remote read is
+    // needed at all. Cache hits therefore do not resume idle threads merely to render history.
+    return this.retainSubscription(host, threadId, "browser", {
+      deferUpstreamSubscription: true,
+    });
   }
 
   async retainStartedThreadSubscription(host: HostRecord, threadId: string) {

--- a/server/utils/gateway/runtime/thread-controller.ts
+++ b/server/utils/gateway/runtime/thread-controller.ts
@@ -102,9 +102,7 @@ export class ThreadController {
     await this.enqueue(async () => {
       // Check and mutation must share the serialized critical section. Two browser peers can
       // acquire the same explicit lease in one tick; checking before enqueue would make both send
-      // thread/resume even though the RPC operations themselves execute sequentially. Conversation
-      // history still uses thread/read plus thread/turns/list; this resume is only the official
-      // subscription and settings hydration operation.
+      // thread/resume even though the RPC operations themselves execute sequentially.
       // A subscription inherited from the background monitor proves only that notifications are
       // attached; it has no ThreadResumeResponse. Existing threads must still resume once when
       // their materialized snapshot does not yet contain model/effort. This is the app-server's
@@ -113,22 +111,23 @@ export class ThreadController {
       // Fresh threads never enter this branch: ControllerRegistry keeps thread/start's implicit
       // subscription under a bootstrap owner until turn/started. Calling thread/resume before that
       // point is invalid because app-server has not materialized a rollout yet.
-      const resumed = await this.client.request(
-        "thread/resume",
-        // Conversation history is hydrated separately through the paginated API. Asking resume to
-        // return it again wastes SSH bandwidth and memory, especially for long-running threads.
-        { threadId: this.threadId, excludeTurns: true },
-        120_000,
-        parseThreadResumeResult,
-      );
-      this.subscribed = true;
-      // `thread/read` and paginated Turn history intentionally omit the persisted model and
-      // reasoning effort. App-server returns those authoritative values from `thread/resume`, but
-      // does not emit `thread/settings/updated` for the resume itself. Project the response through
-      // the same Gateway event path so the server snapshot and every browser use one settings
-      // source instead of guessing from the model catalog.
-      this.publishResumedSettings(resumed);
+      await this.requestResume({ threadId: this.threadId, excludeTurns: true });
     });
+  }
+
+  async resumeWithInitialTurnsPage(limit: number) {
+    await this.ensureConnected();
+    return this.enqueue(() =>
+      this.requestResume({
+        threadId: this.threadId,
+        excludeTurns: true,
+        initialTurnsPage: {
+          limit,
+          sortDirection: "desc",
+          itemsView: "full",
+        },
+      }),
+    );
   }
 
   isSubscribed() {
@@ -231,5 +230,20 @@ export class ThreadController {
         threadSettings: extractThreadSettings(resumed),
       },
     });
+  }
+
+  private async requestResume(params: Record<string, unknown>) {
+    const resumed = await this.client.request(
+      "thread/resume",
+      params,
+      120_000,
+      parseThreadResumeResult,
+    );
+    this.subscribed = true;
+    // App-server exposes persisted model/effort in thread/resume but emits no settings event for
+    // the response itself. Publish it through the ordinary event path so snapshots and all browser
+    // peers converge on one authoritative value instead of maintaining a second settings cache.
+    this.publishResumedSettings(resumed);
+    return resumed;
   }
 }

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -16,6 +16,7 @@ import { projectStore } from "../state/projects";
 import { threadMetadataStore } from "../state/thread-metadata";
 import { threadSnapshotStore } from "../state/thread-snapshots";
 import { ControllerRegistry } from "./controller-registry";
+import type { ThreadController } from "./thread-controller";
 import { pageCursorState, pageToFullHistory } from "./thread-history-pages";
 import { runtimeLog } from "./runtime-log";
 import { threadRuntimeEvents } from "./thread-runtime-events";
@@ -41,24 +42,18 @@ export class ThreadOpenService {
     threadId: string,
     projectId: number | null,
     limit = INITIAL_TURN_PAGE_LIMIT,
+    activationController?: ThreadController,
   ) {
     const cachedSnapshot = threadSnapshotStore.get(host.id, threadId);
     if (cachedSnapshot) {
-      const recentEvents = gatewayEventStore.list(host.id, threadId, 0, 200);
-      const cachedStatus = runtimeStatusFromThreadState(
-        cachedSnapshot.thread,
-        cachedSnapshot.history,
-        recentEvents,
-      );
-      if (cachedStatus === "running") {
-        runtimeLog("thread running cache refresh", {
-          hostId: host.id,
-          threadId,
-          projectId,
-        });
-        return this.refreshThreadState(host, threadId, projectId, limit);
-      }
       if (snapshotSatisfiesTurnLimit(cachedSnapshot, limit)) {
+        // Runtime notifications are projected into this snapshot as they arrive, including the
+        // active Turn's cumulative output and status. Re-reading a running thread here would make
+        // every browser activation call thread/turns/list again. For legacy rollouts app-server
+        // must replay the complete JSONL even when the requested page contains only two Turns, so
+        // that policy made long conversations slow while their realtime controller was healthy.
+        // Only an absent or too-shallow cache requires remote history I/O; reconnect gaps already
+        // use the authoritative refresh path explicitly.
         return this.snapshotResult(host, threadId, projectId, cachedSnapshot);
       }
       runtimeLog("thread cache depth refresh", {
@@ -67,7 +62,7 @@ export class ThreadOpenService {
         cachedTurns: threadTurnsFromHistory(cachedSnapshot.history).length,
         requestedTurns: limit,
       });
-      return this.refreshThreadState(host, threadId, projectId, limit);
+      return this.refreshThreadState(host, threadId, projectId, limit, activationController);
     }
 
     runtimeLog("thread cache miss", {
@@ -75,7 +70,7 @@ export class ThreadOpenService {
       threadId,
       limit,
     });
-    return this.refreshThreadState(host, threadId, projectId, limit);
+    return this.refreshThreadState(host, threadId, projectId, limit, activationController);
   }
 
   startedThreadResult(host: HostRecord, projectId: number | null, rawResult: unknown) {
@@ -133,6 +128,7 @@ export class ThreadOpenService {
     threadId: string,
     projectId: number | null,
     limit = INITIAL_TURN_PAGE_LIMIT,
+    activationController?: ThreadController,
   ): Promise<ReturnTypeResult> {
     const key = refreshKey(host.id, threadId);
     const pending = this.pendingRefreshes.get(key);
@@ -143,10 +139,16 @@ export class ThreadOpenService {
       // same store entry.
       if (pending.limit >= limit) return pending.promise;
       await pending.promise;
-      return this.refreshThreadState(host, threadId, projectId, limit);
+      return this.refreshThreadState(host, threadId, projectId, limit, activationController);
     }
 
-    const promise = this.performThreadStateRefresh(host, threadId, projectId, limit);
+    const promise = this.performThreadStateRefresh(
+      host,
+      threadId,
+      projectId,
+      limit,
+      activationController,
+    );
     this.pendingRefreshes.set(key, { limit, promise });
     try {
       return await promise;
@@ -188,12 +190,14 @@ export class ThreadOpenService {
     threadId: string,
     projectId: number | null,
     limit: number,
+    activationController?: ThreadController,
   ) {
     const { snapshot, resolvedProjectId } = await this.loadRemoteOpenSnapshot(
       host,
       threadId,
       projectId,
       limit,
+      activationController,
     );
     const status = runtimeStatusFromSnapshotState(snapshot.thread, snapshot.history) ?? "completed";
     // The refresh event is the backend's canonical correction after reconnect
@@ -250,7 +254,27 @@ export class ThreadOpenService {
     threadId: string,
     projectId: number | null,
     limit: number,
+    activationController?: ThreadController,
   ) {
+    if (activationController !== undefined) {
+      const resumed = await activationController.resumeWithInitialTurnsPage(limit);
+      const initialTurnsPage = resumed.initialTurnsPage;
+      if (initialTurnsPage === null || initialTurnsPage === undefined) {
+        throw new Error("thread/resume omitted the requested initialTurnsPage");
+      }
+      return this.storeRemoteOpenSnapshot(
+        host,
+        projectId,
+        resumed.thread,
+        initialTurnsPage,
+        extractThreadSettings(resumed),
+        activationController,
+      );
+    }
+
+    // Non-browser refreshes, such as reconciliation after a failed turn command, already run under
+    // a controller operation and must not acquire another subscription lease. They retain the
+    // metadata + page pair; normal browser cold opens use the combined resume path above.
     const client = await this.registry.getHostClient(host);
     const [read, initialTurnsPage] = await Promise.all([
       client.request(
@@ -272,7 +296,24 @@ export class ThreadOpenService {
         parseTurnsPage,
       ),
     ]);
-    const thread = read.thread;
+    return this.storeRemoteOpenSnapshot(
+      host,
+      projectId,
+      read.thread,
+      initialTurnsPage,
+      latestThreadSettingsFromEvents(gatewayEventStore.list(host.id, threadId, 0, 200)),
+    );
+  }
+
+  private storeRemoteOpenSnapshot(
+    host: HostRecord,
+    projectId: number | null,
+    thread: AppServerThread,
+    initialTurnsPage: ReturnType<typeof parseTurnsPage>,
+    threadSettings: ReturnType<typeof extractThreadSettings> | null,
+    activationController?: ThreadController,
+  ) {
+    const threadId = thread.id;
     const resolvedProjectId = resolveProjectId(host.id, projectId, thread.cwd);
     threadMetadataStore.record(host.id, resolvedProjectId, thread);
 
@@ -282,14 +323,15 @@ export class ThreadOpenService {
       history: projectThreadTimelineHistory(pageToFullHistory(thread, initialTurnsPage)),
       projectId: resolvedProjectId,
       turnsPage: pageCursorState(initialTurnsPage),
-      // thread/read intentionally returns only Thread metadata, not the persisted model/effort
-      // exposed by thread/resume. Preserve a setting observed from Gateway events when available;
-      // otherwise report unknown instead of projecting null fields that erase the browser's
-      // page-level per-thread setting cache.
-      threadSettings: latestThreadSettingsFromEvents(recentEvents),
+      threadSettings,
       tokenUsage: latestTokenUsageFromEvents(recentEvents),
     };
-    threadSnapshotStore.set(host.id, threadId, snapshot);
+    // During browser activation the controller is created before the cold snapshot exists. Route
+    // the write through it so sub-agent classification and active-main-thread handoff state are
+    // initialized together with the cache. Non-browser reconciliation has no activation controller
+    // and writes the same canonical snapshot directly.
+    if (activationController === undefined) threadSnapshotStore.set(host.id, threadId, snapshot);
+    else activationController.setOpenSnapshot(snapshot);
     return { snapshot, resolvedProjectId };
   }
 }

--- a/shared/gateway-errors.ts
+++ b/shared/gateway-errors.ts
@@ -1,17 +1,26 @@
 import { recordFromUnknown } from "./utils/records";
 
 export const STALE_THREAD_CURSOR_ERROR_CODE = "staleThreadCursor";
-export const STALE_THREAD_CURSOR_ERROR_MESSAGE = "invalid cursor: anchor turn is no longer present";
+const STALE_THREAD_CURSOR_ERROR_PREFIX = "invalid cursor:";
 
 export function isStaleThreadCursorErrorLike(error: unknown) {
   const candidate = recordFromUnknown(error);
   // Error.message is intentionally non-enumerable, so Zod's object parser cannot carry it into
   // the plain record. Keep Zod for the transport-specific enumerable fields and use the standard
   // Error contract for the built-in message instead of weakening the RPC discriminator.
-  const message = error instanceof Error ? error.message : candidate?.message;
+  const candidateMessage = candidate?.message;
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof candidateMessage === "string"
+        ? candidateMessage
+        : null;
   return (
     candidate?.rpcMethod === "thread/turns/list" &&
     candidate?.rpcCode === -32600 &&
-    message === STALE_THREAD_CURSOR_ERROR_MESSAGE
+    // Codex 0.147 paginated cursors embed their dynamic `{ turnId, includeAnchor }` anchor in the
+    // message. Classify the protocol error by method, JSON-RPC code and stable prefix; full-string
+    // equality is only valid for the legacy rollout message and misroutes paginated recovery.
+    message?.startsWith(STALE_THREAD_CURSOR_ERROR_PREFIX) === true
   );
 }

--- a/shared/runtime/app-server.ts
+++ b/shared/runtime/app-server.ts
@@ -316,6 +316,8 @@ const threadResumeResultSchema = z
         })
         .strict(),
     ]),
+    initialTurnsPage: turnsPageSchema.nullable().optional(),
+    turnsBackwardsCursor: z.string().nullable().optional(),
   })
   .loose();
 

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -60,6 +60,9 @@ test("shows effort and compact context usage without mobile approval controls", 
   page,
 }) => {
   await openApp(page);
+  await page.route("**/api/threads/settings", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
   const threadId = "mobile-composer-settings";
   const tokenBreakdown = {
     totalTokens: 50_000,
@@ -109,10 +112,27 @@ test("shows effort and compact context usage without mobile approval controls", 
   await page.getByTestId("model-select").click();
   const modelSearch = page.getByPlaceholder("搜索模型或推理强度");
   await expect(modelSearch).toBeVisible();
+  await expect(modelSearch).not.toBeFocused();
+  await modelSearch.click();
+  await expect(modelSearch).toBeFocused();
   await modelSearch.fill("luna");
   await expect(page.getByTestId("model-option-gpt-5.6-luna")).toBeVisible();
   await expect(page.getByTestId("model-option-gpt-5.6-sol")).toBeHidden();
-  await page.keyboard.press("Escape");
+  await modelSearch.fill("");
+
+  await page.getByText("High", { exact: true }).click();
+  await expect(modelSearch).toBeVisible();
+  await expect(page.getByTestId("model-select")).toContainText("High");
+  await page.getByTestId("model-option-gpt-5.6-sol").click();
+  await expect(modelSearch).toBeVisible();
+  await expect(page.getByTestId("model-select")).toContainText("GPT-5.6 Sol");
+
+  await page.getByTestId("model-selector-close").click();
+  await expect(modelSearch).toBeHidden();
+  await page.getByTestId("model-select").click();
+  await expect(modelSearch).toBeVisible();
+  await page.locator('[data-slot="dialog-overlay"]').click({ position: { x: 4, y: 4 } });
+  await expect(modelSearch).toBeHidden();
 
   await page.locator('input[type="file"]').setInputFiles({
     name: "mobile-preview.png",


### PR DESCRIPTION
## Summary

- start new App Server threads with paginated history and cold-open them through `thread/resume.initialTurnsPage`
- reuse materialized running-thread snapshots and transfer activation subscription leases without duplicate resumes
- recognize Codex 0.147 paginated stale cursors
- keep the model selector open after choosing model/effort and avoid opening the mobile keyboard until search is tapped

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`81 passed`)
- production Nuxt build completed inside the standard E2E runner