### PR TITLE
feat: color goal banner by status

### DIFF
--- a/app/components/chat/composer/ComposerGoalDetailsDialog.vue
+++ b/app/components/chat/composer/ComposerGoalDetailsDialog.vue
@@ -24,7 +24,11 @@ import {
 } from "@codex-gateway/ui/dialog";
 import { ScrollArea } from "@codex-gateway/ui/scroll-area";
 import { Textarea } from "@codex-gateway/ui/textarea";
-import { goalStatusI18nKey, threadGoalStatusControl } from "@/utils/thread-goal-display";
+import {
+  goalStatusI18nKey,
+  threadGoalStatusControl,
+  threadGoalStatusPresentation,
+} from "@/utils/thread-goal-display";
 
 const props = defineProps<{
   goal: ThreadGoal;
@@ -48,6 +52,7 @@ const { t } = useI18n();
 const normalizedObjective = computed(() => objectiveDraft.value.trim());
 const statusControl = computed(() => threadGoalStatusControl(props.goal.status));
 const statusLabel = computed(() => t(goalStatusI18nKey(props.goal.status)));
+const statusPresentation = computed(() => threadGoalStatusPresentation(props.goal.status));
 const canSave = computed(
   () =>
     props.pendingAction === null &&
@@ -92,11 +97,15 @@ watch(
       <button
         type="button"
         data-testid="composer-goal-summary"
-        class="flex w-full min-w-0 items-center gap-3 rounded-2xl border border-primary/20 bg-primary/5 px-3 py-2 text-left text-sm text-ink shadow-sm shadow-ink/5 transition hover:border-primary/40 hover:bg-primary/10 md:text-base"
+        :data-goal-status="goal.status"
+        class="flex w-full min-w-0 items-center gap-3 rounded-2xl border px-3 py-2 text-left text-sm text-ink shadow-sm shadow-ink/5 transition md:text-base"
+        :class="statusPresentation.triggerClass"
       >
-        <span class="shrink-0 font-medium text-primary">{{ $t("app.goalModeActive") }}</span>
+        <span class="shrink-0 font-medium" :class="statusPresentation.labelClass">
+          {{ $t("app.goalModeActive") }}
+        </span>
         <span class="min-w-0 flex-1 truncate text-ink-secondary">{{ goal.objective }}</span>
-        <Badge variant="outline" class="shrink-0 border-primary/30 bg-surface/70 text-primary">
+        <Badge variant="outline" class="shrink-0" :class="statusPresentation.badgeClass">
           {{ statusLabel }}
         </Badge>
         <span

--- a/app/utils/thread-goal-display.ts
+++ b/app/utils/thread-goal-display.ts
@@ -2,6 +2,52 @@ import type { ThreadGoal, ThreadGoalStatus } from "~~/shared/types";
 
 export type ThreadGoalStatusControl = "pause" | "resume" | null;
 
+export interface ThreadGoalStatusPresentation {
+  triggerClass: string;
+  labelClass: string;
+  badgeClass: string;
+}
+
+// Keep the strip, title, and badge on one semantic palette. A status update then changes the
+// whole affordance atomically instead of leaving a red badge inside an apparently active strip.
+const THREAD_GOAL_STATUS_PRESENTATION = {
+  active: {
+    triggerClass: "border-primary/25 bg-primary/5 hover:border-primary/45 hover:bg-primary/10",
+    labelClass: "text-primary",
+    badgeClass: "border-primary/30 bg-primary/10 text-primary",
+  },
+  paused: {
+    triggerClass:
+      "border-ink-faint/30 bg-ink-faint/10 hover:border-ink-faint/50 hover:bg-ink-faint/15",
+    labelClass: "text-ink-muted",
+    badgeClass: "border-ink-faint/35 bg-ink-faint/10 text-ink-muted",
+  },
+  blocked: {
+    triggerClass:
+      "border-destructive/30 bg-destructive/10 hover:border-destructive/50 hover:bg-destructive/15",
+    labelClass: "text-destructive",
+    badgeClass: "border-destructive/35 bg-destructive/10 text-destructive",
+  },
+  usageLimited: {
+    triggerClass:
+      "border-accent-orange/30 bg-accent-orange/10 hover:border-accent-orange/50 hover:bg-accent-orange/15",
+    labelClass: "text-accent-orange-deep",
+    badgeClass: "border-accent-orange/35 bg-accent-orange/10 text-accent-orange-deep",
+  },
+  budgetLimited: {
+    triggerClass:
+      "border-accent-brown/30 bg-accent-brown/10 hover:border-accent-brown/50 hover:bg-accent-brown/15",
+    labelClass: "text-accent-brown",
+    badgeClass: "border-accent-brown/35 bg-accent-brown/10 text-accent-brown",
+  },
+  complete: {
+    triggerClass:
+      "border-accent-green/30 bg-accent-green/10 hover:border-accent-green/50 hover:bg-accent-green/15",
+    labelClass: "text-accent-green",
+    badgeClass: "border-accent-green/35 bg-accent-green/10 text-accent-green",
+  },
+} satisfies Record<ThreadGoalStatus, ThreadGoalStatusPresentation>;
+
 export function isThreadGoalOngoing(goal: ThreadGoal | null): goal is ThreadGoal {
   return goal !== null && goal.status !== "complete";
 }
@@ -28,6 +74,12 @@ export function goalStatusI18nKey(status: ThreadGoalStatus) {
     complete: "app.goalStatusComplete",
   };
   return keys[status];
+}
+
+export function threadGoalStatusPresentation(
+  status: ThreadGoalStatus,
+): ThreadGoalStatusPresentation {
+  return THREAD_GOAL_STATUS_PRESENTATION[status];
 }
 
 export function formatGoalElapsed(seconds: number) {

--- a/tests/e2e/thread-goal-plan.spec.ts
+++ b/tests/e2e/thread-goal-plan.spec.ts
@@ -226,12 +226,14 @@ test("goal progress updates the composer status strip without flooding the agent
   });
 
   const strip = page.getByTestId("composer-mode-strip");
+  const goalSummary = page.getByTestId("composer-goal-summary");
   await expect(strip.getByText(/持续 \*\*重构\*\* 输入框状态/).first()).toBeVisible();
   await expect(strip.getByText(/256 tokens/).first()).toBeVisible();
+  await expect(goalSummary).toHaveAttribute("data-goal-status", "active");
   const goalCards = page.getByTestId("thread-goal-item");
   await expect(goalCards).toHaveCount(0);
   await expect(page.locator(".thread-user-message", { hasText: "/goal 持续" })).toHaveCount(0);
-  await page.getByTestId("composer-goal-summary").click();
+  await goalSummary.click();
   const goalDialog = page.getByRole("dialog");
   await expect(goalDialog.getByText("目标详情")).toBeVisible();
   await expect(goalDialog.locator(".markdown-content strong").getByText("重构")).toBeVisible();
@@ -240,6 +242,34 @@ test("goal progress updates the composer status strip without flooding the agent
 
   await applyGatewayLiveEvent(page, {
     id: 303,
+    hostId: 1,
+    threadId,
+    method: "thread/goal/updated",
+    payload: {
+      method: "thread/goal/updated",
+      params: {
+        threadId,
+        turnId: "turn-goal-progress",
+        goal: {
+          threadId,
+          objective: goalObjective,
+          status: "blocked",
+          tokenBudget: null,
+          tokensUsed: 384,
+          timeUsedSeconds: 6,
+          createdAt: goalCreatedAt,
+          updatedAt: Date.now(),
+        },
+      },
+    },
+    createdAt: new Date().toISOString(),
+  });
+
+  await expect(goalSummary).toHaveAttribute("data-goal-status", "blocked");
+  await expect(goalSummary).toHaveClass(/bg-destructive\/10/);
+
+  await applyGatewayLiveEvent(page, {
+    id: 304,
     hostId: 1,
     threadId,
     method: "thread/goal/updated",


### PR DESCRIPTION
## Summary
- apply semantic colors to the Goal composer banner by app-server status
- keep strip, title, and status badge on one centralized palette
- cover active, blocked, and completed realtime transitions in the existing Goal E2E flow

## Verification
- pnpm lint
- pnpm test:e2e
- git diff --check