### PR TITLE
fix: hide completed goals from composer

### DIFF
--- a/app/components/chat/composer/ComposerModeStrip.vue
+++ b/app/components/chat/composer/ComposerModeStrip.vue
@@ -52,8 +52,9 @@ const showStrip = computed(
   () => props.planModeActive || showGoalInputHint.value || currentGoal.value,
 );
 
-// A Goal remains useful context after it pauses or completes. Presence controls visibility, while
-// only the active status advances the local elapsed-time projection between app-server updates.
+// A paused or blocked Goal remains actionable and visible. The composer controller removes a
+// completed Goal from this presentation boundary, while only active Goals advance locally between
+// app-server updates.
 watch(
   () => currentGoal.value?.status === "active",
   (active) => (active ? resume() : pause()),

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -12,6 +12,7 @@ import { useGatewayNavigationStore } from "@/stores/gateway-navigation";
 import { useGatewayThreadRuntimeStore } from "@/stores/gateway-thread-runtime";
 import { useGatewayThreadViewStore } from "@/stores/gateway-thread-view";
 import { latestThreadPlanItem, planItemSummary } from "@/utils/thread-plan";
+import { isThreadGoalOngoing } from "@/utils/thread-goal-display";
 import { useComposerSlashMenu } from "./useComposerSlashMenu";
 
 export function useComposerController() {
@@ -23,9 +24,22 @@ export function useComposerController() {
   const { t } = useI18n();
   const { models, loadingModels } = storeToRefs(gateway);
   const { selectedHostId, selectedProjectId, selectedThreadId } = storeToRefs(navigation);
-  const { selectedThreadGoal, selectedThreadGoalObservedAt, selectedThreadTokenUsage } =
-    storeToRefs(composer);
+  const {
+    selectedThreadGoal: selectedThreadGoalSnapshot,
+    selectedThreadGoalObservedAt: selectedThreadGoalObservedAtSnapshot,
+    selectedThreadTokenUsage,
+  } = storeToRefs(composer);
   const { history } = storeToRefs(threadView);
+  // Keep the app-server snapshot in Pinia for timeline/history projection, but stop treating a
+  // completed Goal as composer mode. Filtering once at this boundary keeps the strip and /goal
+  // actions aligned: completion returns the input to normal conversation and a new /goal starts
+  // a new objective instead of editing the completed one.
+  const selectedThreadGoal = computed(() =>
+    isThreadGoalOngoing(selectedThreadGoalSnapshot.value) ? selectedThreadGoalSnapshot.value : null,
+  );
+  const selectedThreadGoalObservedAt = computed(() =>
+    selectedThreadGoal.value === null ? null : selectedThreadGoalObservedAtSnapshot.value,
+  );
   const selectedThreadStatus = computed(() =>
     selectedHostId.value !== null && selectedThreadId.value !== null
       ? runtime.statusFor(selectedHostId.value, selectedThreadId.value)

--- a/app/utils/thread-goal-display.ts
+++ b/app/utils/thread-goal-display.ts
@@ -1,6 +1,10 @@
-import type { ThreadGoalStatus } from "~~/shared/types";
+import type { ThreadGoal, ThreadGoalStatus } from "~~/shared/types";
 
 export type ThreadGoalStatusControl = "pause" | "resume" | null;
+
+export function isThreadGoalOngoing(goal: ThreadGoal | null): goal is ThreadGoal {
+  return goal !== null && goal.status !== "complete";
+}
 
 export function threadGoalStatusControl(status: ThreadGoalStatus): ThreadGoalStatusControl {
   const controls: Record<ThreadGoalStatus, ThreadGoalStatusControl> = {

--- a/tests/e2e/thread-goal-plan.spec.ts
+++ b/tests/e2e/thread-goal-plan.spec.ts
@@ -263,10 +263,15 @@ test("goal progress updates the composer status strip without flooding the agent
     createdAt: new Date().toISOString(),
   });
 
-  await expect(page.getByTestId("composer-goal-summary")).toBeVisible();
-  await expect(page.getByTestId("composer-goal-summary").getByText("Complete")).toBeVisible();
+  await expect(page.getByTestId("composer-goal-summary")).toHaveCount(0);
+  await expect(page.getByTestId("composer-mode-strip")).toHaveCount(0);
   await expect(page.getByTestId("chat-scroll-area").getByText("目标已更新")).toHaveCount(0);
   await expect(goalCards).toHaveCount(0);
+
+  const composer = page.getByPlaceholder("输入后续修改要求");
+  await composer.fill("/goal");
+  await expect(page.getByTestId("slash-command-goal-objective")).toBeVisible();
+  await expect(page.getByTestId("slash-command-goal-edit")).toHaveCount(0);
 });
 
 test("goal snapshot updates only the composer status strip without fabricating history", async ({


### PR DESCRIPTION
## Summary
- hide completed Goals from the composer mode strip
- keep the complete app-server snapshot in Pinia while returning composer controls to normal conversation
- make `/goal` start a new objective after completion instead of editing the completed Goal

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (81 passed)