### PR TITLE
refactor: adopt AI Elements presentation components

### DIFF
--- a/app/components/common/StaticJsonCodeBlock.vue
+++ b/app/components/common/StaticJsonCodeBlock.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue";
+import { computed } from "vue";
+import { CodeBlock } from "@codex-gateway/ai-elements/code-block";
+import { jsonPreview } from "@/utils/thread-items";
+
+const props = withDefaults(
+  defineProps<{
+    value: unknown;
+    maxHeight?: "compact" | "default";
+    class?: HTMLAttributes["class"];
+  }>(),
+  {
+    maxHeight: "compact",
+  },
+);
+
+const code = computed(() => jsonPreview(props.value));
+const heightClass = computed(() =>
+  props.maxHeight === "default" ? "[&>div]:max-h-56" : "[&>div]:max-h-40",
+);
+</script>
+
+<template>
+  <!-- AI Elements owns static syntax highlighting and horizontal overflow here. Streaming command
+       output and diffs deliberately bypass this adapter because repeatedly tokenizing them would
+       contend with the outer chat virtualizer and its bottom-follow measurements. -->
+  <CodeBlock
+    :code="code"
+    language="json"
+    :class="[
+      'bg-surface/80 [&_code]:text-xs [&_pre]:p-3 [&_pre]:text-xs',
+      heightClass,
+      props.class,
+    ]"
+    v-bind="$attrs"
+  />
+</template>

--- a/app/components/thread/items/AgentMessageItem.vue
+++ b/app/components/thread/items/AgentMessageItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ThreadHistoryItem } from "~~/shared/types";
 import { computed } from "vue";
+import { Message, MessageContent } from "@codex-gateway/ai-elements/message";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import AgentMessageActions from "@/components/thread/items/AgentMessageActions.vue";
 import { isItemInProgress, threadItemText } from "@/utils/thread-items";
