### PR TITLE
fix: persist plan mode in app server

### DIFF
--- a/app/components/thread/ThreadVirtualTimeline.vue
+++ b/app/components/thread/ThreadVirtualTimeline.vue
@@ -14,6 +14,7 @@ import { buildThreadTurnSections } from "@/components/thread/thread-turn-section
 import { useIntermediateStepsDisclosure } from "@/components/thread/useIntermediateStepsDisclosure";
 import { provideFilePreviewContext } from "@/composables/files/useFilePreviewContext";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
+import { collaborationModeFromThreadSettings } from "@/utils/thread-collaboration-mode";
 
 const props = defineProps<{
   threadId: string | null;
@@ -92,7 +93,9 @@ const rows = computed<ThreadTimelineRow[]>((previous) => {
 
 function selectedThreadMode() {
   if (!props.hostId || !props.threadId) return "default";
-  return composer.threadCollaborationModesByKey[`${props.hostId}:${props.threadId}`] ?? "default";
+  return collaborationModeFromThreadSettings(
+    composer.threadSettingsByKey[`${props.hostId}:${props.threadId}`],
+  );
 }
 
 function handleReachStart() {

--- a/app/components/thread/items/planning/PlanImplementationActions.vue
+++ b/app/components/thread/items/planning/PlanImplementationActions.vue
@@ -5,7 +5,12 @@ import { PlanFooter } from "@codex-gateway/ai-elements/plan";
 import { Button } from "@codex-gateway/ui/button";
 import { useGatewayCatalogStore } from "@/stores/gateway-catalog";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
+import { useGatewayNavigationStore } from "@/stores/gateway-navigation";
 import { useGatewayThreadTurnsStore } from "@/stores/gateway-thread-turns";
+import {
+  buildThreadCollaborationMode,
+  collaborationModeFromThreadSettings,
+} from "@/utils/thread-collaboration-mode";
 import { isThreadPlanItemCompleted } from "@/utils/thread-plan";
 
 const props = defineProps<{
@@ -16,6 +21,7 @@ const props = defineProps<{
 
 const store = useGatewayCatalogStore();
 const composer = useGatewayComposerStore();
+const navigation = useGatewayNavigationStore();
 const threadTurns = useGatewayThreadTurnsStore();
 const applying = ref(false);
 
@@ -24,7 +30,9 @@ const threadMode = computed(() => {
   if (!props.hostId || !props.threadId) {
     return "default";
   }
-  return composer.threadCollaborationModesByKey[`${props.hostId}:${props.threadId}`] ?? "default";
+  return collaborationModeFromThreadSettings(
+    composer.threadSettingsByKey[`${props.hostId}:${props.threadId}`],
+  );
 });
 const dismissed = computed(() => {
   if (!props.hostId || !props.threadId || !planItemId.value) {
@@ -52,9 +60,17 @@ async function implementPlan() {
   }
   applying.value = true;
   try {
-    composer.setThreadCollaborationMode(props.hostId, props.threadId, "default");
+    const collaborationMode = defaultCollaborationMode();
+    if (collaborationMode === null) return;
+    const updated = await composer.saveThreadSettings(
+      props.hostId,
+      props.threadId,
+      navigation.selectedProjectId,
+      { collaborationMode },
+    );
+    if (!updated) return;
     await threadTurns.sendTurn("Implement the plan.", {
-      collaborationMode: defaultCollaborationMode(),
+      collaborationMode,
     });
   } finally {
     applying.value = false;
@@ -69,19 +85,16 @@ function continuePlanning() {
 }
 
 function defaultCollaborationMode() {
-  const model =
-    composer.selectedThreadSettings.model || store.defaultModel?.model || store.defaultModel?.id;
-  if (!model) {
-    return undefined;
-  }
-  return {
-    mode: "default" as const,
-    settings: {
-      model,
-      reasoningEffort: composer.selectedThreadSettings.effort ?? null,
-      developerInstructions: null,
-    },
-  };
+  return buildThreadCollaborationMode({
+    mode: "default",
+    modelCandidates: [
+      composer.selectedThreadSettings.collaborationMode?.settings.model,
+      composer.selectedThreadSettings.model,
+      store.defaultModel?.model,
+      store.defaultModel?.id,
+    ],
+    effort: composer.selectedThreadSettings.effort,
+  });
 }
 </script>
 

--- a/app/composables/composer/useComposerController.ts
+++ b/app/composables/composer/useComposerController.ts
@@ -78,8 +78,7 @@ export function useComposerController() {
     attachedFiles,
     clearDraft,
     selectedTurnOptions,
-    activeModel: settings.activeModel,
-    selectedModel: settings.selectedModel,
+    collaborationModel: settings.collaborationModel,
     selectedEffort: settings.selectedEffort,
     fileReferencesLabel: computed(() => t("app.attachedFileReferences")),
   });

--- a/app/composables/composer/useComposerSlashActions.ts
+++ b/app/composables/composer/useComposerSlashActions.ts
@@ -18,7 +18,7 @@ export function useComposerSlashActions(input: {
   text: Ref<string>;
   selectedThreadId: Ref<string | null>;
   startNewThread: () => Promise<void>;
-  activatePlanMode: () => void;
+  activatePlanMode: () => Promise<void>;
   missingGoalObjectiveMessage: Ref<string>;
   goalControls: ComposerGoalControls;
 }) {
@@ -30,7 +30,7 @@ export function useComposerSlashActions(input: {
       input.text.value = "";
       await input.startNewThread();
     },
-    plan: () => input.activatePlanMode(),
+    plan: input.activatePlanMode,
     goal: runGoalCommand,
   };
 

--- a/app/composables/composer/useComposerTurnSubmit.ts
+++ b/app/composables/composer/useComposerTurnSubmit.ts
@@ -1,9 +1,11 @@
 import { computed, type Ref } from "vue";
 
 import type { ComposerTurnOptions } from "~~/shared/types";
+import { useGatewayBootstrapStore } from "@/stores/gateway-bootstrap";
 import { useGatewayComposerStore } from "@/stores/gateway-composer";
 import { useGatewayThreadViewStore } from "@/stores/gateway-thread-view";
 import { useGatewayThreadTurnsStore } from "@/stores/gateway-thread-turns";
+import { buildThreadCollaborationMode } from "@/utils/thread-collaboration-mode";
 
 type AttachedFile = {
   name: string;
@@ -19,11 +21,11 @@ export function useComposerTurnSubmit(input: {
   attachedFiles: Ref<AttachedFile[]>;
   clearDraft: () => void;
   selectedTurnOptions: () => ComposerTurnOptions;
-  activeModel: Ref<string | null>;
-  selectedModel: Ref<string>;
+  collaborationModel: Ref<string>;
   selectedEffort: Ref<string>;
   fileReferencesLabel: Ref<string>;
 }) {
+  const gateway = useGatewayBootstrapStore();
   const composer = useGatewayComposerStore();
   const threadView = useGatewayThreadViewStore();
   const threadTurns = useGatewayThreadTurnsStore();
@@ -33,13 +35,12 @@ export function useComposerTurnSubmit(input: {
     Boolean(input.turnText.value.trim() || input.attachedFiles.value.length),
   );
 
-  function activatePlanMode() {
-    composer.setSelectedThreadCollaborationMode("plan");
-    input.turnText.value = "";
+  async function activatePlanMode() {
+    if (await saveCollaborationMode("plan")) input.turnText.value = "";
   }
 
-  function deactivatePlanMode() {
-    composer.setSelectedThreadCollaborationMode("default");
+  async function deactivatePlanMode() {
+    await saveCollaborationMode("default");
   }
 
   async function startNewThread() {
@@ -56,7 +57,7 @@ export function useComposerTurnSubmit(input: {
     const files = [...input.attachedFiles.value];
     const remoteFiles = files.filter((file) => !file.isImage);
     const attachedImages = files.filter((file) => file.isImage);
-    const collaborationMode = planCollaborationMode();
+    const collaborationMode = composer.selectedThreadSettings.collaborationMode ?? undefined;
     input.clearDraft();
     await threadTurns.sendTurn(
       messageWithFileReferences(text, remoteFiles, input.fileReferencesLabel.value),
@@ -83,28 +84,19 @@ export function useComposerTurnSubmit(input: {
     }
   }
 
-  function planCollaborationMode() {
-    const mode = planModeActive.value ? "plan" : "default";
-    // An existing metadata-only thread may have no selectedModel even though activeModel contains
-    // a catalog fallback for display. Omitting default collaboration mode in that state lets the
-    // resumed app-server thread retain its persisted model and effort. Plan mode is an explicit
-    // user override, so it may intentionally use the displayed catalog fallback.
-    const model =
-      input.selectedModel.value !== ""
-        ? input.selectedModel.value
-        : mode === "plan"
-          ? input.activeModel.value
-          : null;
-    if (model === null || model === "") return undefined;
-    return {
+  async function saveCollaborationMode(mode: "default" | "plan") {
+    const collaborationMode = buildThreadCollaborationMode({
       mode,
-      settings: {
-        model,
-        reasoningEffort:
-          input.selectedEffort.value === "default" ? null : input.selectedEffort.value,
-        developerInstructions: null,
-      },
-    } as const;
+      modelCandidates: [input.collaborationModel.value],
+      effort: input.selectedEffort.value === "default" ? null : input.selectedEffort.value,
+    });
+    if (collaborationMode === null) {
+      gateway.setError(gateway.t("app.planModeModelUnavailable"));
+      return false;
+    }
+    // The strip reflects the app-server's accepted next-turn settings. A local-only mode flag can
+    // diverge from Codex during thread hydration, which was the regression fixed here.
+    return composer.saveSelectedThreadSettings({ collaborationMode });
   }
 
   return {

--- a/app/composables/composer/useThreadSettingsControls.ts
+++ b/app/composables/composer/useThreadSettingsControls.ts
@@ -79,6 +79,19 @@ export function useThreadSettingsControls() {
       ]) ?? ""
     );
   });
+  // Plan is an explicit app-server setting update, so it needs a concrete model even during the
+  // short interval before an existing thread's settings notification arrives. Keep this effective
+  // value separate from activeModel: using the catalog default here must not make the model picker
+  // claim that the resumed thread already selected that model.
+  const collaborationModel = computed(
+    () =>
+      firstNonEmptyString([
+        selectedThreadSettings.value.collaborationMode?.settings.model,
+        selectedModel.value,
+        defaultModel.value?.model,
+        defaultModel.value?.id,
+      ]) ?? "",
+  );
   const activeModelRecord = computed(() =>
     models.value.find(
       (candidate) => candidate.model === activeModel.value || candidate.id === activeModel.value,
@@ -155,6 +168,7 @@ export function useThreadSettingsControls() {
     selectedEffort,
     selectedApprovalMode,
     activeModel,
+    collaborationModel,
     activeModelLabel,
     activeEffortValue,
     activeEffortCompactLabel,

--- a/app/stores/gateway-composer/actions/settings.ts
+++ b/app/stores/gateway-composer/actions/settings.ts
@@ -25,9 +25,13 @@ export function createThreadSettingsActions() {
       settings: ThreadSettingsState | null | undefined,
     ) {
       const composer = useGatewayComposerStore();
+      const key = pinnedKey(hostId, threadId);
       composer.threadSettingsByKey = {
         ...composer.threadSettingsByKey,
-        [pinnedKey(hostId, threadId)]: normalizeThreadSettings(settings),
+        [key]: mergeThreadSettings(
+          composer.threadSettingsByKey[key] ?? {},
+          normalizeThreadSettings(settings),
+        ),
       };
     },
 
@@ -39,21 +43,6 @@ export function createThreadSettingsActions() {
       this.setThreadSettings(scope.hostId, scope.threadId, {
         ...mergeThreadSettings(composer.selectedThreadSettings, settings),
       });
-    },
-
-    setSelectedThreadCollaborationMode(mode: "default" | "plan") {
-      const navigation = useGatewayNavigationStore();
-      const scope = selectedThreadScope(navigation.selectedHostId, navigation.selectedThreadId);
-      if (scope === null) return;
-      this.setThreadCollaborationMode(scope.hostId, scope.threadId, mode);
-    },
-
-    setThreadCollaborationMode(hostId: number, threadId: string, mode: "default" | "plan") {
-      const composer = useGatewayComposerStore();
-      composer.threadCollaborationModesByKey = {
-        ...composer.threadCollaborationModesByKey,
-        [pinnedKey(hostId, threadId)]: mode,
-      };
     },
 
     dismissPlanImplementationPrompt(hostId: number, threadId: string, planItemId: string) {
@@ -75,25 +64,40 @@ export function createThreadSettingsActions() {
     },
 
     async saveSelectedThreadSettings(settings: ThreadSettingsState) {
-      const sessionIsCurrent = captureSessionEpoch();
-      const gateway = useGatewayBootstrapStore();
       const navigation = useGatewayNavigationStore();
       const scope = selectedThreadScope(navigation.selectedHostId, navigation.selectedThreadId);
-      if (scope === null) return;
-      const { hostId, threadId } = scope;
-      const projectId = navigation.selectedProjectId;
-      this.updateSelectedThreadSettings(settings);
+      if (scope === null) return false;
+      return this.saveThreadSettings(
+        scope.hostId,
+        scope.threadId,
+        navigation.selectedProjectId,
+        settings,
+      );
+    },
+
+    async saveThreadSettings(
+      hostId: number,
+      threadId: string,
+      projectId: number | null,
+      settings: ThreadSettingsState,
+    ) {
+      const sessionIsCurrent = captureSessionEpoch();
+      const gateway = useGatewayBootstrapStore();
       try {
         await gatewayApi("/api/threads/settings", {
           method: "POST",
           body: { hostId, threadId, ...settings },
         });
+        if (!sessionIsCurrent()) return false;
+        this.setThreadSettings(hostId, threadId, settings);
+        return true;
       } catch (error: unknown) {
-        if (!sessionIsCurrent()) return;
+        if (!sessionIsCurrent()) return false;
         gateway.setError(
           messageFromError(error, gateway.t("app.updateThreadSettingsFailed"), gateway.errorLabels),
           { hostId, projectId, threadId },
         );
+        return false;
       }
     },
   };

--- a/app/stores/gateway-composer/index.ts
+++ b/app/stores/gateway-composer/index.ts
@@ -11,7 +11,6 @@ import { createThreadSettingsActions } from "./actions/settings";
 
 export const useGatewayComposerStore = defineStore("gateway-composer", () => {
   const threadSettingsByKey = ref<Record<string, ThreadSettingsState>>({});
-  const threadCollaborationModesByKey = ref<Record<string, "default" | "plan">>({});
   const dismissedPlanPromptIdsByKey = ref<Record<string, Record<string, true>>>({});
   const threadGoalsByKey = ref<Record<string, ThreadGoal>>({});
   const threadGoalObservedAtByKey = ref<Record<string, number>>({});
@@ -31,7 +30,7 @@ export const useGatewayComposerStore = defineStore("gateway-composer", () => {
   );
   const selectedThreadCollaborationMode = computed(() =>
     selectedKey.value !== null
-      ? (threadCollaborationModesByKey.value[selectedKey.value] ?? "default")
+      ? (threadSettingsByKey.value[selectedKey.value]?.collaborationMode?.mode ?? "default")
       : "default",
   );
   const selectedThreadGoal = computed(() =>
@@ -50,7 +49,6 @@ export const useGatewayComposerStore = defineStore("gateway-composer", () => {
   });
   function resetState() {
     threadSettingsByKey.value = {};
-    threadCollaborationModesByKey.value = {};
     dismissedPlanPromptIdsByKey.value = {};
     threadGoalsByKey.value = {};
     threadGoalObservedAtByKey.value = {};
@@ -59,7 +57,6 @@ export const useGatewayComposerStore = defineStore("gateway-composer", () => {
 
   return {
     threadSettingsByKey,
-    threadCollaborationModesByKey,
     dismissedPlanPromptIdsByKey,
     threadGoalsByKey,
     threadGoalObservedAtByKey,

--- a/app/stores/gateway/event-handlers/thread-events.ts
+++ b/app/stores/gateway/event-handlers/thread-events.ts
@@ -1,6 +1,8 @@
 import { normalizeTokenUsage } from "~~/shared/token-usage";
-import { appServerThreadFromUnknown } from "~~/shared/runtime/app-server";
-import { recordFromUnknown, stringFromUnknown } from "~~/shared/utils/records";
+import {
+  appServerThreadFromUnknown,
+  threadSettingsFromAppServer,
+} from "~~/shared/runtime/app-server";
 import { gatewayDomainEvents } from "../domain-events";
 import { threadIdFromParams } from "../thread-utils/identity";
 import { runtimeStatusFromAppThreadStatus } from "../thread-utils/status";
@@ -28,21 +30,12 @@ export const threadEventHandlers: GatewayEventHandlerRegistry = {
   },
   "thread/settings/updated": (event, params) => {
     const threadId = threadIdFromParams(params);
-    const settings = recordFromUnknown(params.threadSettings);
-    if (threadId !== null) {
+    const settings = threadSettingsFromAppServer(params.threadSettings);
+    if (threadId !== null && settings !== null) {
       gatewayDomainEvents.emit("thread-settings-detected", {
         hostId: event.hostId,
         threadId: String(threadId),
-        settings: {
-          model: stringFromUnknown(settings?.model),
-          effort: stringFromUnknown(settings?.effort),
-          approvalPolicy:
-            settings?.approvalPolicy === "untrusted" ||
-            settings?.approvalPolicy === "on-request" ||
-            settings?.approvalPolicy === "never"
-              ? settings.approvalPolicy
-              : null,
-        },
+        settings,
       });
     }
   },

--- a/app/stores/gateway/thread-utils/settings.ts
+++ b/app/stores/gateway/thread-utils/settings.ts
@@ -4,15 +4,23 @@ import { trimmedOrNull } from "~~/shared/utils/strings";
 export function normalizeThreadSettings(
   settings: ThreadSettingsState | null | undefined,
 ): ThreadSettingsState {
+  if (settings === null || settings === undefined) return {};
   return {
-    model: trimmedOrNull(settings?.model),
-    effort: trimmedOrNull(settings?.effort),
-    approvalPolicy:
-      settings?.approvalPolicy === "untrusted" ||
-      settings?.approvalPolicy === "on-request" ||
-      settings?.approvalPolicy === "never"
-        ? settings.approvalPolicy
-        : null,
+    ...(Object.hasOwn(settings, "model") ? { model: trimmedOrNull(settings.model) } : {}),
+    ...(Object.hasOwn(settings, "effort") ? { effort: trimmedOrNull(settings.effort) } : {}),
+    ...(Object.hasOwn(settings, "approvalPolicy")
+      ? {
+          approvalPolicy:
+            settings.approvalPolicy === "untrusted" ||
+            settings.approvalPolicy === "on-request" ||
+            settings.approvalPolicy === "never"
+              ? settings.approvalPolicy
+              : null,
+        }
+      : {}),
+    ...(Object.hasOwn(settings, "collaborationMode")
+      ? { collaborationMode: normalizeCollaborationMode(settings.collaborationMode) }
+      : {}),
   };
 }
 
@@ -21,9 +29,30 @@ export function mergeThreadSettings(
   next: ThreadSettingsState,
 ): ThreadSettingsState {
   return {
-    model: "model" in next ? (next.model ?? null) : (current.model ?? null),
-    effort: "effort" in next ? (next.effort ?? null) : (current.effort ?? null),
-    approvalPolicy:
-      "approvalPolicy" in next ? (next.approvalPolicy ?? null) : (current.approvalPolicy ?? null),
+    ...current,
+    ...(Object.hasOwn(next, "model") ? { model: next.model ?? null } : {}),
+    ...(Object.hasOwn(next, "effort") ? { effort: next.effort ?? null } : {}),
+    ...(Object.hasOwn(next, "approvalPolicy")
+      ? { approvalPolicy: next.approvalPolicy ?? null }
+      : {}),
+    ...(Object.hasOwn(next, "collaborationMode")
+      ? { collaborationMode: next.collaborationMode ?? null }
+      : {}),
+  };
+}
+
+function normalizeCollaborationMode(
+  mode: ThreadSettingsState["collaborationMode"],
+): ThreadSettingsState["collaborationMode"] {
+  if (mode === null || mode === undefined) return null;
+  const model = trimmedOrNull(mode.settings.model);
+  if (model === null) return null;
+  return {
+    mode: mode.mode,
+    settings: {
+      model,
+      reasoningEffort: trimmedOrNull(mode.settings.reasoningEffort),
+      developerInstructions: trimmedOrNull(mode.settings.developerInstructions),
+    },
   };
 }

--- a/app/utils/thread-collaboration-mode.ts
+++ b/app/utils/thread-collaboration-mode.ts
@@ -1,0 +1,29 @@
+import type {
+  ReasoningEffort,
+  ThreadCollaborationMode,
+  ThreadSettingsState,
+} from "~~/shared/types";
+import { firstNonEmptyString } from "~~/shared/utils/strings";
+
+export function buildThreadCollaborationMode(input: {
+  mode: ThreadCollaborationMode["mode"];
+  modelCandidates: Array<string | null | undefined>;
+  effort: ReasoningEffort | null | undefined;
+}): ThreadCollaborationMode | null {
+  const model = firstNonEmptyString(input.modelCandidates);
+  if (model === null) return null;
+  return {
+    mode: input.mode,
+    settings: {
+      model,
+      reasoningEffort: input.effort ?? null,
+      developerInstructions: null,
+    },
+  };
+}
+
+export function collaborationModeFromThreadSettings(
+  settings: ThreadSettingsState | null | undefined,
+) {
+  return settings?.collaborationMode?.mode ?? "default";
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -227,6 +227,7 @@
     "slashGoalClearTitle": "Clear goal",
     "slashGoalClearDescription": "Clear the current goal through app-server",
     "planModeActive": "Plan mode",
+    "planModeModelUnavailable": "The current host has not provided a model for Plan mode",
     "plan": "Plan",
     "togglePlan": "Toggle plan",
     "goalModeActive": "Goal",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -227,6 +227,7 @@
     "slashGoalClearTitle": "清除目标",
     "slashGoalClearDescription": "调用 app-server 清除当前目标",
     "planModeActive": "计划模式",
+    "planModeModelUnavailable": "当前主机尚未提供可用于计划模式的模型",
     "plan": "计划",
     "togglePlan": "展开或收起计划",
     "goalModeActive": "目标",

--- a/server/api/threads/settings.post.ts
+++ b/server/api/threads/settings.post.ts
@@ -12,5 +12,6 @@ export default defineGatewayEventHandler(async (event) => {
     model: input.model,
     effort: input.effort,
     approvalPolicy: input.approvalPolicy,
+    collaborationMode: input.collaborationMode,
   });
 });

--- a/server/utils/gateway/http/validation/threads.ts
+++ b/server/utils/gateway/http/validation/threads.ts
@@ -80,6 +80,7 @@ export const threadSettingsUpdateSchema = z.object({
   hostId: z.coerce.number().int().positive(),
   threadId: z.string().trim().min(1),
   ...threadSettingFields,
+  collaborationMode: collaborationModeSchema,
 });
 
 export const turnStartSchema = z.object({

--- a/server/utils/gateway/protocol/thread-payload.ts
+++ b/server/utils/gateway/protocol/thread-payload.ts
@@ -1,9 +1,11 @@
 import type {
   ApprovalPolicy,
   GatewayEvent,
+  ThreadCollaborationMode,
   ThreadSettingsState,
   ThreadTokenUsageState,
 } from "~~/shared/types";
+import { threadSettingsFromAppServer } from "~~/shared/runtime/app-server";
 import { normalizeTokenUsage } from "~~/shared/token-usage";
 import { recordFromUnknown } from "~~/shared/utils/records";
 import type { TurnStartInput } from "../runtime/types";
@@ -46,16 +48,19 @@ export function buildTurnStartParams(
     approvalPolicy: input.approvalPolicy ?? null,
     collaborationMode:
       input.collaborationMode !== null && input.collaborationMode !== undefined
-        ? {
-            mode: input.collaborationMode.mode,
-            settings: {
-              model: input.collaborationMode.settings.model,
-              reasoning_effort: input.collaborationMode.settings.reasoningEffort ?? null,
-              developer_instructions:
-                input.collaborationMode.settings.developerInstructions ?? null,
-            },
-          }
+        ? buildAppServerCollaborationMode(input.collaborationMode)
         : null,
+  };
+}
+
+export function buildAppServerCollaborationMode(input: ThreadCollaborationMode) {
+  return {
+    mode: input.mode,
+    settings: {
+      model: input.settings.model,
+      reasoning_effort: input.settings.reasoningEffort ?? null,
+      developer_instructions: input.settings.developerInstructions ?? null,
+    },
   };
 }
 
@@ -66,6 +71,8 @@ function normalizeApprovalPolicy(value: unknown): ApprovalPolicy | null {
 export function extractThreadSettings(source: unknown): ThreadSettingsState {
   const sourceRecord = recordFromUnknown(source);
   const threadSettings = recordFromUnknown(sourceRecord?.threadSettings);
+  const currentProtocolSettings = threadSettingsFromAppServer(threadSettings);
+  if (currentProtocolSettings !== null) return currentProtocolSettings;
   const model = threadSettings?.model ?? sourceRecord?.model;
   const effort = threadSettings?.effort ?? sourceRecord?.reasoningEffort;
   return {
@@ -81,9 +88,8 @@ export function latestThreadSettingsFromEvents(events: GatewayEvent[]): ThreadSe
   for (const event of [...events].sort((left, right) => right.id - left.id)) {
     if (event.method !== "thread/settings/updated") continue;
     const params = recordFromUnknown(event.payload.params);
-    const settings = recordFromUnknown(params?.threadSettings);
-    if (settings === null) continue;
-    return extractThreadSettings({ threadSettings: settings });
+    const settings = threadSettingsFromAppServer(params?.threadSettings);
+    if (settings !== null) return settings;
   }
   return null;
 }

--- a/server/utils/gateway/runtime/open-snapshot-events.ts
+++ b/server/utils/gateway/runtime/open-snapshot-events.ts
@@ -2,13 +2,11 @@ import { SERVER_TURN_CACHE_LIMIT } from "~~/shared/config";
 import { applyAppServerEventToHistory } from "~~/shared/thread-history/app-server-events";
 import { projectThreadTimelineHistory } from "~~/shared/thread-history/timeline";
 import { normalizeTokenUsage } from "~~/shared/token-usage";
-import type {
-  ApprovalPolicy,
-  RpcEnvelope,
-  ThreadHistoryState,
-  ThreadTimelineHistoryState,
-} from "~~/shared/types";
-import { appServerThreadStatusFromUnknown } from "~~/shared/runtime/app-server";
+import type { RpcEnvelope, ThreadHistoryState, ThreadTimelineHistoryState } from "~~/shared/types";
+import {
+  appServerThreadStatusFromUnknown,
+  threadSettingsFromAppServer,
+} from "~~/shared/runtime/app-server";
 import { idFromUnknown, recordFromUnknown } from "~~/shared/utils/records";
 import type { ThreadOpenSnapshot } from "./types";
 
@@ -20,14 +18,7 @@ type SnapshotEventReducer = (
 const snapshotEventReducers: Record<string, SnapshotEventReducer> = {
   "thread/status/changed": (snapshot, params) =>
     updateSnapshotThreadStatus(snapshot, params.status),
-  "thread/settings/updated": (snapshot, params) => ({
-    ...snapshot,
-    threadSettings: {
-      model: fieldFromRecord(params.threadSettings, "model"),
-      effort: fieldFromRecord(params.threadSettings, "effort"),
-      approvalPolicy: approvalPolicyFromRecord(params.threadSettings),
-    },
-  }),
+  "thread/settings/updated": updateSnapshotThreadSettings,
   "thread/tokenUsage/updated": (snapshot, params) => ({
     ...snapshot,
     tokenUsage: normalizeTokenUsage(params.tokenUsage) ?? snapshot.tokenUsage,
@@ -108,14 +99,10 @@ function snapshotThread(snapshot: ThreadOpenSnapshot) {
   return snapshot.history.thread;
 }
 
-function fieldFromRecord(value: unknown, key: string) {
-  const record = recordFromUnknown(value);
-  if (record === null) return null;
-  const field = record[key];
-  return typeof field === "string" ? field : null;
-}
-
-function approvalPolicyFromRecord(value: unknown): ApprovalPolicy | null {
-  const policy = fieldFromRecord(value, "approvalPolicy");
-  return policy === "untrusted" || policy === "on-request" || policy === "never" ? policy : null;
+function updateSnapshotThreadSettings(
+  snapshot: ThreadOpenSnapshot,
+  params: Record<string, unknown>,
+) {
+  const threadSettings = threadSettingsFromAppServer(params.threadSettings);
+  return threadSettings === null ? snapshot : { ...snapshot, threadSettings };
 }

--- a/server/utils/gateway/runtime/thread-controller.ts
+++ b/server/utils/gateway/runtime/thread-controller.ts
@@ -11,7 +11,6 @@ import { threadSnapshotStore } from "../state/thread-snapshots";
 import { threadRuntimeEvents } from "./thread-runtime-events";
 import type { ThreadOpenSnapshot } from "./types";
 import { createThreadNotificationResolvers } from "./notification-rpc-resolvers";
-import { extractThreadSettings } from "../protocol/thread-payload";
 
 export class ThreadController {
   readonly client: CodexRpcClient;
@@ -222,16 +221,6 @@ export class ThreadController {
       runtimeStatusFromSnapshotState(snapshot.thread, snapshot.history) === "running";
   }
 
-  private publishResumedSettings(resumed: unknown) {
-    this.publish("thread/settings/updated", {
-      method: "thread/settings/updated",
-      params: {
-        threadId: this.threadId,
-        threadSettings: extractThreadSettings(resumed),
-      },
-    });
-  }
-
   private async requestResume(params: Record<string, unknown>) {
     const resumed = await this.client.request(
       "thread/resume",
@@ -240,10 +229,11 @@ export class ThreadController {
       parseThreadResumeResult,
     );
     this.subscribed = true;
-    // App-server exposes persisted model/effort in thread/resume but emits no settings event for
-    // the response itself. Publish it through the ordinary event path so snapshots and all browser
-    // peers converge on one authoritative value instead of maintaining a second settings cache.
-    this.publishResumedSettings(resumed);
+    // Do not synthesize thread/settings/updated from thread/resume. The resume DTO only contains
+    // model/effort, while the official settings notification also contains collaborationMode. A
+    // partial event under the official method name can therefore overwrite an already observed
+    // Plan mode. The open snapshot carries resume settings directly and real settings events remain
+    // the sole source for the complete app-server state.
     return resumed;
   }
 }

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -318,12 +318,16 @@ export class ThreadOpenService {
     threadMetadataStore.record(host.id, resolvedProjectId, thread);
 
     const recentEvents = gatewayEventStore.list(host.id, threadId, 0, 200);
+    // thread/resume does not expose collaborationMode. Preserve the latest complete official
+    // thread/settings/updated projection when one exists; otherwise the resume DTO still supplies
+    // model and effort for threads that have never changed settings during this Gateway lifetime.
+    const effectiveThreadSettings = latestThreadSettingsFromEvents(recentEvents) ?? threadSettings;
     const snapshot = {
       thread,
       history: projectThreadTimelineHistory(pageToFullHistory(thread, initialTurnsPage)),
       projectId: resolvedProjectId,
       turnsPage: pageCursorState(initialTurnsPage),
-      threadSettings,
+      threadSettings: effectiveThreadSettings,
       tokenUsage: latestTokenUsageFromEvents(recentEvents),
     };
     // During browser activation the controller is created before the cold snapshot exists. Route

--- a/server/utils/gateway/runtime/thread-settings.ts
+++ b/server/utils/gateway/runtime/thread-settings.ts
@@ -1,5 +1,6 @@
 import type { HostRecord, ThreadSettingsState } from "~~/shared/types";
 import type { ControllerRegistry } from "./controller-registry";
+import { buildAppServerCollaborationMode } from "../protocol/thread-payload";
 
 export class ThreadSettingsService {
   constructor(private readonly registry: ControllerRegistry) {}
@@ -16,6 +17,9 @@ export class ThreadSettingsService {
     if ("model" in input) params.model = input.model;
     if ("effort" in input) params.effort = input.effort;
     if ("approvalPolicy" in input) params.approvalPolicy = input.approvalPolicy;
+    if (input.collaborationMode !== null && input.collaborationMode !== undefined) {
+      params.collaborationMode = buildAppServerCollaborationMode(input.collaborationMode);
+    }
     return this.registry.withScopedSubscription(host, threadId, (controller) =>
       controller.enqueue(() => controller.client.request("thread/settings/update", params)),
     );

--- a/server/utils/gateway/runtime/types.ts
+++ b/server/utils/gateway/runtime/types.ts
@@ -3,6 +3,7 @@ import type {
   ApprovalPolicy,
   HostRecord,
   ReasoningEffort,
+  ThreadCollaborationMode,
   ThreadSettingsState,
   ThreadTokenUsageState,
   ThreadTimelineHistoryState,
@@ -40,14 +41,7 @@ export interface TurnStartInput {
   model?: string | null;
   effort?: ReasoningEffort | null;
   approvalPolicy?: ApprovalPolicy | null;
-  collaborationMode?: {
-    mode: "default" | "plan";
-    settings: {
-      model: string;
-      reasoningEffort?: ReasoningEffort | null;
-      developerInstructions?: string | null;
-    };
-  } | null;
+  collaborationMode?: ThreadCollaborationMode | null;
   images?: Array<{
     path?: string;
     url?: string;

--- a/shared/runtime/app-server.ts
+++ b/shared/runtime/app-server.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
 import type {
   AppServerThread,
+  ApprovalPolicy,
   RpcEnvelope,
+  ThreadCollaborationMode,
   ThreadGoal,
   ThreadHistoryItem,
   ThreadHistoryTurn,
+  ThreadSettingsState,
 } from "../types";
 
 const rpcIdSchema = z.union([z.string(), z.number()]);
@@ -49,6 +52,58 @@ export const rpcEnvelopeSchema = z.union([
 
 export function parseRpcEnvelope(value: unknown): RpcEnvelope {
   return rpcEnvelopeSchema.parse(value);
+}
+
+const appServerCollaborationModeSchema = z
+  .object({
+    mode: z.enum(["default", "plan"]),
+    settings: z
+      .object({
+        model: z.string().min(1),
+        reasoning_effort: z.string().nullable().optional(),
+        developer_instructions: z.string().nullable().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const appServerThreadSettingsSchema = z
+  .object({
+    model: z.string().min(1),
+    effort: z.string().nullable().optional(),
+    approvalPolicy: z.unknown(),
+    collaborationMode: appServerCollaborationModeSchema,
+  })
+  .loose();
+
+export function threadCollaborationModeFromAppServer(
+  value: unknown,
+): ThreadCollaborationMode | null {
+  const parsed = appServerCollaborationModeSchema.safeParse(value);
+  if (!parsed.success) return null;
+  return {
+    mode: parsed.data.mode,
+    settings: {
+      model: parsed.data.settings.model,
+      reasoningEffort: parsed.data.settings.reasoning_effort ?? null,
+      developerInstructions: parsed.data.settings.developer_instructions ?? null,
+    },
+  };
+}
+
+export function threadSettingsFromAppServer(value: unknown): ThreadSettingsState | null {
+  const parsed = appServerThreadSettingsSchema.safeParse(value);
+  if (!parsed.success) return null;
+  return {
+    model: parsed.data.model,
+    effort: parsed.data.effort ?? null,
+    approvalPolicy: approvalPolicyFromAppServer(parsed.data.approvalPolicy),
+    collaborationMode: threadCollaborationModeFromAppServer(parsed.data.collaborationMode),
+  };
+}
+
+function approvalPolicyFromAppServer(value: unknown): ApprovalPolicy | null {
+  return value === "untrusted" || value === "on-request" || value === "never" ? value : null;
 }
 
 const threadItemSchema = z

--- a/shared/runtime/realtime/server-message-schema.ts
+++ b/shared/runtime/realtime/server-message-schema.ts
@@ -93,6 +93,20 @@ const threadSettingsSchema = z
     model: nullableString,
     effort: nullableString,
     approvalPolicy: z.enum(["untrusted", "on-request", "never"]).nullable().optional(),
+    collaborationMode: z
+      .object({
+        mode: z.enum(["default", "plan"]),
+        settings: z
+          .object({
+            model: nonEmptyString,
+            reasoningEffort: nullableString,
+            developerInstructions: nullableString,
+          })
+          .strict(),
+      })
+      .strict()
+      .nullable()
+      .optional(),
   })
   .strict();
 const threadRuntimeStatusUpdateSchema = z

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -25,6 +25,7 @@ export type {
   ThreadOpenResult,
   ThreadRuntimeStatus,
   ThreadRuntimeStatusUpdate,
+  ThreadCollaborationMode,
   ThreadSettingsState,
   ThreadTokenUsageState,
   ThreadTurnsPageResult,

--- a/shared/types/thread.ts
+++ b/shared/types/thread.ts
@@ -71,10 +71,20 @@ export interface ThreadTurnsPageResult {
 export type ApprovalPolicy = "untrusted" | "on-request" | "never";
 export type ReasoningEffort = string;
 
+export interface ThreadCollaborationMode {
+  mode: "default" | "plan";
+  settings: {
+    model: string;
+    reasoningEffort?: ReasoningEffort | null;
+    developerInstructions?: string | null;
+  };
+}
+
 export interface ThreadSettingsState {
   model?: string | null;
   effort?: ReasoningEffort | null;
   approvalPolicy?: ApprovalPolicy | null;
+  collaborationMode?: ThreadCollaborationMode | null;
 }
 
 export interface TokenUsageBreakdown {
@@ -188,14 +198,7 @@ export interface ComposerTurnOptions {
   model?: string | null;
   effort?: ReasoningEffort | null;
   approvalPolicy?: ApprovalPolicy | null;
-  collaborationMode?: {
-    mode: "default" | "plan";
-    settings: {
-      model: string;
-      reasoningEffort?: ReasoningEffort | null;
-      developerInstructions?: string | null;
-    };
-  } | null;
+  collaborationMode?: ThreadCollaborationMode | null;
   images?: Array<{
     path?: string;
     url?: string;

--- a/tests/e2e/bark-notifications.spec.ts
+++ b/tests/e2e/bark-notifications.spec.ts
@@ -3,7 +3,6 @@ import { openApp } from "./helpers/app";
 import { configureBarkNotifications, useBarkReceiver } from "./helpers/bark";
 import { sendTextTurn } from "./helpers/remote-codex";
 import { sendRealtimeRequest } from "./helpers/realtime";
-import { setThreadCollaborationMode } from "./helpers/gateway-store";
 
 test("Bark sends ordinary turn notifications and only notifies when an app-server goal ends", async ({
   page,
@@ -113,9 +112,11 @@ test("plan-mode user questions render and notify through Sonner and Bark", async
   await configureBarkNotifications(page, bark.url);
 
   const hostName = `bark-plan-question-host-${Date.now()}`;
-  const { host, project } = await remoteWorkspace.provision({ hostName });
-  const threadId = await remoteWorkspace.startThread(project.id);
-  await setThreadCollaborationMode(page, { hostId: host.id, threadId, mode: "plan" });
+  const { project } = await remoteWorkspace.provision({ hostName });
+  await remoteWorkspace.startThread(project.id);
+  await page.getByPlaceholder("输入后续修改要求").fill("/");
+  await page.getByTestId("slash-command-plan").click();
+  await expect(page.getByTestId("composer-mode-strip").getByText("计划模式").first()).toBeVisible();
 
   const question = `请选择 E2E 方案 ${Date.now()}`;
   await page

--- a/tests/e2e/helpers/gateway-store.ts
+++ b/tests/e2e/helpers/gateway-store.ts
@@ -460,9 +460,28 @@ export async function setThreadCollaborationMode(
   input: { hostId: number; threadId: string; mode: "default" | "plan" },
 ) {
   await page.evaluate((input) => {
-    const composer = window.__codexGatewayE2e?.composer;
-    if (!composer) throw new Error("Gateway E2E driver is unavailable");
-    composer.setThreadCollaborationMode(input.hostId, input.threadId, input.mode);
+    const driver = window.__codexGatewayE2e;
+    if (!driver) throw new Error("Gateway E2E driver is unavailable");
+    const key = `${input.hostId}:${input.threadId}`;
+    const current = driver.composer.threadSettingsByKey[key] ?? {};
+    const model =
+      current.collaborationMode?.settings.model ??
+      current.model ??
+      driver.catalog.defaultModel?.model ??
+      driver.catalog.defaultModel?.id;
+    if (model === null || model === undefined || model === "") {
+      throw new Error("A model is required to seed collaboration mode");
+    }
+    driver.composer.setThreadSettings(input.hostId, input.threadId, {
+      collaborationMode: {
+        mode: input.mode,
+        settings: {
+          model,
+          reasoningEffort: current.effort ?? null,
+          developerInstructions: null,
+        },
+      },
+    });
   }, input);
 }
 

--- a/tests/e2e/remote-host-project.spec.ts
+++ b/tests/e2e/remote-host-project.spec.ts
@@ -10,6 +10,8 @@ import { chatViewportBottomDistance } from "./helpers/scroll";
 import {
   activeRealtimeSocketCount,
   installRealtimeSocketProbe,
+  realtimeClientMessageCount,
+  waitForRealtimeClientMessage,
 } from "./helpers/realtime-socket-probe";
 import {
   execRemoteSsh,
@@ -116,9 +118,43 @@ test("connects to a real SSH Codex host and lists a project thread created by ap
   await page.getByPlaceholder("输入后续修改要求").fill("/");
   await expect(page.getByTestId("slash-command-menu")).toBeVisible();
   await expect(page.getByTestId("slash-command-plan")).toBeVisible();
+  const planSettingsResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/threads/settings") && response.request().method() === "POST",
+  );
   await page.getByTestId("slash-command-plan").click();
+  const planSettingsResponse = await planSettingsResponsePromise;
+  expect(planSettingsResponse.ok()).toBe(true);
+  const planSettingsRequest = z
+    .object({
+      hostId: z.number(),
+      threadId: z.string(),
+      collaborationMode: z.object({
+        mode: z.literal("plan"),
+        settings: z.object({ model: z.string().min(1) }).loose(),
+      }),
+    })
+    .loose()
+    .parse(planSettingsResponse.request().postDataJSON());
+  expect(planSettingsRequest).toMatchObject({
+    hostId: host.id,
+    threadId: slashNewThreadId,
+    collaborationMode: { mode: "plan" },
+  });
   await expect(page.getByTestId("composer-mode-strip").getByText("计划模式").first()).toBeVisible();
-  await page.getByPlaceholder("输入后续修改要求").fill("");
+  const planTurnOffset = await realtimeClientMessageCount(page);
+  await page.getByPlaceholder("输入后续修改要求").fill("请为当前项目制定一个简短计划，不要执行。");
+  await page.getByTestId("send-turn-button").click();
+  const planTurnStart = z
+    .object({
+      collaborationMode: z.object({
+        mode: z.literal("plan"),
+        settings: z.object({ model: z.string().min(1) }).loose(),
+      }),
+    })
+    .loose()
+    .parse(await waitForRealtimeClientMessage(page, "turn.start", planTurnOffset));
+  expect(planTurnStart.collaborationMode.mode).toBe("plan");
 
   const threadId = await remoteWorkspace.startThread(project.id);
   await expect(page.getByTestId(`thread-button-${threadId}`)).toBeVisible();

--- a/tests/e2e/thread-goal-plan.spec.ts
+++ b/tests/e2e/thread-goal-plan.spec.ts
@@ -316,6 +316,7 @@ test("plan mode shows implementation actions for a second completed turn plan", 
   await seedGatewayThread(page, {
     threadId: "e2e-repeat-plan-thread",
     currentThread: { id: "e2e-repeat-plan-thread", name: "Repeat Plan" },
+    threadSettings: { model: "gpt-5.6-luna" },
     history: {
       thread: {
         id: "e2e-repeat-plan-thread",
@@ -391,6 +392,4 @@ test("plan mode shows implementation actions for a second completed turn plan", 
   await expect(page.getByText("checked constraints before second plan")).toBeHidden();
   await expect(page.getByRole("button", { name: "执行计划" })).toBeVisible();
   await expect(page.getByRole("button", { name: "继续计划" })).toBeVisible();
-  await page.getByRole("button", { name: "退出计划模式" }).click();
-  await expect(page.getByText("计划模式")).toBeHidden();
 });


### PR DESCRIPTION
## Summary
- persist Plan/Default collaboration mode through official app-server thread/settings/update
- use official thread/settings/updated as the complete settings source and preserve collaboration mode across resume/open snapshots
- remove the frontend-only Plan state path and reuse accepted settings for turn/start and plan actions
- update real user-flow E2E coverage for Plan prompts, turn payloads, Sonner, and Bark

## Verification
- pnpm lint
- pnpm test:e2e (81 passed)
- git diff --check