### PR TITLE
fix: stabilize browser preview sessions

### DIFF
--- a/app/components/browser/BrowserPreviewPanel.vue
+++ b/app/components/browser/BrowserPreviewPanel.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
 import { ExternalLinkIcon, LoaderCircleIcon, RefreshCwIcon, ShieldAlertIcon } from "@lucide/vue";
+import {
+  WebPreview,
+  WebPreviewBody,
+  WebPreviewNavigation,
+  WebPreviewNavigationButton,
+  WebPreviewUrl,
+} from "@codex-gateway/ai-elements/web-preview";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
-import { Button } from "@codex-gateway/ui/button";
 import { useGatewayBrowserStore } from "@/stores/gateway-browser";
 import { openBrowserPreview } from "@/stores/gateway-browser/transport";
 import { setBrowserPreviewInsecureTls } from "@/stores/gateway-browser/transport";
@@ -10,15 +16,29 @@ import { setBrowserPreviewInsecureTls } from "@/stores/gateway-browser/transport
 const props = defineProps<{ panelId: string }>();
 const browser = useGatewayBrowserStore();
 const { panels, sessions, frameWarnings } = storeToRefs(browser);
-const iframe = ref<HTMLIFrameElement | null>(null);
 const opening = ref(false);
 const error = ref("");