@@ -20,8 +21,12 @@ const hasFooter = computed(
 </script>
 
 <template>
-  <div class="group min-w-0 max-w-full text-[0.9375rem] leading-8 text-ink lg:max-w-4xl">
-    <MarkdownContent :content="text" :streaming="inProgress" />
-    <AgentMessageActions v-if="hasFooter" :text="text" :turn-timing="turnTiming" />
-  </div>
+  <Message from="assistant" class="min-w-0 max-w-full lg:max-w-4xl">
+    <MessageContent
+      class="min-w-0 w-full gap-0 overflow-visible text-[0.9375rem] leading-8 text-ink"
+    >
+      <MarkdownContent :content="text" :streaming="inProgress" />
+      <AgentMessageActions v-if="hasFooter" :text="text" :turn-timing="turnTiming" />
+    </MessageContent>
+  </Message>
 </template>

--- a/app/components/thread/items/CommandExecutionItem.vue
+++ b/app/components/thread/items/CommandExecutionItem.vue
@@ -9,15 +9,17 @@ import {
 } from "@lucide/vue";
 import { computed } from "vue";
 import { Loader } from "@codex-gateway/ai-elements/loader";
+import { ConfirmationAction } from "@codex-gateway/ai-elements/confirmation";
 import { Badge } from "@codex-gateway/ui/badge";
-import { Button } from "@codex-gateway/ui/button";
 import { Collapsible, CollapsibleTrigger } from "@codex-gateway/ui/collapsible";
 import HighlightedCode from "@/components/common/HighlightedCode.vue";
 import DeferredCollapsibleContent from "@/components/common/DeferredCollapsibleContent.vue";
 import { ChatStickToBottomScrollArea } from "@/components/common/chat-virtualizer";
+import CodexApprovalConfirmation from "@/components/thread/items/approval/CodexApprovalConfirmation.vue";
 import { useServerRequestResponder } from "@/composables/thread/useServerRequestResponder";
 import { commandDisplayLabel } from "@/utils/thread-item-display";
 import { threadItemResultText } from "@/utils/thread-items";
+import { projectCodexApproval } from "./approval/presentation";
 
 const props = defineProps<{
   item: ThreadHistoryItem;
@@ -58,9 +60,18 @@ const visualStatus = computed<"running" | "completed" | "failed" | null>(() => {
   if (commandStatus.value === "completed" || props.item.exitCode === 0) return "completed";
   return null;
 });
+const approvalPresentation = computed(() =>
+  projectCodexApproval({
+    kind: "command",
+    requestId: requestId.value,
+    pending: pendingApproval.value !== null,
+    canRespond: canRespond.value,
+    presentationId: `command-${String(props.item.id ?? props.item.turnId ?? "request")}`,
+  }),
+);
 
-async function respond(decision: "accept" | "decline") {
-  await respondToRequest({ decision });
+async function respond(result: unknown) {
+  await respondToRequest(result);
 }
 </script>
 
@@ -105,37 +116,29 @@ async function respond(decision: "accept" | "decline") {
       </span>
     </CollapsibleTrigger>
     <DeferredCollapsibleContent :open="open">
-      <div
+      <CodexApprovalConfirmation
         v-if="pendingApproval"
-        class="mt-2 rounded-lg border border-accent-orange/30 bg-accent-orange/10 px-3 py-2 text-sm text-accent-orange-deep"
+        class="mt-2"
+        :presentation="approvalPresentation"
       >
-        <div class="font-medium">{{ t("app.commandApprovalRequired") }}</div>
+        <template #title>{{ t("app.commandApprovalRequired") }}</template>
         <div v-if="pendingApproval.params?.reason" class="mt-1 text-accent-orange-deep">
           {{ pendingApproval.params.reason }}
         </div>
-        <div v-if="canRespond" class="mt-2 flex flex-wrap gap-2">
-          <Button
+        <template #actions>
+          <ConfirmationAction
+            v-for="action in approvalPresentation.actions"
+            :key="action.id"
             size="sm"
+            :variant="action.variant"
             :disabled="responding"
-            data-testid="command-approval-accept"
-            @click="respond('accept')"
+            :data-testid="action.testId"
+            @click="respond(action.result)"
           >
-            {{ t("app.approve") }}
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            :disabled="responding"
-            data-testid="command-approval-decline"
-            @click="respond('decline')"
-          >
-            {{ t("app.decline") }}
-          </Button>
-        </div>
-        <div v-else class="mt-2 text-xs text-accent-orange-deep">
-          {{ t("app.serverRequestResolved") }}
-        </div>
-      </div>
+            {{ t(action.label) }}
+          </ConfirmationAction>
+        </template>
+      </CodexApprovalConfirmation>
       <ChatStickToBottomScrollArea
         v-if="output"
         class="mt-2 max-h-56 rounded-lg border border-hairline bg-canvas-soft"

--- a/app/components/thread/items/ContextCompactionItem.vue
+++ b/app/components/thread/items/ContextCompactionItem.vue
@@ -3,6 +3,7 @@ import type { ThreadHistoryItem } from "~~/shared/types";
 import { useTimestamp } from "@vueuse/core";
 import { ArchiveIcon, CheckCircle2Icon, Loader2Icon } from "@lucide/vue";
 import { computed, ref, watch } from "vue";
+import { Checkpoint, CheckpointIcon } from "@codex-gateway/ai-elements/checkpoint";
 import { isItemInProgress } from "@/utils/thread-items";
 import { formatDurationMs, itemCompletedAtMs, itemStartedAtMs } from "@/utils/item-timing";
 
@@ -32,17 +33,13 @@ watch(inProgress, (active) => (active ? resume() : pause()), { immediate: true }
 </script>
 
 <template>
-  <div
-    class="max-w-4xl rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-ink-secondary"
-  >
-    <div class="flex items-center gap-2 text-[0.9375rem]">
+  <Checkpoint class="max-w-4xl gap-2 py-1 text-[0.9375rem] text-ink-muted">
+    <CheckpointIcon>
       <Loader2Icon v-if="inProgress" class="size-4 shrink-0 animate-spin text-primary" />
       <CheckCircle2Icon v-else class="size-4 shrink-0 text-accent-green" />
-      <span class="min-w-0 flex-1 truncate">{{ t("app.contextCompaction") }}</span>
-      <span class="rounded-full bg-surface/80 px-2 py-0.5 font-mono text-xs text-ink-secondary">{{
-        timeLabel
-      }}</span>
-      <ArchiveIcon class="size-4 shrink-0 text-ink-muted" />
-    </div>
-  </div>
+    </CheckpointIcon>
+    <ArchiveIcon class="size-4 shrink-0" />
+    <span class="shrink-0">{{ t("app.contextCompaction") }}</span>
+    <span class="shrink-0 font-mono text-xs text-ink-secondary">{{ timeLabel }}</span>
+  </Checkpoint>
 </template>

--- a/app/components/thread/items/ToolCallItem.vue
+++ b/app/components/thread/items/ToolCallItem.vue
@@ -8,6 +8,7 @@ import { Collapsible, CollapsibleTrigger } from "@codex-gateway/ui/collapsible";
 import { ScrollArea } from "@codex-gateway/ui/scroll-area";
 import DeferredCollapsibleContent from "@/components/common/DeferredCollapsibleContent.vue";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
+import StaticJsonCodeBlock from "@/components/common/StaticJsonCodeBlock.vue";
 import { isItemInProgress } from "@/utils/thread-items";
 import { presentToolCall } from "./tool-call-presenters";
 
@@ -49,8 +50,12 @@ const detailSections = computed(() => presentation.value.details);
         <div class="space-y-3 border-t border-hairline px-3 py-3">
           <div v-for="section in detailSections" :key="section.label" class="space-y-1">
             <div class="text-xs font-medium uppercase text-ink-faint">{{ section.label }}</div>
-            <MarkdownContent v-if="section.markdown" :content="section.content || ''" compact />
-            <Sources v-else-if="section.links?.length" class="mb-0 w-full space-y-2 text-sm">
+            <MarkdownContent
+              v-if="section.kind === 'markdown'"
+              :content="section.content"
+              compact
+            />
+            <Sources v-else-if="section.kind === 'links'" class="mb-0 w-full space-y-2 text-sm">
               <Source
                 v-for="link in section.links"
                 :key="link.url"
@@ -71,6 +76,11 @@ const detailSections = computed(() => presentation.value.details);
                 </span>
               </Source>
             </Sources>
+            <StaticJsonCodeBlock
+              v-else-if="section.kind === 'json'"
+              :value="section.value"
+              max-height="default"
+            />
             <ScrollArea v-else class="h-56 rounded-md bg-canvas-soft">
               <pre class="p-3 text-xs leading-5 text-ink-secondary">{{ section.content }}</pre>
             </ScrollArea>

--- a/app/components/thread/items/UserMessageItem.vue
+++ b/app/components/thread/items/UserMessageItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { Message, MessageContent } from "@codex-gateway/ai-elements/message";
 import { Badge } from "@codex-gateway/ui/badge";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import ThreadImageAttachment from "@/components/thread/attachments/ThreadImageAttachment.vue";
@@ -53,13 +54,20 @@ function imageSource(image: { type: string; url: string; path: string }) {
 </script>
 
 <template>
-  <div class="flex min-w-0 justify-end">
-    <div
-      v-if="variant === 'steer'"
-      data-testid="steered-conversation-item"
-      class="thread-user-message min-w-0 max-w-full space-y-3 overflow-hidden rounded-xl border border-primary/20 bg-primary/5 px-4 py-4 text-[0.9375rem] leading-7 text-ink md:max-w-3xl md:px-5"
+  <Message from="user" class="min-w-0 max-w-full">
+    <MessageContent
+      :data-testid="variant === 'steer' ? 'steered-conversation-item' : undefined"
+      :class="[
+        'thread-user-message min-w-0 max-w-full space-y-3 px-4 py-4 text-[0.9375rem] leading-7 text-ink group-[.is-user]:py-4 group-[.is-user]:text-ink md:max-w-3xl md:px-5 md:group-[.is-user]:px-5',
+        variant === 'steer'
+          ? 'rounded-xl border border-primary/20 bg-primary/5 group-[.is-user]:rounded-xl group-[.is-user]:border group-[.is-user]:border-primary/20 group-[.is-user]:bg-primary/5'
+          : 'rounded-2xl bg-canvas-soft group-[.is-user]:rounded-2xl group-[.is-user]:bg-canvas-soft',
+      ]"
     >
-      <div class="flex items-center gap-2 text-sm font-medium text-primary">
+      <div
+        v-if="variant === 'steer'"
+        class="flex items-center gap-2 text-sm font-medium text-primary"
+      >
         <Badge variant="outline" class="border-primary/30 bg-surface/60 text-primary">{{
           t("app.steeredConversation")
         }}</Badge>
@@ -75,24 +83,8 @@ function imageSource(image: { type: string; url: string; path: string }) {
         </template>
       </div>
       <MarkdownContent v-if="text" :content="text" compact />
-    </div>
-    <div
-      v-else
-      class="thread-user-message min-w-0 max-w-full space-y-3 overflow-hidden rounded-2xl bg-canvas-soft px-4 py-4 text-[0.9375rem] leading-7 text-ink md:max-w-3xl md:px-5"
-    >
-      <div v-if="imageParts.length" class="grid max-w-2xl grid-cols-1 gap-2 sm:grid-cols-2">
-        <template v-for="image in imageParts" :key="image.id">
-          <ThreadImageAttachment
-            v-if="imageSource(image)"
-            :source="imageSource(image)"
-            :label="image.path || null"
-            :detail="image.detail"
-          />
-        </template>
-      </div>
-      <MarkdownContent v-if="text" :content="text" compact />
-    </div>
-  </div>
+    </MessageContent>
+  </Message>
 </template>
 
 <style scoped>

--- a/app/components/thread/items/approval/CodexApprovalConfirmation.vue
+++ b/app/components/thread/items/approval/CodexApprovalConfirmation.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { CodexApprovalPresentation } from "./presentation";
+import {
+  Confirmation,
+  ConfirmationActions,
+  ConfirmationTitle,
+} from "@codex-gateway/ai-elements/confirmation";
+
+defineProps<{
+  presentation: CodexApprovalPresentation;
+}>();
+</script>
+
+<template>
+  <Confirmation
+    :approval="presentation.approval"
+    :state="presentation.state"
+    class="border-accent-orange/30 bg-accent-orange/10 text-sm text-accent-orange-deep"
+  >
+    <ConfirmationTitle class="flex items-center gap-2 font-medium text-accent-orange-deep">
+      <slot name="title" />
+    </ConfirmationTitle>
+    <slot />
+    <ConfirmationActions
+      v-if="presentation.respondable && presentation.actions.length > 0"
+      class="mt-1 flex-wrap justify-start self-start"
+    >
+      <slot name="actions" />
+    </ConfirmationActions>
+    <div v-if="presentation.phase === 'resolved'" class="text-xs text-accent-orange-deep">
+      {{ $t("app.serverRequestResolved") }}
+    </div>
+  </Confirmation>
+</template>

--- a/app/components/thread/items/approval/presentation.ts
+++ b/app/components/thread/items/approval/presentation.ts
@@ -1,0 +1,132 @@
+export type CodexApprovalActionLabel =
+  | "app.approveForTurn"
+  | "app.approveForSession"
+  | "app.decline";
+
+export interface CodexApprovalAction {
+  id: "approve-turn" | "approve-session" | "decline";
+  label: CodexApprovalActionLabel;
+  result: unknown;
+  testId: string;
+  variant: "default" | "outline";
+}
+
+export interface CodexApprovalPresentation {
+  actions: CodexApprovalAction[];
+  approval: { id: string };
+  phase: "requested" | "resolved";
+  requestId: string | number | null;
+  respondable: boolean;
+  state: "approval-requested" | "output-available";
+}
+
+interface CodexApprovalSourceBase {
+  requestId: unknown;
+  pending: boolean;
+  canRespond: boolean;
+  presentationId: string;
+}
+
+type CodexApprovalSource =
+  | (CodexApprovalSourceBase & {
+      kind: "command" | "fileChange";
+    })
+  | (CodexApprovalSourceBase & {
+      kind: "permissions";
+      permissions: unknown;
+    });
+
+export function projectCodexApproval(source: CodexApprovalSource): CodexApprovalPresentation {
+  const requestId = approvalRequestId(source.requestId);
+  const approval = { id: requestId === null ? source.presentationId : String(requestId) };
+  if (source.pending) {
+    return {
+      actions: approvalActions(source),
+      approval,
+      phase: "requested",
+      requestId,
+      respondable: source.canRespond,
+      state: "approval-requested",
+    };
+  }
+
+  // serverRequest/resolved removes requestId and pendingApproval from Gateway history but does not
+  // persist whether the user accepted or declined. Keep that truthful "handled" state instead of
+  // manufacturing AI SDK approved/rejected booleans from a completed command or file status.
+  return {
+    actions: [],
+    approval,
+    phase: "resolved",
+    requestId,
+    respondable: false,
+    state: "output-available",
+  };
+}
+
+function approvalActions(source: CodexApprovalSource): CodexApprovalAction[] {
+  const prefix = source.kind === "fileChange" ? "file" : source.kind;
+  if (source.kind === "permissions") {
+    return [
+      action(
+        "approve-turn",
+        "app.approveForTurn",
+        { permissions: source.permissions, scope: "turn" },
+        `${prefix}-approval-turn`,
+        "default",
+      ),
+      action(
+        "approve-session",
+        "app.approveForSession",
+        { permissions: source.permissions, scope: "session" },
+        `${prefix}-approval-session`,
+        "outline",
+      ),
+      action(
+        "decline",
+        "app.decline",
+        { permissions: {}, scope: "turn" },
+        `${prefix}-approval-decline`,
+        "outline",
+      ),
+    ];
+  }
+
+  return [
+    action(
+      "approve-turn",
+      "app.approveForTurn",
+      { decision: "accept" },
+      `${prefix}-approval-accept`,
+      "default",
+    ),
+    action(
+      "approve-session",
+      "app.approveForSession",
+      { decision: "acceptForSession" },
+      `${prefix}-approval-session`,
+      "outline",
+    ),
+    action(
+      "decline",
+      "app.decline",
+      { decision: "decline" },
+      `${prefix}-approval-decline`,
+      "outline",
+    ),
+  ];
+}
+
+function action(
+  id: CodexApprovalAction["id"],
+  label: CodexApprovalActionLabel,
+  result: unknown,
+  testId: string,
+  variant: CodexApprovalAction["variant"],
+): CodexApprovalAction {
+  return { id, label, result, testId, variant };
+}
+
+function approvalRequestId(value: unknown): string | number | null {
+  if (typeof value === "string") return value === "" ? null : value;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/app/components/thread/items/file-change/FileChangeApprovalBar.vue
+++ b/app/components/thread/items/file-change/FileChangeApprovalBar.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { Button } from "@codex-gateway/ui/button";
+import { ConfirmationAction } from "@codex-gateway/ai-elements/confirmation";
+import CodexApprovalConfirmation from "@/components/thread/items/approval/CodexApprovalConfirmation.vue";
 import { useServerRequestResponder } from "@/composables/thread/useServerRequestResponder";
+import { projectCodexApproval } from "@/components/thread/items/approval/presentation";
 
 const props = defineProps<{
   pendingApproval: {
@@ -10,6 +12,7 @@ const props = defineProps<{
   };
   hostId: number | null;
   threadId: string | null;
+  presentationId: string;
 }>();
 
 const { t } = useI18n();
@@ -23,41 +26,39 @@ const {
   threadId: computed(() => props.threadId),
   requestId,
 });
+const approvalPresentation = computed(() =>
+  projectCodexApproval({
+    kind: "fileChange",
+    requestId: requestId.value,
+    pending: true,
+    canRespond: canRespond.value,
+    presentationId: props.presentationId,
+  }),
+);
 
-async function respond(decision: "accept" | "decline") {
-  await respondToRequest({ decision });
+async function respond(result: unknown) {
+  await respondToRequest(result);
 }
 </script>
 
 <template>
-  <div
-    class="mt-3 rounded-lg border border-accent-orange/30 bg-accent-orange/10 px-3 py-2 text-sm text-accent-orange-deep"
-  >
-    <div class="font-medium">{{ t("app.fileApprovalRequired") }}</div>
+  <CodexApprovalConfirmation class="mt-3" :presentation="approvalPresentation">
+    <template #title>{{ t("app.fileApprovalRequired") }}</template>
     <div v-if="pendingApproval.params?.reason" class="mt-1 text-accent-orange-deep">
       {{ pendingApproval.params.reason }}
     </div>
-    <div v-if="canRespond" class="mt-2 flex flex-wrap gap-2">
-      <Button
+    <template #actions>
+      <ConfirmationAction
+        v-for="action in approvalPresentation.actions"
+        :key="action.id"
         size="sm"
+        :variant="action.variant"
         :disabled="responding"
-        data-testid="file-approval-accept"
-        @click="respond('accept')"
+        :data-testid="action.testId"
+        @click="respond(action.result)"
       >
-        {{ t("app.approve") }}
-      </Button>
-      <Button
-        size="sm"
-        variant="outline"
-        :disabled="responding"
-        data-testid="file-approval-decline"
-        @click="respond('decline')"
-      >
-        {{ t("app.decline") }}
-      </Button>
-    </div>
-    <div v-else class="mt-2 text-xs text-accent-orange-deep">
-      {{ t("app.serverRequestResolved") }}
-    </div>
-  </div>
+        {{ t(action.label) }}
+      </ConfirmationAction>
+    </template>
+  </CodexApprovalConfirmation>
 </template>

--- a/app/components/thread/items/file-change/FileChangeItem.vue
+++ b/app/components/thread/items/file-change/FileChangeItem.vue
@@ -102,6 +102,7 @@ watch(
         :pending-approval="pendingApproval"
         :host-id="hostId"
         :thread-id="threadId"
+        :presentation-id="`file-${String(item.id ?? item.turnId ?? 'request')}`"
       />
     </div>
     <div v-if="fileChanges.length" class="mt-3 space-y-2">

--- a/app/components/thread/items/planning/CodexPlanCard.vue
+++ b/app/components/thread/items/planning/CodexPlanCard.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ListChecksIcon } from "@lucide/vue";
+import {
+  Plan,
+  PlanAction,
+  PlanContent,
+  PlanHeader,
+  PlanTitle,
+  PlanTrigger,
+} from "@codex-gateway/ai-elements/plan";
+
+defineProps<{
+  title: string;
+  isStreaming?: boolean;
+}>();
+</script>
+
+<template>
+  <Plan
+    :default-open="true"
+    :is-streaming="isStreaming"
+    class="max-w-4xl border-hairline bg-surface text-ink-secondary"
+  >
+    <PlanHeader class="items-center gap-3 px-4 py-3">
+      <div class="flex min-w-0 items-center gap-2">
+        <slot name="icon">
+          <ListChecksIcon class="size-4 shrink-0" />
+        </slot>
+        <PlanTitle class="truncate text-[0.9375rem] font-medium">{{ title }}</PlanTitle>
+      </div>
+      <PlanAction>
+        <PlanTrigger :aria-label="$t('app.togglePlan')" />
+      </PlanAction>
+    </PlanHeader>
+    <PlanContent class="px-4 pb-4 text-[0.9375rem] leading-7">
+      <slot />
+    </PlanContent>
+    <slot name="footer" />
+  </Plan>
+</template>

--- a/app/components/thread/items/planning/PlanImplementationActions.vue
+++ b/app/components/thread/items/planning/PlanImplementationActions.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ThreadHistoryItem } from "~~/shared/types";
 import { computed, ref } from "vue";
+import { PlanFooter } from "@codex-gateway/ai-elements/plan";
 import { Button } from "@codex-gateway/ui/button";
 import { useGatewayCatalogStore } from "@/stores/gateway-catalog";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
@@ -85,9 +86,9 @@ function defaultCollaborationMode() {
 </script>
 
 <template>
-  <div
+  <PlanFooter
     v-if="visible"
-    class="mt-3 flex flex-wrap items-center gap-2 rounded-xl border border-hairline bg-canvas-soft px-3 py-2"
+    class="flex flex-wrap items-center gap-2 border-t border-hairline bg-canvas-soft px-4 py-3"
   >
     <span class="min-w-0 flex-1 text-sm text-ink-secondary">
       {{ $t("app.planImplementationPrompt") }}
@@ -98,5 +99,5 @@ function defaultCollaborationMode() {
     <Button size="sm" variant="ghost" @click="continuePlanning">
       {{ $t("app.continuePlanning") }}
     </Button>
-  </div>
+  </PlanFooter>
 </template>

--- a/app/components/thread/items/planning/PlanItem.vue
+++ b/app/components/thread/items/planning/PlanItem.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { ThreadHistoryItem } from "~~/shared/types";
-import { ListChecksIcon } from "@lucide/vue";
 import { computed } from "vue";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import { threadItemText } from "@/utils/thread-items";
+import CodexPlanCard from "./CodexPlanCard.vue";
 import PlanImplementationActions from "./PlanImplementationActions.vue";
 
 const props = defineProps<{
@@ -11,16 +11,15 @@ const props = defineProps<{
   hostId: number | null;
   threadId: string | null;
 }>();
+const { t } = useI18n();
 const text = computed(() => threadItemText(props.item));
 </script>
 
 <template>
-  <div class="max-w-4xl text-[0.9375rem] leading-8 text-ink">
-    <div class="mb-2 flex items-center gap-2 text-ink-faint">
-      <ListChecksIcon class="size-4" />
-      <span>Plan</span>
-    </div>
+  <CodexPlanCard :title="t('app.plan')">
     <MarkdownContent :content="text" />
-    <PlanImplementationActions :item="item" :host-id="hostId" :thread-id="threadId" />
-  </div>
+    <template #footer>
+      <PlanImplementationActions :item="item" :host-id="hostId" :thread-id="threadId" />
+    </template>
+  </CodexPlanCard>
 </template>

--- a/app/components/thread/items/planning/TurnPlanItem.vue
+++ b/app/components/thread/items/planning/TurnPlanItem.vue
@@ -5,6 +5,7 @@ import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import PlanImplementationActions from "./PlanImplementationActions.vue";
 import type { ThreadHistoryItem } from "~~/shared/types";
 import { recordFromUnknown } from "~~/shared/utils/records";
+import CodexPlanCard from "./CodexPlanCard.vue";
 
 const props = defineProps<{
   item: ThreadHistoryItem;
@@ -22,11 +23,10 @@ function stepStatus(step: unknown) {
 </script>
 
 <template>
-  <div class="max-w-4xl rounded-lg border border-hairline bg-surface px-4 py-3 text-ink-secondary">
-    <div class="mb-3 flex items-center gap-2 text-[0.9375rem] font-medium text-ink-secondary">
+  <CodexPlanCard :title="t('app.todoPlan')">
+    <template #icon>
       <ListTodoIcon class="size-4" />
-      <span>{{ t("app.todoPlan") }}</span>
-    </div>
+    </template>
     <MarkdownContent v-if="item.explanation" :content="item.explanation" compact />
     <div v-if="steps.length" class="mt-3 space-y-2">
       <div
@@ -46,6 +46,8 @@ function stepStatus(step: unknown) {
         <span class="min-w-0 flex-1">{{ step.step }}</span>
       </div>
     </div>
-    <PlanImplementationActions :item="item" :host-id="hostId" :thread-id="threadId" />
-  </div>
+    <template #footer>
+      <PlanImplementationActions :item="item" :host-id="hostId" :thread-id="threadId" />
+    </template>
+  </CodexPlanCard>
 </template>

--- a/app/components/thread/items/requests/DynamicToolClientRequestItem.vue
+++ b/app/components/thread/items/requests/DynamicToolClientRequestItem.vue
@@ -4,10 +4,9 @@ import { WrenchIcon } from "@lucide/vue";
 import { computed, ref } from "vue";
 import { Badge } from "@codex-gateway/ui/badge";
 import { Button } from "@codex-gateway/ui/button";
-import { ScrollArea } from "@codex-gateway/ui/scroll-area";
 import { Textarea } from "@codex-gateway/ui/textarea";
+import StaticJsonCodeBlock from "@/components/common/StaticJsonCodeBlock.vue";
 import { useServerRequestResponder } from "@/composables/thread/useServerRequestResponder";
-import { jsonPreview } from "@/utils/thread-items";
 
 const props = defineProps<{
   item: ThreadHistoryItem;
@@ -48,9 +47,7 @@ async function submit() {
     </div>
     <div class="mt-3">
       <div class="mb-1 text-xs font-medium uppercase text-primary">{{ t("app.arguments") }}</div>
-      <ScrollArea class="h-40 rounded-md bg-surface/80">
-        <pre class="p-2 text-xs">{{ jsonPreview(params.arguments) }}</pre>
-      </ScrollArea>
+      <StaticJsonCodeBlock :value="params.arguments" />
     </div>
     <div v-if="canRespond" class="mt-3">
       <div class="mb-1 text-xs font-medium uppercase text-primary">

--- a/app/components/thread/items/requests/McpElicitationRequestItem.vue
+++ b/app/components/thread/items/requests/McpElicitationRequestItem.vue
@@ -4,10 +4,9 @@ import { ExternalLinkIcon, MessageCircleQuestionIcon } from "@lucide/vue";
 import { computed, ref } from "vue";
 import { Button } from "@codex-gateway/ui/button";
 import { Badge } from "@codex-gateway/ui/badge";
-import { ScrollArea } from "@codex-gateway/ui/scroll-area";
 import { Textarea } from "@codex-gateway/ui/textarea";
+import StaticJsonCodeBlock from "@/components/common/StaticJsonCodeBlock.vue";
 import { useServerRequestResponder } from "@/composables/thread/useServerRequestResponder";
-import { jsonPreview } from "@/utils/thread-items";
 
 const props = defineProps<{
   item: ThreadHistoryItem;
@@ -65,9 +64,7 @@ async function respond(action: "accept" | "decline" | "cancel") {
     </a>
     <div v-if="params.requestedSchema" class="mt-3">
       <div class="mb-1 text-xs font-medium uppercase text-primary">{{ t("app.schema") }}</div>
-      <ScrollArea class="h-40 rounded-md bg-surface/80">
-        <pre class="p-2 text-xs">{{ jsonPreview(params.requestedSchema) }}</pre>
-      </ScrollArea>
+      <StaticJsonCodeBlock :value="params.requestedSchema" />
     </div>
     <Textarea
       v-if="canRespond"

--- a/app/components/thread/items/requests/PermissionsRequestItem.vue
+++ b/app/components/thread/items/requests/PermissionsRequestItem.vue
@@ -2,11 +2,12 @@
 import type { ThreadHistoryItem } from "~~/shared/types";
 import { ShieldQuestionIcon } from "@lucide/vue";
 import { computed } from "vue";
+import { ConfirmationAction } from "@codex-gateway/ai-elements/confirmation";
 import { Badge } from "@codex-gateway/ui/badge";
-import { Button } from "@codex-gateway/ui/button";
-import { ScrollArea } from "@codex-gateway/ui/scroll-area";
+import StaticJsonCodeBlock from "@/components/common/StaticJsonCodeBlock.vue";
+import CodexApprovalConfirmation from "@/components/thread/items/approval/CodexApprovalConfirmation.vue";
+import { projectCodexApproval } from "@/components/thread/items/approval/presentation";
 import { useServerRequestResponder } from "@/composables/thread/useServerRequestResponder";
-import { jsonPreview } from "@/utils/thread-items";
 
 const props = defineProps<{
   item: ThreadHistoryItem;
@@ -38,20 +39,16 @@ const writePaths = computed(() =>
 const entries = computed(() =>
   Array.isArray(fileSystem.value?.entries) ? fileSystem.value.entries : [],
 );
-
-async function approve(scope: "turn" | "session") {
-  await respond({
+const approvalPresentation = computed(() =>
+  projectCodexApproval({
+    kind: "permissions",
+    requestId: requestId.value,
+    pending: requestId.value !== null && requestId.value !== undefined && requestId.value !== "",
+    canRespond: canRespond.value,
+    presentationId: `permissions-${String(props.item.id ?? "request")}`,
     permissions: requested.value,
-    scope,
-  });
-}
-
-async function decline() {
-  await respond({
-    permissions: {},
-    scope: "turn",
-  });
-}
+  }),
+);
 
 async function respond(result: unknown) {
   await respondToRequest(result);
@@ -59,14 +56,12 @@ async function respond(result: unknown) {
 </script>
 
 <template>
-  <div
-    class="max-w-4xl rounded-lg border border-accent-orange/30 bg-accent-orange/10 px-3 py-3 text-sm text-ink-secondary"
-  >
-    <div class="flex items-center gap-2">
+  <CodexApprovalConfirmation class="max-w-4xl" :presentation="approvalPresentation">
+    <template #title>
       <ShieldQuestionIcon class="size-4 shrink-0" />
       <span class="font-medium">{{ t("app.permissionsRequest") }}</span>
       <Badge variant="outline">{{ item.status }}</Badge>
-    </div>
+    </template>
     <div v-if="params.reason" class="mt-2 text-accent-orange-deep">{{ params.reason }}</div>
     <div class="mt-3 grid gap-2">
       <div v-if="params.cwd" class="rounded-md bg-surface/80 px-3 py-2">
@@ -102,41 +97,21 @@ async function respond(result: unknown) {
             {{ path }}
           </div>
         </div>
-        <ScrollArea v-if="entries.length" class="mt-2 h-40 rounded-md bg-surface">
-          <pre class="p-2 text-xs">{{ jsonPreview(entries) }}</pre>
-        </ScrollArea>
+        <StaticJsonCodeBlock v-if="entries.length" class="mt-2" :value="entries" />
       </div>
     </div>
-    <div v-if="canRespond" class="mt-3 flex flex-wrap gap-2">
-      <Button
+    <template #actions>
+      <ConfirmationAction
+        v-for="action in approvalPresentation.actions"
+        :key="action.id"
         size="sm"
+        :variant="action.variant"
         :disabled="responding"
-        data-testid="permissions-approval-turn"
-        @click="approve('turn')"
+        :data-testid="action.testId"
+        @click="respond(action.result)"
       >
-        {{ t("app.approveForTurn") }}
-      </Button>
-      <Button
-        size="sm"
-        variant="outline"
-        :disabled="responding"
-        data-testid="permissions-approval-session"
-        @click="approve('session')"
-      >
-        {{ t("app.approveForSession") }}
-      </Button>
-      <Button
-        size="sm"
-        variant="outline"
-        :disabled="responding"
-        data-testid="permissions-approval-decline"
-        @click="decline"
-      >
-        {{ t("app.decline") }}
-      </Button>
-    </div>
-    <div v-else class="mt-3 rounded-md bg-surface/80 px-3 py-2 text-xs text-ink-muted">
-      {{ t("app.serverRequestResolved") }}
-    </div>
-  </div>
+        {{ t(action.label) }}
+      </ConfirmationAction>
+    </template>
+  </CodexApprovalConfirmation>
 </template>

--- a/app/components/thread/items/requests/ProtocolMismatchRequestItem.vue
+++ b/app/components/thread/items/requests/ProtocolMismatchRequestItem.vue
@@ -3,8 +3,7 @@ import type { ThreadHistoryItem } from "~~/shared/types";
 import { AlertTriangleIcon } from "@lucide/vue";
 import { computed } from "vue";
 import { Badge } from "@codex-gateway/ui/badge";
-import { ScrollArea } from "@codex-gateway/ui/scroll-area";
-import { jsonPreview } from "@/utils/thread-items";
+import StaticJsonCodeBlock from "@/components/common/StaticJsonCodeBlock.vue";
 
 const props = defineProps<{
   item: ThreadHistoryItem;
@@ -27,8 +26,6 @@ const description = computed(() => props.description || t("app.protocolMismatchD
       <Badge variant="outline">{{ item.status }}</Badge>
     </div>
     <div class="mt-2">{{ description }}</div>
-    <ScrollArea class="mt-3 h-56 rounded-md bg-surface/80">
-      <pre class="p-2 text-xs">{{ jsonPreview(item.params) }}</pre>
-    </ScrollArea>
+    <StaticJsonCodeBlock class="mt-3" :value="item.params" max-height="default" />
   </div>
 </template>

--- a/app/components/thread/items/requests/ServerRequestItem.vue
+++ b/app/components/thread/items/requests/ServerRequestItem.vue
@@ -3,13 +3,11 @@ import type { ThreadHistoryItem } from "~~/shared/types";
 import { AlertCircleIcon } from "@lucide/vue";
 import { computed } from "vue";
 import { Badge } from "@codex-gateway/ui/badge";
-import { ScrollArea } from "@codex-gateway/ui/scroll-area";
-import { jsonPreview } from "@/utils/thread-items";
+import StaticJsonCodeBlock from "@/components/common/StaticJsonCodeBlock.vue";
 
 const props = defineProps<{ item: ThreadHistoryItem }>();
 const { t } = useI18n();
 const title = computed(() => props.item.method || "server request");
-const payload = computed(() => jsonPreview(props.item.params ?? {}));
 </script>
 
 <template>
@@ -21,8 +19,6 @@ const payload = computed(() => jsonPreview(props.item.params ?? {}));
       <span class="min-w-0 flex-1 truncate">{{ t("app.serverRequestWaiting") }} · {{ title }}</span>
       <Badge variant="outline">{{ item.status }}</Badge>
     </div>
-    <ScrollArea class="mt-2 h-40 rounded-md bg-surface/70">
-      <pre class="p-2 text-xs leading-5 text-ink-secondary">{{ payload }}</pre>
-    </ScrollArea>
+    <StaticJsonCodeBlock class="mt-2" :value="item.params ?? {}" />
   </div>
 </template>

--- a/app/components/thread/items/tool-call-presenters.ts
+++ b/app/components/thread/items/tool-call-presenters.ts
@@ -1,5 +1,3 @@
-import { jsonPreview } from "@/utils/thread-items";
-
 import type { ThreadHistoryItem } from "~~/shared/types";
 import { recordFromUnknown } from "~~/shared/utils/records";
 import { trimmedOrFallback, trimmedOrNull } from "~~/shared/utils/strings";
@@ -8,12 +6,35 @@ type ToolCallItem = ThreadHistoryItem;
 
 export type ToolCallIcon = "image" | "search" | "tool";
 
-export interface ToolCallDetailSection {
+interface ToolCallMarkdownDetail {
   label: string;
-  content?: string;
-  markdown?: boolean;
-  links?: ToolCallResultLink[];
+  kind: "markdown";
+  content: string;
 }
+
+interface ToolCallTextDetail {
+  label: string;
+  kind: "text";
+  content: string;
+}
+
+interface ToolCallJsonDetail {
+  label: string;
+  kind: "json";
+  value: unknown;
+}
+
+interface ToolCallLinksDetail {
+  label: string;
+  kind: "links";
+  links: ToolCallResultLink[];
+}
+
+export type ToolCallDetailSection =
+  | ToolCallMarkdownDetail
+  | ToolCallTextDetail
+  | ToolCallJsonDetail
+  | ToolCallLinksDetail;
 
 export interface ToolCallResultLink {
   title: string;
@@ -39,12 +60,12 @@ const toolCallPresenters: Record<string, ToolCallPresenter> = {
       title: `${trimmedOrFallback(item.server, "MCP")} · ${trimmedOrFallback(item.tool, "tool")}`,
       icon: "tool",
       details: compactDetails([
-        { label: t("app.arguments"), content: jsonPreview(item.arguments) },
+        { label: t("app.arguments"), kind: "json", value: item.arguments },
         item.result !== null && item.result !== undefined
-          ? { label: t("app.result"), content: jsonPreview(item.result) }
+          ? { label: t("app.result"), kind: "json", value: item.result }
           : null,
         errorMessage !== null
-          ? { label: t("app.error"), content: errorMessage, markdown: true }
+          ? { label: t("app.error"), kind: "markdown", content: errorMessage }
           : null,
       ]),
     };
@@ -54,9 +75,9 @@ const toolCallPresenters: Record<string, ToolCallPresenter> = {
     title: trimmedOrFallback(item.name, trimmedOrFallback(item.tool, "Tool call")),
     icon: "tool",
     details: compactDetails([
-      { label: t("app.arguments"), content: jsonPreview(item.arguments) },
+      { label: t("app.arguments"), kind: "json", value: item.arguments },
       Array.isArray(item.contentItems) && item.contentItems.length > 0
-        ? { label: t("app.result"), content: jsonPreview(item.contentItems) }
+        ? { label: t("app.result"), kind: "json", value: item.contentItems }
         : null,
     ]),
   }),
@@ -70,9 +91,9 @@ const toolCallPresenters: Record<string, ToolCallPresenter> = {
       icon: "image",
       details: compactDetails([
         typeof item.result === "string"
-          ? { label: t("app.result"), content: item.result, markdown: true }
+          ? { label: t("app.result"), kind: "markdown", content: item.result }
           : null,
-        savedPath !== null ? { label: t("app.savedPath"), content: savedPath } : null,
+        savedPath !== null ? { label: t("app.savedPath"), kind: "text", content: savedPath } : null,
       ]),
     };
   },
@@ -103,7 +124,7 @@ function reviewModePresentation(item: ToolCallItem, t: Translate, title: string)
     title,
     icon: "tool" as const,
     details: compactDetails([
-      review !== null ? { label: t("app.review"), content: review, markdown: true } : null,
+      review !== null ? { label: t("app.review"), kind: "markdown", content: review } : null,
     ]),
   };
 }
@@ -115,20 +136,20 @@ function webSearchPresentation(item: ToolCallItem, t: Translate): ToolCallPresen
     icon: "search",
     details: compactDetails([
       item.action !== null && item.action !== undefined
-        ? { label: t("app.action"), content: jsonPreview(item.action) }
+        ? { label: t("app.action"), kind: "json", value: item.action }
         : null,
-      links.length > 0 ? { label: t("app.result"), links } : null,
+      links.length > 0 ? { label: t("app.result"), kind: "links", links } : null,
     ]),
   };
 }
 
 function compactDetails(details: Array<ToolCallDetailSection | null>) {
-  return details.filter(
-    (detail): detail is ToolCallDetailSection =>
-      detail !== null &&
-      (trimmedOrNull(detail.content) !== null ||
-        (detail.links !== undefined && detail.links.length > 0)),
-  );
+  return details.filter((detail): detail is ToolCallDetailSection => {
+    if (detail === null) return false;
+    if (detail.kind === "links") return detail.links.length > 0;
+    if (detail.kind === "json") return detail.value !== null && detail.value !== undefined;
+    return trimmedOrNull(detail.content) !== null;
+  });
 }
 
 function webSearchResultLinks(results: unknown): ToolCallResultLink[] {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -227,6 +227,8 @@
     "slashGoalClearTitle": "Clear goal",
     "slashGoalClearDescription": "Clear the current goal through app-server",
     "planModeActive": "Plan mode",
+    "plan": "Plan",
+    "togglePlan": "Toggle plan",
     "goalModeActive": "Goal",
     "threadGoal": "Goal",
     "goalInputHint": "Enter an objective and press Enter",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -227,6 +227,8 @@
     "slashGoalClearTitle": "清除目标",
     "slashGoalClearDescription": "调用 app-server 清除当前目标",
     "planModeActive": "计划模式",
+    "plan": "计划",
+    "togglePlan": "展开或收起计划",
     "goalModeActive": "目标",
     "threadGoal": "Goal",
     "goalInputHint": "输入目标后回车",


### PR DESCRIPTION
## Summary
- adopt AI Elements Message, Plan, Checkpoint, CodeBlock, and Confirmation presentation primitives
- centralize static JSON rendering and typed Codex approval projection
- preserve Markdown, authenticated images, streaming command/diff rendering, plan actions, and turn/session approval semantics

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e (81 passed)
- two read-only architecture reviews completed and findings resolved