### PR TITLE
fix: proxy complete browser preview origins

### DIFF
--- a/app/components/browser/BrowserPreviewDiagnostics.vue
+++ b/app/components/browser/BrowserPreviewDiagnostics.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { AlertTriangleIcon, XIcon } from "@lucide/vue";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@codex-gateway/ui/alert";
+import { Button } from "@codex-gateway/ui/button";
+import type { BrowserPreviewResourceFailure } from "~~/shared/types";
+
+defineProps<{ failures: BrowserPreviewResourceFailure[] }>();
+defineEmits<{ dismiss: [] }>();
+</script>
+
+<template>
+  <Alert variant="destructive" class="shrink-0 rounded-none border-x-0 border-t-0 px-3 py-2 pr-12">
+    <AlertTriangleIcon />
+    <AlertTitle>{{ $t("app.browserResourceLoadFailed", { count: failures.length }) }}</AlertTitle>
+    <AlertDescription class="min-w-0 space-y-1">
+      <p>{{ $t("app.browserResourceLoadFailedHint") }}</p>
+      <div class="flex max-h-20 flex-col gap-0.5 overflow-auto font-mono">
+        <span v-for="failure in failures" :key="`${failure.statusCode}:${failure.path}`">
+          {{ failure.statusCode }} {{ failure.method }} {{ failure.path }}
+        </span>
+      </div>
+    </AlertDescription>
+    <AlertAction>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        :aria-label="$t('app.close')"
+        @click="$emit('dismiss')"
+      >
+        <XIcon class="size-4" />
+      </Button>
+    </AlertAction>
+  </Alert>
+</template>

--- a/app/components/browser/BrowserPreviewPanel.vue
+++ b/app/components/browser/BrowserPreviewPanel.vue
@@ -12,10 +12,11 @@ import { computed, ref, watch } from "vue";
 import { useGatewayBrowserStore } from "@/stores/gateway-browser";
 import { openBrowserPreview } from "@/stores/gateway-browser/transport";
 import { setBrowserPreviewInsecureTls } from "@/stores/gateway-browser/transport";
+import BrowserPreviewDiagnostics from "./BrowserPreviewDiagnostics.vue";
 
 const props = defineProps<{ panelId: string }>();
 const browser = useGatewayBrowserStore();
-const { panels, sessions, frameWarnings } = storeToRefs(browser);
+const { panels, sessions, frameWarnings, resourceFailures } = storeToRefs(browser);
 const opening = ref(false);
 const error = ref("");
 const frameKey = ref(0);