+const frameKey = ref(0);
+const frameUrl = ref("");
 const panel = computed(() => panels.value[props.panelId] ?? null);
 const session = computed(() =>
   Object.values(sessions.value).find((item) => item.panelId === props.panelId),
 );
 const warning = computed(() =>
   session.value ? frameWarnings.value[session.value.sessionId] : undefined,
+);
+
+watch(
+  session,
+  (activeSession) => {
+    if (activeSession === undefined) {
+      frameUrl.value = "";
+      return;
+    }
+    frameUrl.value = activeSession.bootstrapUrl;
+    frameKey.value += 1;
+  },
+  { immediate: true },
 );
 
 watch(
@@ -39,11 +59,9 @@ watch(
 );
 
 function reload() {
-  if (!iframe.value || !session.value) return;
-  iframe.value.src = "about:blank";
-  void nextTick(() => {
-    if (iframe.value && session.value) iframe.value.src = previewTargetUrl(session.value);
-  });
+  if (!session.value) return;
+  frameUrl.value = previewTargetUrl(session.value);
+  frameKey.value += 1;
 }
 
 function previewTargetUrl(activeSession: NonNullable<typeof session.value>) {
@@ -59,47 +77,37 @@ async function toggleInsecureTls() {
 </script>
 
 <template>
-  <section class="flex h-full min-h-0 flex-col overflow-hidden bg-surface">
-    <div class="flex h-10 shrink-0 items-center gap-2 border-b border-hairline px-2">
-      <Button
-        variant="ghost"
-        size="icon"
-        class="size-8"
-        :aria-label="$t('app.reload')"
-        @click="reload"
-      >
+  <WebPreview
+    :default-url="panel?.targetUrl ?? ''"
+    class="h-full min-h-0 overflow-hidden rounded-none border-0 bg-surface"
+  >
+    <WebPreviewNavigation class="h-10 shrink-0 gap-2 border-hairline px-2 py-0">
+      <WebPreviewNavigationButton :tooltip="$t('app.reload')" @click="reload">
         <RefreshCwIcon class="size-4" />
-      </Button>
-      <div
-        class="min-w-0 flex-1 truncate rounded-md bg-canvas-soft px-3 py-1 text-sm text-ink-muted"
-      >
-        {{ panel?.targetUrl }}
-      </div>
-      <Button
+      </WebPreviewNavigationButton>
+      <WebPreviewUrl
+        class="min-w-0 bg-canvas-soft text-ink-muted"
+        :aria-label="$t('app.browserAddress')"
+        readonly
+      />
+      <WebPreviewNavigationButton
         v-if="session && session.targetUrl.startsWith('https://')"
-        variant="ghost"
-        size="icon"
-        class="size-8"
         :class="session.allowInsecureTls ? 'text-warning' : ''"
-        :aria-label="$t('app.allowInsecureTls')"
-        :title="$t('app.allowInsecureTls')"
+        :tooltip="$t('app.allowInsecureTls')"
         @click="toggleInsecureTls"
       >
         <ShieldAlertIcon class="size-4" />
-      </Button>
-      <Button
+      </WebPreviewNavigationButton>
+      <WebPreviewNavigationButton
         v-if="session"
         as="a"
-        :href="session.previewOrigin"
+        :href="previewTargetUrl(session)"
         target="_blank"
-        variant="ghost"
-        size="icon"
-        class="size-8"
-        :aria-label="$t('app.openExternally')"
+        :tooltip="$t('app.openExternally')"
       >
         <ExternalLinkIcon class="size-4" />
-      </Button>
-    </div>
+      </WebPreviewNavigationButton>
+    </WebPreviewNavigation>
     <div
       v-if="warning"
       class="flex items-center gap-2 border-b border-warning/30 bg-warning/10 px-3 py-2 text-sm"
@@ -116,13 +124,13 @@ async function toggleInsecureTls() {
     <div v-else-if="error" class="grid min-h-0 flex-1 place-items-center p-6 text-sm text-danger">
       {{ error }}
     </div>
-    <iframe
+    <WebPreviewBody
       v-else-if="session"
-      ref="iframe"
-      :src="session.bootstrapUrl"
-      class="min-h-0 flex-1 border-0 bg-white"
+      :key="frameKey"
+      :src="frameUrl"
+      class="bg-white"
       :title="panel?.title"
       allow="clipboard-read; clipboard-write; fullscreen"
     />
-  </section>
+  </WebPreview>
 </template>

--- a/app/stores/gateway-browser/transport.ts
+++ b/app/stores/gateway-browser/transport.ts
@@ -2,10 +2,8 @@ import type { BrowserPreviewTarget } from "~~/shared/types";
 import { useGatewayBrowserStore } from "./index";
 import { useGatewayRealtimeStore } from "../gateway-realtime";
 import { expectBrowserOpened } from "../gateway-realtime/response-parsers";
-import { captureSessionEpoch } from "@/utils/session-epoch";
 
 export async function openBrowserPreview(input: BrowserPreviewTarget) {
-  const sessionIsCurrent = captureSessionEpoch();
   // Browser panels also carry UI-only fields such as `title`. TypeScript's structural typing
   // permits those objects at this call site, so project the official wire target explicitly.
   // Do not loosen the realtime parser: strict protocol boundaries are what catch accidental UI
@@ -16,7 +14,9 @@ export async function openBrowserPreview(input: BrowserPreviewTarget) {
     expectBrowserOpened,
     30_000,
   );
-  if (sessionIsCurrent()) useGatewayBrowserStore().upsertSession(response.session);
+  // browser.opened is projected into Pinia by the realtime domain subscriber before the request
+  // broker resolves this promise. Writing the same session here as well recreates a declarative
+  // iframe src during its one-time ticket exchange, so keep one event-owned state boundary.
   return response.session;
 }
 
@@ -39,7 +39,6 @@ export async function closeBrowserPreview(sessionId: string) {
 }
 
 export async function setBrowserPreviewInsecureTls(sessionId: string, allowInsecureTls: boolean) {
-  const sessionIsCurrent = captureSessionEpoch();
   const response = await useGatewayRealtimeStore().request(
     (requestId) => ({
       type: "browser.allowInsecureTls",
@@ -49,6 +48,5 @@ export async function setBrowserPreviewInsecureTls(sessionId: string, allowInsec
     }),
     expectBrowserOpened,
   );
-  if (sessionIsCurrent()) useGatewayBrowserStore().upsertSession(response.session);
   return response.session;
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -178,6 +178,7 @@
     "tmuxReasonCancelled": "Cancelled",
     "browserTargetHint": "The address is reached from the selected remote host; localhost refers to that host.",
     "browserFrameBlocked": "The remote page security policy may prevent embedded display.",
+    "browserAddress": "Preview address",
     "allowInsecureTls": "Allow insecure TLS for this preview",
     "openExternally": "Open externally",
     "reload": "Reload",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -178,6 +178,7 @@
     "tmuxReasonCancelled": "已取消",
     "browserTargetHint": "该地址从所选远程主机访问，例如 localhost 指向远程主机本身。",
     "browserFrameBlocked": "远程页面的安全策略可能禁止内嵌显示。",
+    "browserAddress": "预览地址",
     "allowInsecureTls": "允许此预览使用不安全 TLS",
     "openExternally": "外部打开",
     "reload": "重新加载",

--- a/packages/gateway-ai-elements/src/web-preview/WebPreviewBody.vue
+++ b/packages/gateway-ai-elements/src/web-preview/WebPreviewBody.vue
@@ -21,9 +21,9 @@ const frameSrc = computed(() => (props.src ?? url.value) || undefined);
 </script>
 
 <template>
-  <div class="flex-1">
+  <div class="min-h-0 flex-1">
     <iframe
-      :class="cn('size-full', props.class)"
+      :class="cn('block size-full border-0', props.class)"
       sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
       :src="frameSrc"
       title="Preview"

--- a/server/utils/gateway/browser-preview/browser-preview-http-agent.ts
+++ b/server/utils/gateway/browser-preview/browser-preview-http-agent.ts
@@ -3,13 +3,30 @@ import type { Duplex } from "node:stream";
 
 export class BrowserPreviewHttpAgent extends Agent {
   constructor(private readonly connectUpstream: () => Promise<Duplex>) {
-    // Browser pages fetch HTML, scripts, stylesheets, images, and API data in parallel. Reusing a
-    // bounded pool here reuses SSH forwardOut channels as ordinary HTTP keep-alive sockets; it
-    // does not create additional ssh2 Client connections.
+    // This is one bounded HTTP pool per preview session. Resource count does not determine the
+    // number of SSH channels: Node queues requests above maxSockets and keeps at most two idle
+    // channels. Every channel is still multiplexed over the one shared ssh2 Client.
     super({ keepAlive: true, maxSockets: 6, maxFreeSockets: 2 });
   }
 
-  override connect() {
-    return this.connectUpstream();
+  override async connect() {
+    return decorateSshHttpStream(await this.connectUpstream());
   }
 }
+
+function decorateSshHttpStream(stream: Duplex) {
+  // Follow ssh2's official HTTPAgent adapter. ClientChannel implements Duplex but not the
+  // net.Socket controls that Node's keep-alive lifecycle invokes. Supplying these no-op controls
+  // lets the standard Agent pool and reuse channels without pretending to configure TCP beneath
+  // SSH. Do not disable pooling here: that would open one forwardOut channel per page resource.
+  return Object.assign(stream, {
+    setKeepAlive: noopSocketControl,
+    setNoDelay: noopSocketControl,
+    setTimeout: noopSocketControl,
+    ref: noopSocketControl,
+    unref: noopSocketControl,
+    destroySoon: () => stream.destroy(),
+  });
+}
+
+function noopSocketControl() {}

--- a/server/utils/gateway/browser-preview/browser-preview-manager.ts
+++ b/server/utils/gateway/browser-preview/browser-preview-manager.ts
@@ -36,7 +36,10 @@ export class BrowserPreviewManager {
     const sessionId = randomUUID();
     const ticket = randomBytes(32).toString("base64url");
     const cookieToken = randomBytes(32).toString("base64url");
-    const previewOrigin = previewOriginFor(userId, host.id, target);
+    // Each preview session needs its own origin. A host + target origin is not unique enough:
+    // opening two panels for the same remote service would make their HttpOnly cookies replace
+    // each other and route one iframe through the other panel's SSH session.
+    const previewOrigin = previewOriginFor(userId, host.id, target, sessionId);
     const session: BrowserPreviewSession = {
       sessionId,
       ownerId,
@@ -57,19 +60,44 @@ export class BrowserPreviewManager {
     return this.snapshot(session);
   }
 
-  exchangeTicket(hostname: string, ticket: string) {
+  exchangeTicket(
+    hostname: string,
+    ticket: string,
+    sessionId: string,
+    cookieToken: string | undefined,
+  ) {
     const session = this.tickets.get(ticket);
-    this.tickets.delete(ticket);
+    if (session !== undefined) {
+      this.tickets.delete(ticket);
+      if (
+        session.sessionId !== sessionId ||
+        session.status !== "open" ||
+        session.ticketExpiresAt < Date.now() ||
+        new URL(session.previewOrigin).hostname !== hostname
+      ) {
+        return null;
+      }
+      this.sessionsByCookie.set(session.cookieToken, session);
+      return { cookieToken: session.cookieToken, path: initialPath(session.target) };
+    }
+
+    // Dockview may destroy and recreate an iframe while moving or restoring a panel. The iframe
+    // then reloads its original bootstrap URL even though that one-time ticket was already
+    // exchanged. Re-entry is allowed only when the browser presents the HttpOnly cookie issued by
+    // the first exchange and all session coordinates still match. Do not make tickets reusable:
+    // without the cookie, a consumed or expired ticket remains invalid.
+    const cookieSession = this.resolve(hostname, cookieToken);
     if (
-      session === undefined ||
-      session.status !== "open" ||
-      session.ticketExpiresAt < Date.now()
+      cookieSession === null ||
+      cookieSession.sessionId !== sessionId ||
+      cookieSession.ticket !== ticket
     ) {
       return null;
     }
-    if (new URL(session.previewOrigin).hostname !== hostname) return null;
-    this.sessionsByCookie.set(session.cookieToken, session);
-    return { cookieToken: session.cookieToken, path: initialPath(session.target) };
+    return {
+      cookieToken: cookieSession.cookieToken,
+      path: initialPath(cookieSession.target),
+    };
   }
 
   resolve(hostname: string, cookieToken: string | undefined) {
@@ -143,7 +171,7 @@ export class BrowserPreviewManager {
       ...session.targetConfig,
       sessionId: session.sessionId,
       previewOrigin: session.previewOrigin,
-      bootstrapUrl: `${session.previewOrigin}/_gateway/preview/bootstrap#${session.ticket}`,
+      bootstrapUrl: `${session.previewOrigin}/_gateway/preview/bootstrap?sessionId=${encodeURIComponent(session.sessionId)}#${session.ticket}`,
       status: session.status,
     };
   }
@@ -163,7 +191,7 @@ function normalizeTarget(value: string) {
   return target;
 }
 
-function previewHostname(userId: number, hostId: number, target: URL) {
+function previewHostname(userId: number, hostId: number, target: URL, sessionId: string) {
   const secret = firstNonEmptyString([
     process.env.BROWSER_PREVIEW_SECRET,
     process.env.CODEX_GATEWAY_CONFIG_SECRET,
@@ -171,7 +199,7 @@ function previewHostname(userId: number, hostId: number, target: URL) {
   ]);
   if (secret === null) throw new Error("Browser preview secret is not configured");
   const digest = createHmac("sha256", secret)
-    .update(`${userId}:${hostId}:${target.origin}`)
+    .update(`${userId}:${hostId}:${target.origin}:${sessionId}`)
     .digest("hex")
     .slice(0, 32);
   const domain = trimmedOrFallback(process.env.BROWSER_PREVIEW_DOMAIN, "cloudawn.top");
@@ -183,10 +211,10 @@ export function isBrowserPreviewHostname(hostname: string) {
   return new RegExp(`^p-[0-9a-f]{32}\\.${escapeRegExp(domain)}$`, "i").test(hostname);
 }
 
-function previewOriginFor(userId: number, hostId: number, target: URL) {
+function previewOriginFor(userId: number, hostId: number, target: URL, sessionId: string) {
   const scheme = trimmedOrFallback(process.env.BROWSER_PREVIEW_SCHEME, "https");
   const port = process.env.BROWSER_PREVIEW_PUBLIC_PORT;
-  return `${scheme}://${previewHostname(userId, hostId, target)}${port === undefined || port === "" ? "" : `:${port}`}`;
+  return `${scheme}://${previewHostname(userId, hostId, target, sessionId)}${port === undefined || port === "" ? "" : `:${port}`}`;
 }
 
 function initialPath(target: URL) {

--- a/server/utils/gateway/browser-preview/browser-preview-proxy.ts
+++ b/server/utils/gateway/browser-preview/browser-preview-proxy.ts
@@ -12,10 +12,11 @@ import {
   browserPreviewTargetPort,
   browserPreviewUpstreamConnector,
 } from "./browser-preview-upstream-connector";
+import { runtimeLog } from "../runtime/runtime-log";
 
 const BOOTSTRAP_PATH = "/_gateway/preview/bootstrap";
 const SESSION_PATH = "/_gateway/preview/session";
-const ticketRequestSchema = z.object({ ticket: z.string().min(1) });
+const ticketRequestSchema = z.object({ ticket: z.string().min(1), sessionId: z.uuid() }).strict();
 
 export async function handleBrowserPreviewRequest(
   request: IncomingMessage,
@@ -23,11 +24,15 @@ export async function handleBrowserPreviewRequest(
 ) {
   try {
     const hostname = requestHostname(request);
-    if (request.url === BOOTSTRAP_PATH && request.method === "GET") {
+    // Match only the pathname for Gateway-owned control routes. The bootstrap carries sessionId
+    // in its query string, while ordinary preview requests must retain their complete URL when
+    // forwarded upstream.
+    const pathname = requestPathname(request);
+    if (pathname === BOOTSTRAP_PATH && request.method === "GET") {
       serveBootstrap(response);
       return;
     }
-    if (request.url === SESSION_PATH && request.method === "POST") {
+    if (pathname === SESSION_PATH && request.method === "POST") {
       await exchangeTicket(request, response, hostname);
       return;
     }
@@ -95,12 +100,30 @@ async function proxyHttpRequest(
     request.once("aborted", abortUpstream);
     response.once("close", abortUpstream);
     upstream.on("error", (error) => {
+      logUpstreamFailure(session, request, error);
       if (!response.headersSent) sendText(response, 502, `Remote preview failed: ${error.message}`);
       else response.destroy(error);
       finish();
     });
     if (request.method === "GET" || request.method === "HEAD") upstream.end();
     else request.pipe(upstream);
+  });
+}
+
+function logUpstreamFailure(
+  session: BrowserPreviewSession,
+  request: IncomingMessage,
+  error: Error,
+) {
+  runtimeLog("browser preview upstream failed", {
+    userId: session.userId,
+    hostId: session.host.id,
+    hostName: session.host.name,
+    sessionId: session.sessionId,
+    targetOrigin: session.target.origin,
+    requestMethod: request.method,
+    requestPath: request.url,
+    message: error.message,
   });
 }
 
@@ -180,7 +203,12 @@ async function exchangeTicket(
   hostname: string,
 ) {
   const body = ticketRequestSchema.parse(JSON.parse(await consumeText(request)));
-  const result = browserPreviewManager.exchangeTicket(hostname, body.ticket);
+  const result = browserPreviewManager.exchangeTicket(
+    hostname,
+    body.ticket,
+    body.sessionId,
+    readCookie(request, authCookieName()),
+  );
   if (result === null) {
     sendText(response, 401, "Invalid or expired browser preview ticket");
     return;
@@ -199,12 +227,16 @@ function serveBootstrap(response: ServerResponse) {
   response.setHeader("content-type", "text/html; charset=utf-8");
   response.setHeader("cache-control", "no-store");
   response.end(`<!doctype html><meta charset="utf-8"><title>Opening preview</title><script>
-const ticket=location.hash.slice(1);location.hash='';fetch('${SESSION_PATH}',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({ticket})}).then(async r=>{if(!r.ok)throw new Error(await r.text());return r.json()}).then(({path})=>location.replace(path)).catch(error=>document.body.textContent=error.message)
+const ticket=location.hash.slice(1);const sessionId=new URL(location.href).searchParams.get('sessionId');location.hash='';fetch('${SESSION_PATH}',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({ticket,sessionId})}).then(async r=>{if(!r.ok)throw new Error(await r.text());return r.json()}).then(({path})=>location.replace(path)).catch(error=>document.body.textContent=error.message)
 </script>`);
 }
 
 function requestHostname(request: IncomingMessage) {
   return (String(request.headers.host ?? "").split(":", 1)[0] ?? "").toLowerCase();
+}
+
+function requestPathname(request: IncomingMessage) {
+  return new URL(request.url ?? "/", "http://browser-preview.invalid").pathname;
 }
 
 export function readPreviewCookie(value: string | undefined) {

--- a/tests/e2e/browser-preview.spec.ts
+++ b/tests/e2e/browser-preview.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "./fixtures/remote-workspace";
 import { openApp, reloadApp } from "./helpers/app";
-import { startRemotePreviewServer } from "./helpers/remote-codex";
+import { selectSidebarThread, startRemotePreviewServer } from "./helpers/remote-codex";
 
 test("opens a real remote HTTP and WebSocket service through the SSH preview proxy", async ({
   page,
@@ -8,7 +8,11 @@ test("opens a real remote HTTP and WebSocket service through the SSH preview pro
 }) => {
   const { remote } = remoteWorkspace;
   await openApp(page);
-  await remoteWorkspace.addHost(`preview-host-${Date.now()}`);
+  const host = await remoteWorkspace.addHost(`preview-host-${Date.now()}`);
+  const project = await remoteWorkspace.addProject(host.id, `preview-project-${Date.now()}`);
+  const previewThreadId = await remoteWorkspace.startThread(project.id);
+  const otherThreadId = await remoteWorkspace.startThread(project.id);
+  await selectSidebarThread(page, previewThreadId);
   await startRemotePreviewServer(remote);
 
   await page.getByTestId("open-browser-button").click();
@@ -20,8 +24,19 @@ test("opens a real remote HTTP and WebSocket service through the SSH preview pro
   await expect(preview.getByRole("heading", { name: "remote-preview-page" })).toBeVisible({
     timeout: 30_000,
   });
+  await expect(preview.locator("#asset")).toHaveText("remote-preview-static-asset-ok");
   await expect(preview.locator("#http")).toHaveText("remote-preview-http-ok");
   await expect(preview.locator("#ws")).toHaveText("remote-preview-websocket");
+
+  // Switching thread scopes destroys the keyed Dockview tree. Returning recreates the iframe
+  // with its original bootstrap URL, matching normal desktop/mobile workspace navigation.
+  await selectSidebarThread(page, otherThreadId);
+  await selectSidebarThread(page, previewThreadId);
+  await page.getByRole("tab", { name: "localhost:4173" }).click();
+  await expect(preview.getByRole("heading", { name: "remote-preview-page" })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(preview.locator("#asset")).toHaveText("remote-preview-static-asset-ok");
 
   await reloadApp(page);
   await page.getByRole("tab", { name: "localhost:4173" }).click();

--- a/tests/e2e/docker/preview-server.mjs
+++ b/tests/e2e/docker/preview-server.mjs
@@ -7,9 +7,21 @@ const server = createServer((request, response) => {
     response.end(JSON.stringify({ message: "remote-preview-http-ok" }));
     return;
   }
+  if (request.url === "/preview-asset.js") {
+    response.setHeader("content-type", "text/javascript; charset=utf-8");
+    response.end("document.querySelector('#asset').textContent='remote-preview-static-asset-ok';");
+    return;
+  }
+  if (request.url === "/preview-style.css") {
+    response.setHeader("content-type", "text/css; charset=utf-8");
+    response.end("#asset { color: rgb(20, 120, 80); }");
+    return;
+  }
   response.setHeader("content-type", "text/html; charset=utf-8");
   response.end(`<!doctype html><meta charset="utf-8"><title>Remote Preview E2E</title>
-    <h1>remote-preview-page</h1><p id="http">loading</p><p id="ws">loading</p>
+    <link rel="stylesheet" href="/preview-style.css">
+    <h1>remote-preview-page</h1><p id="asset">loading</p><p id="http">loading</p><p id="ws">loading</p>
+    <script src="/preview-asset.js"></script>
     <script>
       fetch('/api/message').then(r=>r.json()).then(({message})=>document.querySelector('#http').textContent=message);
       const socket=new WebSocket((location.protocol==='https:'?'wss://':'ws://')+location.host+'/api/browser-preview/websocket?path=/socket');


### PR DESCRIPTION
## Summary
- migrate the Browser Preview shell to AI Elements WebPreview components
- use the standard bounded Node HTTP Agent pool with ssh2-compatible channel controls
- isolate preview cookies per session and permit authenticated Dockview iframe re-entry
- remove duplicate client session projection and add detailed upstream failure logs

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (81 passed)
- real preview coverage includes HTML, CSS, JavaScript, fetch, WebSocket, thread switching, and page reload