### PR TITLE
fix: keep existing goals visible

### DIFF
--- a/app/components/chat/ChatComposer.vue
+++ b/app/components/chat/ChatComposer.vue
@@ -42,6 +42,7 @@ const {
   sendButtonLabel,
   saveSelectedThreadGoal,
   stopSelectedThreadGoal,
+  resumeSelectedThreadGoal,
   clearSelectedThreadGoal,
   setSelectedApprovalMode,
   setSelectedEffort,
@@ -89,6 +90,7 @@ const {
     @deactivate-plan="deactivatePlanMode"
     @save-goal="saveSelectedThreadGoal"
     @stop-goal="stopSelectedThreadGoal"
+    @resume-goal="resumeSelectedThreadGoal"
     @clear-goal="clearSelectedThreadGoal"
     @hover-slash-command="selectSlashCommandIndex"
     @select-slash-command="runSlashCommand"

--- a/app/components/chat/composer/ComposerGoalDetailsDialog.vue
+++ b/app/components/chat/composer/ComposerGoalDetailsDialog.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
-import { LoaderCircleIcon, PencilIcon, SaveIcon, SquareIcon, Trash2Icon } from "@lucide/vue";
+import {
+  LoaderCircleIcon,
+  PencilIcon,
+  PlayIcon,
+  SaveIcon,
+  SquareIcon,
+  Trash2Icon,
+} from "@lucide/vue";
 import { computed, ref, watch } from "vue";
 import type { ThreadGoal } from "~~/shared/types";
 import MarkdownContent from "@/components/common/MarkdownContent.vue";
 import type { ComposerGoalPendingAction } from "@/composables/composer/useComposerGoalControls";
 import { Button } from "@codex-gateway/ui/button";
+import { Badge } from "@codex-gateway/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -16,6 +24,7 @@ import {
 } from "@codex-gateway/ui/dialog";
 import { ScrollArea } from "@codex-gateway/ui/scroll-area";
 import { Textarea } from "@codex-gateway/ui/textarea";
+import { goalStatusI18nKey, threadGoalStatusControl } from "@/utils/thread-goal-display";
 
 const props = defineProps<{
   goal: ThreadGoal;
@@ -28,13 +37,17 @@ const props = defineProps<{
 const emit = defineEmits<{
   save: [objective: string];
   stop: [];
+  resume: [];
   clear: [];
 }>();
 
 const open = ref(false);
 const editing = ref(false);
 const objectiveDraft = ref("");
+const { t } = useI18n();
 const normalizedObjective = computed(() => objectiveDraft.value.trim());
+const statusControl = computed(() => threadGoalStatusControl(props.goal.status));
+const statusLabel = computed(() => t(goalStatusI18nKey(props.goal.status)));
 const canSave = computed(
   () =>
     props.pendingAction === null &&
@@ -83,6 +96,9 @@ watch(
       >
         <span class="shrink-0 font-medium text-primary">{{ $t("app.goalModeActive") }}</span>
         <span class="min-w-0 flex-1 truncate text-ink-secondary">{{ goal.objective }}</span>
+        <Badge variant="outline" class="shrink-0 border-primary/30 bg-surface/70 text-primary">
+          {{ statusLabel }}
+        </Badge>
         <span
           class="flex shrink-0 flex-col items-end gap-0.5 font-mono text-xs text-ink-muted sm:flex-row sm:items-center sm:gap-2"
         >
@@ -171,7 +187,8 @@ watch(
 
       <DialogFooter
         data-testid="goal-details-footer"
-        class="grid shrink-0 grid-cols-3 gap-2 border-t border-hairline px-4 py-3 sm:flex sm:px-6 sm:py-4 sm:items-center sm:justify-between"
+        class="grid shrink-0 gap-2 border-t border-hairline px-4 py-3 sm:flex sm:px-6 sm:py-4 sm:items-center sm:justify-between"
+        :class="statusControl === null ? 'grid-cols-2' : 'grid-cols-3'"
       >
         <Button
           type="button"
@@ -213,6 +230,7 @@ watch(
           </template>
           <template v-else>
             <Button
+              v-if="statusControl === 'pause'"
               type="button"
               variant="outline"
               class="order-2 min-w-0 px-1 sm:order-none sm:px-2"
@@ -223,6 +241,19 @@ watch(
               <LoaderCircleIcon v-if="pendingAction === 'pause'" class="size-4 animate-spin" />
               <SquareIcon v-else class="size-4" />
               {{ $t("app.goalStop") }}
+            </Button>
+            <Button
+              v-else-if="statusControl === 'resume'"
+              type="button"
+              variant="outline"
+              class="order-2 min-w-0 px-1 sm:order-none sm:px-2"
+              data-testid="goal-details-resume"
+              :disabled="pendingAction !== null"
+              @click="emit('resume')"
+            >
+              <LoaderCircleIcon v-if="pendingAction === 'resume'" class="size-4 animate-spin" />
+              <PlayIcon v-else class="size-4" />
+              {{ $t("app.slashGoalResumeTitle") }}
             </Button>
             <Button
               type="button"

--- a/app/components/chat/composer/ComposerModeStrip.vue
+++ b/app/components/chat/composer/ComposerModeStrip.vue
@@ -21,36 +21,44 @@ const emit = defineEmits<{
   deactivatePlan: [];
   saveGoal: [objective: string];
   stopGoal: [];
+  resumeGoal: [];
   clearGoal: [];
 }>();
 
 const { timestamp: now, pause, resume } = useTimestamp({ controls: true, interval: 250 });
 
-const visibleGoal = computed(() => (props.goal?.status === "active" ? props.goal : null));
-const activeGoalElapsedSeconds = computed(() => {
-  if (!visibleGoal.value) {
+const currentGoal = computed(() => props.goal);
+const goalElapsedSeconds = computed(() => {
+  if (!currentGoal.value) {
     return 0;
   }
-  const observedDelta = props.goalObservedAt
-    ? Math.max(0, (now.value - props.goalObservedAt) / 1000)
-    : 0;
-  return visibleGoal.value.timeUsedSeconds + observedDelta;
+  const observedDelta =
+    currentGoal.value.status === "active" && props.goalObservedAt
+      ? Math.max(0, (now.value - props.goalObservedAt) / 1000)
+      : 0;
+  return currentGoal.value.timeUsedSeconds + observedDelta;
 });
 
 const goalTokensLabel = computed(() =>
-  visibleGoal.value ? `${visibleGoal.value.tokensUsed.toLocaleString()} tokens` : "",
+  currentGoal.value ? `${currentGoal.value.tokensUsed.toLocaleString()} tokens` : "",
 );
 const goalBudgetLabel = computed(() => {
-  const budget = visibleGoal.value?.tokenBudget;
+  const budget = currentGoal.value?.tokenBudget;
   return budget === null || budget === undefined ? "∞" : budget.toLocaleString();
 });
-const goalElapsedLabel = computed(() => formatGoalElapsed(activeGoalElapsedSeconds.value));
-const showGoalInputHint = computed(() => props.goalInputActive && !visibleGoal.value);
+const goalElapsedLabel = computed(() => formatGoalElapsed(goalElapsedSeconds.value));
+const showGoalInputHint = computed(() => props.goalInputActive && !currentGoal.value);
 const showStrip = computed(
-  () => props.planModeActive || showGoalInputHint.value || visibleGoal.value,
+  () => props.planModeActive || showGoalInputHint.value || currentGoal.value,
 );
 
-watch(visibleGoal, (goal) => (goal ? resume() : pause()), { immediate: true });
+// A Goal remains useful context after it pauses or completes. Presence controls visibility, while
+// only the active status advances the local elapsed-time projection between app-server updates.
+watch(
+  () => currentGoal.value?.status === "active",
+  (active) => (active ? resume() : pause()),
+  { immediate: true },
+);
 </script>
 
 <template>
@@ -84,14 +92,15 @@ watch(visibleGoal, (goal) => (goal ? resume() : pause()), { immediate: true });
     </div>
 
     <ComposerGoalDetailsDialog
-      v-if="visibleGoal"
-      :goal="visibleGoal"
+      v-if="currentGoal"
+      :goal="currentGoal"
       :elapsed-label="goalElapsedLabel"
       :tokens-label="goalTokensLabel"
       :budget-label="goalBudgetLabel"
       :pending-action="goalActionPending"
       @save="emit('saveGoal', $event)"
       @stop="emit('stopGoal')"
+      @resume="emit('resumeGoal')"
       @clear="emit('clearGoal')"
     />
   </div>

--- a/app/components/chat/composer/ComposerShell.vue
+++ b/app/components/chat/composer/ComposerShell.vue
@@ -57,6 +57,7 @@ const emit = defineEmits<{
   deactivatePlan: [];
   saveGoal: [objective: string];
   stopGoal: [];
+  resumeGoal: [];
   clearGoal: [];
   hoverSlashCommand: [index: number];
   selectSlashCommand: [command: SlashMenuItem];
@@ -92,6 +93,7 @@ function openAttachmentPicker() {
         @deactivate-plan="emit('deactivatePlan')"
         @save-goal="emit('saveGoal', $event)"
         @stop-goal="emit('stopGoal')"
+        @resume-goal="emit('resumeGoal')"
         @clear-goal="emit('clearGoal')"
       />
       <div

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -152,6 +152,7 @@ export function useComposerController() {
     goalActionPending: goalControls.pendingAction,
     saveSelectedThreadGoal: goalControls.saveObjective,
     stopSelectedThreadGoal: goalControls.pause,
+    resumeSelectedThreadGoal: goalControls.resume,
     clearSelectedThreadGoal: goalControls.clear,
     selectedThreadGoal,
     selectedThreadGoalObservedAt,

--- a/app/utils/composer-goal-slash-actions.ts
+++ b/app/utils/composer-goal-slash-actions.ts
@@ -1,5 +1,6 @@
 import type { ThreadGoal, ThreadGoalStatus } from "~~/shared/types";
 import type { SlashMenuItem } from "@/composables/composer/useSlashCommands";
+import { threadGoalStatusControl } from "@/utils/thread-goal-display";
 
 export type GoalSlashActionId = Extract<
   SlashMenuItem["id"],
@@ -23,15 +24,10 @@ export function goalSlashActions(input: {
 }
 
 function goalActionIdsForStatus(status: ThreadGoalStatus): GoalSlashActionId[] {
-  const statusActions: Record<ThreadGoalStatus, GoalSlashActionId[]> = {
-    active: ["goal-edit", "goal-pause", "goal-clear"],
-    paused: ["goal-edit", "goal-resume", "goal-clear"],
-    blocked: ["goal-edit", "goal-resume", "goal-clear"],
-    usageLimited: ["goal-edit", "goal-resume", "goal-clear"],
-    budgetLimited: ["goal-edit", "goal-clear"],
-    complete: ["goal-edit", "goal-clear"],
-  };
-  return statusActions[status];
+  const control = threadGoalStatusControl(status);
+  const controlAction: GoalSlashActionId[] =
+    control === null ? [] : [control === "pause" ? "goal-pause" : "goal-resume"];
+  return ["goal-edit", ...controlAction, "goal-clear"];
 }
 
 function goalAction(

--- a/app/utils/thread-goal-display.ts
+++ b/app/utils/thread-goal-display.ts
@@ -1,5 +1,19 @@
 import type { ThreadGoalStatus } from "~~/shared/types";
 
+export type ThreadGoalStatusControl = "pause" | "resume" | null;
+
+export function threadGoalStatusControl(status: ThreadGoalStatus): ThreadGoalStatusControl {
+  const controls: Record<ThreadGoalStatus, ThreadGoalStatusControl> = {
+    active: "pause",
+    paused: "resume",
+    blocked: "resume",
+    usageLimited: "resume",
+    budgetLimited: null,
+    complete: null,
+  };
+  return controls[status];
+}
+
 export function goalStatusI18nKey(status: ThreadGoalStatus) {
   const keys: Record<ThreadGoalStatus, string> = {
     active: "app.goalStatusActive",

--- a/tests/e2e/thread-goal-plan.spec.ts
+++ b/tests/e2e/thread-goal-plan.spec.ts
@@ -91,6 +91,8 @@ test("goal controls are shared by the slash menu and details dialog", async ({ p
   await expect
     .poll(() => page.evaluate(() => window.__codexGatewayE2e?.captures.goalControls))
     .toEqual([{ type: "status", status: "paused" }]);
+  await expect(page.getByTestId("composer-goal-summary")).toBeVisible();
+  await expect(page.getByTestId("composer-goal-summary").getByText("Paused")).toBeVisible();
 
   await composer.fill("/goal");
   await expect(page.getByTestId("slash-command-goal-resume")).toBeVisible();
@@ -128,11 +130,8 @@ test("goal controls are shared by the slash menu and details dialog", async ({ p
       { type: "status", status: "active" },
       { type: "status", status: "paused" },
     ]);
-  await expect(page.getByTestId("composer-mode-strip")).toHaveCount(0);
-
-  await composer.fill("/goal");
-  await page.getByTestId("slash-command-goal-resume").click();
-  await page.getByTestId("composer-goal-summary").click();
+  await expect(goalDialog.getByTestId("goal-details-resume")).toBeVisible();
+  await goalDialog.getByTestId("goal-details-resume").click();
   await page.getByRole("dialog").getByTestId("goal-details-clear").click();
   await expect
     .poll(() => page.evaluate(() => window.__codexGatewayE2e?.captures.goalControls))
@@ -264,7 +263,8 @@ test("goal progress updates the composer status strip without flooding the agent
     createdAt: new Date().toISOString(),
   });
 
-  await expect(page.getByTestId("composer-mode-strip")).toHaveCount(0);
+  await expect(page.getByTestId("composer-goal-summary")).toBeVisible();
+  await expect(page.getByTestId("composer-goal-summary").getByText("Complete")).toBeVisible();
   await expect(page.getByTestId("chat-scroll-area").getByText("目标已更新")).toHaveCount(0);
   await expect(goalCards).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- keep the composer Goal strip visible for every persisted Goal status
- advance elapsed time only while the Goal is active
- share pause/resume status policy between the Goal dialog and slash menu
- show Goal status and allow paused Goals to resume from details

## Verification
- pnpm lint
- git diff --check
- pnpm test:e2e (81 passed)