@@ -26,6 +27,9 @@ const session = computed(() =>
 );
 const warning = computed(() =>
   session.value ? frameWarnings.value[session.value.sessionId] : undefined,
+);
+const failures = computed(() =>
+  session.value ? (resourceFailures.value[session.value.sessionId] ?? []) : [],
 );
 
 watch(
@@ -60,6 +64,7 @@ watch(
 
 function reload() {
   if (!session.value) return;
+  browser.clearResourceFailures(session.value.sessionId);
   frameUrl.value = previewTargetUrl(session.value);
   frameKey.value += 1;
 }
@@ -118,6 +123,11 @@ async function toggleInsecureTls() {
         {{ $t("app.openExternally") }}
       </a>
     </div>
+    <BrowserPreviewDiagnostics
+      v-if="session && failures.length > 0"
+      :failures="failures"
+      @dismiss="browser.clearResourceFailures(session.sessionId)"
+    />
     <div v-if="opening" class="grid min-h-0 flex-1 place-items-center text-ink-muted">
       <LoaderCircleIcon class="size-5 animate-spin" />
     </div>

--- a/app/stores/gateway-browser/index.ts
+++ b/app/stores/gateway-browser/index.ts
@@ -1,5 +1,9 @@
 import { defineStore, skipHydrate } from "pinia";
-import type { BrowserPreviewSessionSnapshot, BrowserPreviewTarget } from "~~/shared/types";
+import type {
+  BrowserPreviewResourceFailure,
+  BrowserPreviewSessionSnapshot,
+  BrowserPreviewTarget,
+} from "~~/shared/types";
 import { useAccountLocalStorage } from "@/composables/storage/useAccountLocalStorage";
 
 export interface BrowserPanelState extends BrowserPreviewTarget {
@@ -10,6 +14,7 @@ export const useGatewayBrowserStore = defineStore("gateway-browser", () => {
   const panels = useAccountLocalStorage<Record<string, BrowserPanelState>>("browser-panels", {});
   const sessions = ref<Record<string, BrowserPreviewSessionSnapshot>>({});
   const frameWarnings = ref<Record<string, string>>({});
+  const resourceFailures = ref<Record<string, BrowserPreviewResourceFailure[]>>({});
 
   function addPanel(panel: BrowserPanelState) {
     panels.value = { ...panels.value, [panel.panelId]: panel };
@@ -41,10 +46,34 @@ export const useGatewayBrowserStore = defineStore("gateway-browser", () => {
     sessions.value = remaining;
     const { [sessionId]: _warning, ...warnings } = frameWarnings.value;
     frameWarnings.value = warnings;
+    clearResourceFailures(sessionId);
   }
 
   function setFrameWarning(sessionId: string, value: string) {
     frameWarnings.value = { ...frameWarnings.value, [sessionId]: value };
+  }
+
+  function addResourceFailure(sessionId: string, failure: BrowserPreviewResourceFailure) {
+    // Preview HTTP events are user-scoped, so other tabs receive them too. Keep diagnostics only
+    // in the page that owns the runtime session rather than accumulating unreachable session IDs.
+    if (sessions.value[sessionId] === undefined) return;
+    const previous = resourceFailures.value[sessionId] ?? [];
+    const duplicateIndex = previous.findIndex(
+      (item) =>
+        item.statusCode === failure.statusCode &&
+        item.method === failure.method &&
+        item.path === failure.path,
+    );
+    const withoutDuplicate = previous.filter((_, index) => index !== duplicateIndex);
+    resourceFailures.value = {
+      ...resourceFailures.value,
+      [sessionId]: [...withoutDuplicate, failure].slice(-5),
+    };
+  }
+
+  function clearResourceFailures(sessionId: string) {
+    const { [sessionId]: _failures, ...remaining } = resourceFailures.value;
+    resourceFailures.value = remaining;
   }
 
   function sessionForPanel(panelId: string) {
@@ -54,17 +83,21 @@ export const useGatewayBrowserStore = defineStore("gateway-browser", () => {
   function resetRuntime() {
     sessions.value = {};
     frameWarnings.value = {};
+    resourceFailures.value = {};
   }
 
   return {
     panels: skipHydrate(panels),
     sessions,
     frameWarnings,
+    resourceFailures,
     addPanel,
     removePanel,
     upsertSession,
     removeSession,
     setFrameWarning,
+    addResourceFailure,
+    clearResourceFailures,
     sessionForPanel,
     resetRuntime,
   };

--- a/app/stores/gateway-realtime/handlers/browser.ts
+++ b/app/stores/gateway-realtime/handlers/browser.ts
@@ -19,5 +19,7 @@ export function createBrowserRealtimeHandlers(ctx: RealtimeServerMessageHandlerC
     },
     "browser.framePolicyWarning": ({ sessionId, value }) =>
       gatewayDomainEvents.emit("realtime-browser-frame-warning", { sessionId, value }),
+    "browser.resourceFailed": ({ sessionId, failure }) =>
+      gatewayDomainEvents.emit("realtime-browser-resource-failed", { sessionId, failure }),
   } satisfies RealtimeHandlers;
 }

--- a/app/stores/gateway-realtime/server-message-handlers.ts
+++ b/app/stores/gateway-realtime/server-message-handlers.ts
@@ -49,6 +49,7 @@ export function createRealtimeServerMessageDispatcher(ctx: RealtimeServerMessage
       .with({ type: "browser.closed" }, browser["browser.closed"])
       .with({ type: "browser.error" }, browser["browser.error"])
       .with({ type: "browser.framePolicyWarning" }, browser["browser.framePolicyWarning"])
+      .with({ type: "browser.resourceFailed" }, browser["browser.resourceFailed"])
       .with({ type: "notification.published" }, notifications["notification.published"])
       .with({ type: "host.lifecycle" }, notifications["host.lifecycle"])
       .with({ type: "host.metrics.snapshot" }, hostMetrics["host.metrics.snapshot"])

--- a/app/stores/gateway/domain-events.ts
+++ b/app/stores/gateway/domain-events.ts
@@ -1,6 +1,7 @@
 import type {
   AppServerThread,
   BrowserPreviewSessionSnapshot,
+  BrowserPreviewResourceFailure,
   ThreadHistoryItem,
   ThreadHistoryTurn,
   RealtimeServerMessage,
@@ -50,6 +51,10 @@ export type GatewayDomainEventMap = {
   "realtime-browser-closed": { sessionId: string };
   "realtime-browser-error": { message: string };
   "realtime-browser-frame-warning": { sessionId: string; value: string };
+  "realtime-browser-resource-failed": {
+    sessionId: string;
+    failure: BrowserPreviewResourceFailure;
+  };
   "realtime-notification-published": {
     notification: ServerNotification;
     actionLabel: string;

--- a/app/stores/gateway/domain-subscribers/realtime-resources.ts
+++ b/app/stores/gateway/domain-subscribers/realtime-resources.ts
@@ -65,6 +65,9 @@ export function registerRealtimeResourceSubscribers() {
   gatewayDomainEvents.on("realtime-browser-frame-warning", ({ sessionId, value }) => {
     useGatewayBrowserStore().setFrameWarning(sessionId, value);
   });
+  gatewayDomainEvents.on("realtime-browser-resource-failed", ({ sessionId, failure }) => {
+    useGatewayBrowserStore().addResourceFailure(sessionId, failure);
+  });
   gatewayDomainEvents.on("realtime-notification-published", ({ notification, actionLabel }) => {
     projectPublishedNotification(notification);
     const action = notificationAction(notification);

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -178,6 +178,8 @@
     "tmuxReasonCancelled": "Cancelled",
     "browserTargetHint": "The address is reached from the selected remote host; localhost refers to that host.",
     "browserFrameBlocked": "The remote page security policy may prevent embedded display.",
+    "browserResourceLoadFailed": "{count} remote request failed | {count} remote requests failed",
+    "browserResourceLoadFailedHint": "A remote document, asset, or API request failed. These errors can leave the preview blank or incomplete.",
     "browserAddress": "Preview address",
     "allowInsecureTls": "Allow insecure TLS for this preview",
     "openExternally": "Open externally",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -178,6 +178,8 @@
     "tmuxReasonCancelled": "已取消",
     "browserTargetHint": "该地址从所选远程主机访问，例如 localhost 指向远程主机本身。",
     "browserFrameBlocked": "远程页面的安全策略可能禁止内嵌显示。",
+    "browserResourceLoadFailed": "远端页面有 {count} 个请求失败",
+    "browserResourceLoadFailedHint": "远端文档、资源或 API 请求失败，可能导致预览空白或内容不完整。",
     "browserAddress": "预览地址",
     "allowInsecureTls": "允许此预览使用不安全 TLS",
     "openExternally": "外部打开",

--- a/server/api/browser-preview/http.ts
+++ b/server/api/browser-preview/http.ts
@@ -1,0 +1,16 @@
+import { getRequestHost } from "h3";
+import { isBrowserPreviewHostname } from "../../utils/gateway/browser-preview/browser-preview-manager";
+import { handleBrowserPreviewRequest } from "../../utils/gateway/browser-preview/browser-preview-proxy";
+
+export default defineEventHandler(async (event) => {
+  const hostname = getRequestHost(event, { xForwardedHost: false }).split(":", 1)[0]!.toLowerCase();
+  if (!isBrowserPreviewHostname(hostname)) {
+    throw createError({ statusCode: 404, statusMessage: "Not Found" });
+  }
+
+  // In production nginx sends every preview-origin HTTP request through this explicit route.
+  // That routing happens before Nitro can mistake remote absolute assets such as /_nuxt/*.js for
+  // Codex Gateway's own public files. The original URI stays in X-Browser-Preview-Path and the
+  // same proxy handler used by development forwards the complete remote origin.
+  await handleBrowserPreviewRequest(event.node.req, event.node.res);
+});

--- a/server/utils/gateway/browser-preview/browser-preview-events.ts
+++ b/server/utils/gateway/browser-preview/browser-preview-events.ts
@@ -1,23 +1,39 @@
 import { EventEmitter } from "node:events";
 
 export interface BrowserFramePolicyEvent {
+  type: "frame-policy";
   userId: number;
   sessionId: string;
   policy: "x-frame-options" | "content-security-policy";
   value: string;
 }
 
+export interface BrowserResourceFailureEvent {
+  type: "resource-failed";
+  userId: number;
+  sessionId: string;
+  failure: {
+    statusCode: number;
+    method: string;
+    path: string;
+    destination: string;
+    occurredAt: string;
+  };
+}
+
+export type BrowserPreviewEvent = BrowserFramePolicyEvent | BrowserResourceFailureEvent;
+
 const events = new EventEmitter();
 
 export const browserPreviewEvents = {
-  publish(event: BrowserFramePolicyEvent) {
-    events.emit("frame-policy", event);
+  publish(event: BrowserPreviewEvent) {
+    events.emit("browser-preview", event);
   },
-  subscribe(userId: number, listener: (event: BrowserFramePolicyEvent) => void) {
-    const scoped = (event: BrowserFramePolicyEvent) => {
+  subscribe(userId: number, listener: (event: BrowserPreviewEvent) => void) {
+    const scoped = (event: BrowserPreviewEvent) => {
       if (event.userId === userId) listener(event);
     };
-    events.on("frame-policy", scoped);
-    return () => events.off("frame-policy", scoped);
+    events.on("browser-preview", scoped);
+    return () => events.off("browser-preview", scoped);
   },
 };

--- a/server/utils/gateway/browser-preview/browser-preview-proxy.ts
+++ b/server/utils/gateway/browser-preview/browser-preview-proxy.ts
@@ -79,7 +79,7 @@ async function proxyHttpRequest(
     const upstream = http.request(
       {
         method: request.method,
-        path: request.url,
+        path: browserPreviewRequestUrl(request),
         headers,
         agent,
         host: session.target.hostname,
@@ -87,6 +87,7 @@ async function proxyHttpRequest(
       },
       (incoming) => {
         upstreamResponse = incoming;
+        publishUpstreamFailureResponse(session, request, incoming.statusCode ?? 502);
         const responseHeaders = { ...incoming.headers };
         rewriteLocation(session, responseHeaders);
         stripCookieDomains(responseHeaders);
@@ -110,6 +111,43 @@ async function proxyHttpRequest(
   });
 }
 
+function publishUpstreamFailureResponse(
+  session: BrowserPreviewSession,
+  request: IncomingMessage,
+  statusCode: number,
+) {
+  if (statusCode < 400) return;
+  const method = request.method ?? "GET";
+  const path = requestPathname(request);
+  const destination = requestDestination(request);
+  const failure = {
+    statusCode,
+    method,
+    path,
+    destination,
+    occurredAt: new Date().toISOString(),
+  };
+  runtimeLog("browser preview upstream returned error", {
+    userId: session.userId,
+    hostId: session.host.id,
+    hostName: session.host.name,
+    projectId: session.targetConfig.projectId ?? null,
+    threadId: session.targetConfig.threadId ?? null,
+    sessionId: session.sessionId,
+    targetOrigin: session.target.origin,
+    ...failure,
+  });
+  // Do not filter on Sec-Fetch-Dest here. Reverse proxies are allowed to omit that optional header,
+  // and production nginx does so today; treating `unknown` as non-critical hid the exact script
+  // 404 that left the preview blank. The client bounds and deduplicates the per-session list.
+  browserPreviewEvents.publish({
+    type: "resource-failed",
+    userId: session.userId,
+    sessionId: session.sessionId,
+    failure,
+  });
+}
+
 function logUpstreamFailure(
   session: BrowserPreviewSession,
   request: IncomingMessage,
@@ -122,7 +160,7 @@ function logUpstreamFailure(
     sessionId: session.sessionId,
     targetOrigin: session.target.origin,
     requestMethod: request.method,
-    requestPath: request.url,
+    requestPath: browserPreviewRequestUrl(request),
     message: error.message,
   });
 }
@@ -180,6 +218,7 @@ function publishFramePolicy(session: BrowserPreviewSession, headers: http.Outgoi
   const xFrame = headers["x-frame-options"];
   if (typeof xFrame === "string" && !/^allowall$/i.test(xFrame)) {
     browserPreviewEvents.publish({
+      type: "frame-policy",
       userId: session.userId,
       sessionId: session.sessionId,
       policy: "x-frame-options",
@@ -189,12 +228,18 @@ function publishFramePolicy(session: BrowserPreviewSession, headers: http.Outgoi
   const csp = headers["content-security-policy"];
   if (typeof csp === "string" && /(?:^|;)\s*frame-ancestors\s+/i.test(csp)) {
     browserPreviewEvents.publish({
+      type: "frame-policy",
       userId: session.userId,
       sessionId: session.sessionId,
       policy: "content-security-policy",
       value: csp,
     });
   }
+}
+
+function requestDestination(request: IncomingMessage) {
+  const destination = request.headers["sec-fetch-dest"];
+  return typeof destination === "string" && destination !== "" ? destination : "unknown";
 }
 
 async function exchangeTicket(
@@ -236,7 +281,12 @@ function requestHostname(request: IncomingMessage) {
 }
 
 function requestPathname(request: IncomingMessage) {
-  return new URL(request.url ?? "/", "http://browser-preview.invalid").pathname;
+  return new URL(browserPreviewRequestUrl(request), "http://browser-preview.invalid").pathname;
+}
+
+function browserPreviewRequestUrl(request: IncomingMessage) {
+  const original = request.headers["x-browser-preview-path"];
+  return typeof original === "string" && original !== "" ? original : (request.url ?? "/");
 }
 
 export function readPreviewCookie(value: string | undefined) {

--- a/server/utils/gateway/realtime/handlers/browser-preview.ts
+++ b/server/utils/gateway/realtime/handlers/browser-preview.ts
@@ -79,11 +79,19 @@ export function subscribeBrowserPreviewEvents(peer: RealtimePeer) {
   state.browserPreviewUnsubscribe = browserPreviewEvents.subscribe(
     authenticatedUserId(peer),
     (event) => {
+      if (event.type === "frame-policy") {
+        sendRealtimePeerMessage(peer, {
+          type: "browser.framePolicyWarning",
+          sessionId: event.sessionId,
+          policy: event.policy,
+          value: event.value,
+        });
+        return;
+      }
       sendRealtimePeerMessage(peer, {
-        type: "browser.framePolicyWarning",
+        type: "browser.resourceFailed",
         sessionId: event.sessionId,
-        policy: event.policy,
-        value: event.value,
+        failure: event.failure,
       });
     },
   );

--- a/shared/runtime/realtime/server-message-schema.ts
+++ b/shared/runtime/realtime/server-message-schema.ts
@@ -553,6 +553,21 @@ export const realtimeServerMessageSchema: z.ZodType<RealtimeServerMessage> = z.d
       .strict(),
     z
       .object({
+        type: z.literal("browser.resourceFailed"),
+        sessionId: nonEmptyString,
+        failure: z
+          .object({
+            statusCode: z.number().int().min(400).max(599),
+            method: nonEmptyString,
+            path: nonEmptyString,
+            destination: nonEmptyString,
+            occurredAt: nonEmptyString,
+          })
+          .strict(),
+      })
+      .strict(),
+    z
+      .object({
         type: z.literal("error"),
         message: z.string(),
         requestId: z.string().optional(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -34,7 +34,11 @@ export type {
 } from "./types/thread";
 export type { ModelListResult, ModelRecord } from "./types/models";
 export type { TerminalOpenTarget, TerminalScope, TerminalSessionSnapshot } from "./types/terminal";
-export type { BrowserPreviewSessionSnapshot, BrowserPreviewTarget } from "./types/browser";
+export type {
+  BrowserPreviewResourceFailure,
+  BrowserPreviewSessionSnapshot,
+  BrowserPreviewTarget,
+} from "./types/browser";
 export type {
   TmuxMonitor,
   TmuxMonitorCompletionReason,

--- a/shared/types/browser.ts
+++ b/shared/types/browser.ts
@@ -13,3 +13,11 @@ export interface BrowserPreviewSessionSnapshot extends BrowserPreviewTarget {
   bootstrapUrl: string;
   status: "open" | "closed";
 }
+
+export interface BrowserPreviewResourceFailure {
+  statusCode: number;
+  method: string;
+  path: string;
+  destination: string;
+  occurredAt: string;
+}

--- a/shared/types/realtime.ts
+++ b/shared/types/realtime.ts
@@ -9,7 +9,11 @@ import type {
 } from "./thread";
 import type { ApprovalPolicy, ReasoningEffort } from "./thread";
 import type { TerminalOpenTarget, TerminalSessionSnapshot } from "./terminal";
-import type { BrowserPreviewSessionSnapshot, BrowserPreviewTarget } from "./browser";
+import type {
+  BrowserPreviewResourceFailure,
+  BrowserPreviewSessionSnapshot,
+  BrowserPreviewTarget,
+} from "./browser";
 import type { ServerNotification } from "./notifications";
 import type {
   HostGpuProcessSnapshot,
@@ -381,6 +385,11 @@ export type RealtimeServerMessage =
       sessionId: string;
       policy: "x-frame-options" | "content-security-policy";
       value: string;
+    }
+  | {
+      type: "browser.resourceFailed";
+      sessionId: string;
+      failure: BrowserPreviewResourceFailure;
     }
   | {
       type: "error";

--- a/tests/e2e/browser-preview.spec.ts
+++ b/tests/e2e/browser-preview.spec.ts
@@ -27,6 +27,7 @@ test("opens a real remote HTTP and WebSocket service through the SSH preview pro
   await expect(preview.locator("#asset")).toHaveText("remote-preview-static-asset-ok");
   await expect(preview.locator("#http")).toHaveText("remote-preview-http-ok");
   await expect(preview.locator("#ws")).toHaveText("remote-preview-websocket");
+  await expect(page.getByText("404 GET /missing-preview-entry.js")).toBeVisible();
 
   // Switching thread scopes destroys the keyed Dockview tree. Returning recreates the iframe
   // with its original bootstrap URL, matching normal desktop/mobile workspace navigation.

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -74,7 +74,9 @@ services:
       CODEX_GATEWAY_CONFIG_SECRET: e2e-config-secret
       CODEX_GATEWAY_DB_PATH: /workspace/codex-gateway/.data-e2e/codex-gateway.db
       NUXT_IGNORE_LOCK: "1"
-      BROWSER_PREVIEW_PUBLIC_PORT: "3100"
+      # Preview origins enter through the nginx sidecar below. This mirrors production so remote
+      # /_nuxt/* assets cannot be intercepted as Gateway public assets before reaching the proxy.
+      BROWSER_PREVIEW_PUBLIC_PORT: "3200"
       BROWSER_PREVIEW_DOMAIN: 127.0.0.1.nip.io
       BROWSER_PREVIEW_SCHEME: http
     volumes:
@@ -95,12 +97,28 @@ services:
       timeout: 3s
       retries: 60
 
+  browser-preview-ingress:
+    image: nginx:1.29-alpine
+    network_mode: service:gateway-under-test
+    depends_on:
+      gateway-under-test:
+        condition: service_healthy
+    volumes:
+      - ./docker/browser-preview-nginx.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      # An unauthenticated preview request correctly returns 401, so readiness probes the listener
+      # rather than treating an application status code as an ingress failure.
+      test: ["CMD", "nc", "-z", "127.0.0.1", "3200"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
   test-runner:
     image: codex-gateway-e2e-runner
     mem_limit: 2g
     network_mode: service:gateway-under-test
     depends_on:
-      gateway-under-test:
+      browser-preview-ingress:
         condition: service_healthy
     environment:
       CI: ${CI:-}

--- a/tests/e2e/docker/browser-preview-nginx.conf
+++ b/tests/e2e/docker/browser-preview-nginx.conf
@@ -1,0 +1,26 @@
+events {}
+
+http {
+  map $http_upgrade $browser_preview_gateway_path {
+    default   /api/browser-preview/http;
+    websocket /api/browser-preview/websocket;
+  }
+
+  server {
+    listen 3200;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_set_header X-Browser-Preview-Path $request_uri;
+      proxy_pass http://127.0.0.1:3100$browser_preview_gateway_path;
+    }
+  }
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+}

--- a/tests/e2e/docker/preview-server.mjs
+++ b/tests/e2e/docker/preview-server.mjs
@@ -17,11 +17,17 @@ const server = createServer((request, response) => {
     response.end("#asset { color: rgb(20, 120, 80); }");
     return;
   }
+  if (request.url === "/missing-preview-entry.js") {
+    response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    response.end("missing preview entry");
+    return;
+  }
   response.setHeader("content-type", "text/html; charset=utf-8");
   response.end(`<!doctype html><meta charset="utf-8"><title>Remote Preview E2E</title>
     <link rel="stylesheet" href="/preview-style.css">
     <h1>remote-preview-page</h1><p id="asset">loading</p><p id="http">loading</p><p id="ws">loading</p>
     <script src="/preview-asset.js"></script>
+    <script src="/missing-preview-entry.js"></script>
     <script>
       fetch('/api/message').then(r=>r.json()).then(({message})=>document.querySelector('#http').textContent=message);
       const socket=new WebSocket((location.protocol==='https:'?'wss://':'ws://')+location.host+'/api/browser-preview/websocket?path=/socket');

--- a/tests/e2e/run-in-containers.sh
+++ b/tests/e2e/run-in-containers.sh
@@ -36,7 +36,8 @@ docker compose -p "$project_name" -f "$compose_file" build \
 # preview tests without coupling process memory.
 docker compose -p "$project_name" -f "$compose_file" run --rm build-runner \
   bash -lc 'rm -rf .output .nuxt .data-e2e/* /e2e-output/* && pnpm exec nuxt build --extends ./tests/e2e/nuxt-layer && cp -a .output/. /e2e-output/ && node scripts/create-user.mjs "$E2E_GATEWAY_USERNAME" "$E2E_GATEWAY_PASSWORD"'
-docker compose -p "$project_name" -f "$compose_file" up -d --wait gateway-under-test
+docker compose -p "$project_name" -f "$compose_file" up -d --wait \
+  gateway-under-test browser-preview-ingress
 docker compose -p "$project_name" -f "$compose_file" run --rm test-runner \
   bash -lc 'exec pnpm exec playwright test "$@"' \
   e2e "$@"


### PR DESCRIPTION
## Summary
- route every browser-preview HTTP path through an explicit Nitro proxy endpoint so remote `/_nuxt/*`, CSS, API, and nested paths cannot be intercepted as Gateway assets
- preserve the original preview URI through nginx and keep WebSocket traffic on the dedicated bridge
- surface bounded, deduplicated upstream HTTP failures in the Browser panel and detailed host/thread/session diagnostics in server logs
- run Browser Preview E2E through a production-shaped nginx ingress

## Verification
- `pnpm lint`
- `git diff --check`
- `docker exec nginx nginx -t`
- `pnpm test:e2e` (`81 passed`)

## Deployment
- deploy the merged Gateway image first
- then reload the mounted nginx config containing the preview-origin route