### PR TITLE
feat: add workspace Git review

### DIFF
--- a/app/components/chat/workspace-dock/WorkspaceDock.vue
+++ b/app/components/chat/workspace-dock/WorkspaceDock.vue
@@ -36,6 +36,7 @@ const {
   browserPanels,
   tmuxPanels,
   hostMetricsPanel,
+  gitReviewPanel,
   fileWorkspaceRoot,
 } = useWorkspacePanels({
   selectedHostId: workspace.selectedHostId,
@@ -49,6 +50,7 @@ const panels = useWorkspaceDockPanels({
   browserPanels,
   tmuxPanels,
   hostMetricsPanel,
+  gitReviewPanel,
   scopeKey,
 });
 const fileRequestScopeKey = computed(() =>
@@ -62,6 +64,7 @@ const panelIds = computed(() => [
   browserPanels.value.map(({ id }) => id),
   tmuxPanels.value.map(({ id }) => id),
   hostMetricsPanel.value.map(({ id }) => id),
+  gitReviewPanel.value.map(({ id }) => id),
 ]);
 const browserDialogOpen = ref(false);
 const dockviewHost = ref<HTMLElement | null>(null);

--- a/app/components/chat/workspace-dock/WorkspaceDockGitReviewPanel.vue
+++ b/app/components/chat/workspace-dock/WorkspaceDockGitReviewPanel.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { IDockviewPanelProps } from "dockview-vue";
+import { computed } from "vue";
+import GitChangesView from "@/components/files/git/GitChangesView.vue";
+import { useFileGitReviewPanelStore } from "@/stores/file-workspace/git/review-panel";
+import { workspaceLayoutScopeKey } from "@/stores/gateway-workspace-layout";
+import type { WorkspaceDockPanelParamsFor } from "./types";
+import { requireWorkspaceFilesPanelContext } from "./context";
+
+defineProps<{ params: IDockviewPanelProps<WorkspaceDockPanelParamsFor<"gitReview">> }>();
+const context = requireWorkspaceFilesPanelContext();
+const reviews = useFileGitReviewPanelStore();
+const scopeKey = computed(() =>
+  workspaceLayoutScopeKey(
+    context.selectedHostId.value,
+    context.selectedProjectId.value,
+    context.selectedThreadId.value,
+  ),
+);
+const selectedPath = computed(() => reviews.selectedPathFor(scopeKey.value));
+</script>
+
+<template>
+  <div data-testid="git-review-panel" class="flex h-full min-h-0 flex-col overflow-hidden">
+    <GitChangesView
+      v-if="context.selectedHostId.value && context.selectedProjectId.value"
+      presentation="review"
+      :host-id="context.selectedHostId.value"
+      :project-id="context.selectedProjectId.value"
+      :root-path="context.rootPath.value"
+      :selected-path="selectedPath"
+      @select="reviews.select(scopeKey, $event)"
+    />
+  </div>
+</template>

--- a/app/components/chat/workspace-dock/panel-registry.ts
+++ b/app/components/chat/workspace-dock/panel-registry.ts
@@ -3,6 +3,7 @@ import {
   ActivityIcon,
   BotIcon,
   FilesIcon,
+  GitCompareArrowsIcon,
   GlobeIcon,
   MonitorIcon,
   TerminalIcon,
@@ -24,6 +25,12 @@ export const workspacePanelRegistry = {
     dynamic: false,
   },
   files: { component: "WorkspaceDockFilesPanel", icon: FilesIcon, closable: false, dynamic: false },
+  gitReview: {
+    component: "WorkspaceDockGitReviewPanel",
+    icon: GitCompareArrowsIcon,
+    closable: true,
+    dynamic: true,
+  },
   terminal: {
     component: "WorkspaceDockTerminalPanel",
     icon: TerminalIcon,

--- a/app/components/chat/workspace-dock/types.ts
+++ b/app/components/chat/workspace-dock/types.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export type WorkspacePanelKind =
   | "agent"
   | "files"
+  | "gitReview"
   | "terminal"
   | "subagent"
   | "browser"
@@ -13,6 +14,7 @@ export type WorkspacePanelKind =
 export const workspaceDockPanelParamsSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("agent") }),
   z.object({ kind: z.literal("files") }),
+  z.object({ kind: z.literal("gitReview") }),
   z.object({ kind: z.literal("terminal"), sessionId: z.string().min(1) }),
   z.object({
     kind: z.literal("subagent"),

--- a/app/components/chat/workspace-dock/useWorkspaceDockLifecycle.ts
+++ b/app/components/chat/workspace-dock/useWorkspaceDockLifecycle.ts
@@ -169,7 +169,14 @@ export function useWorkspaceDockLifecycle(options: {
   );
   watch(
     () => workspaceLayout.panelActivationRequest,
-    (request) => request && activate(request.panelId),
+    (request) => {
+      if (!request || !api.value) return;
+      // Dynamic panels are represented by domain stores, while activation is a layout request.
+      // Both updates are synchronous, but their Vue watchers are not ordered. Reconcile here before
+      // activation so opening a panel never depends on the panel-list watcher winning that race.
+      options.reconcile(api.value);
+      activate(request.panelId);
+    },
   );
   watch(
     () => fileWorkspace.workspaceOpenRequest,

--- a/app/components/chat/workspace-dock/useWorkspaceDockPanels.ts
+++ b/app/components/chat/workspace-dock/useWorkspaceDockPanels.ts
@@ -15,6 +15,7 @@ import {
 import { workspaceDockPanelParamsFromUnknown, type WorkspaceDockPanelParams } from "./types";
 import { workspacePanelPolicy } from "./panel-registry";
 import { useGatewayHostMetricsPanelStore } from "@/stores/gateway-host-metrics/panels";
+import { useFileGitReviewPanelStore } from "@/stores/file-workspace/git/review-panel";
 
 interface PanelDefinition {
   id: string;
@@ -34,6 +35,7 @@ export function useWorkspaceDockPanels(options: {
   browserPanels: ComputedRef<Array<{ id: string; panel: { panelId: string; title: string } }>>;
   tmuxPanels: ComputedRef<Array<{ id: string }>>;
   hostMetricsPanel: ComputedRef<Array<{ id: string; hostId: number }>>;
+  gitReviewPanel: ComputedRef<Array<{ id: string }>>;
   scopeKey: ComputedRef<string>;
 }) {
   const { t } = useI18n();
@@ -43,6 +45,7 @@ export function useWorkspaceDockPanels(options: {
   const browserStore = useGatewayBrowserStore();
   const tmuxStore = useGatewayTmuxStore();
   const hostMetricsPanels = useGatewayHostMetricsPanelStore();
+  const gitReviewPanels = useFileGitReviewPanelStore();
 
   function definitions(): PanelDefinition[] {
     const panels: PanelDefinition[] = [
@@ -62,6 +65,12 @@ export function useWorkspaceDockPanels(options: {
       });
     }
     panels.push(
+      ...options.gitReviewPanel.value.map(({ id }) => ({
+        id,
+        title: t("app.fileGitReviewTab"),
+        component: workspacePanelPolicy("gitReview").component,
+        params: { kind: "gitReview" as const },
+      })),
       ...options.terminalPanels.value.map(({ id, session }) => ({
         id,
         title: session.title,
@@ -200,6 +209,12 @@ export function useWorkspaceDockPanels(options: {
       case "hostMetrics":
         hostMetricsPanels.close(options.scopeKey.value);
         break;
+      case "gitReview":
+        gitReviewPanels.close(options.scopeKey.value);
+        // Source-control review is launched from Files. Returning there is deterministic on both
+        // desktop and locked mobile Dockview; the generic dynamic-panel fallback prefers Agent.
+        workspaceLayout.requestPanelActivation(FILES_WORKSPACE_PANEL_ID);
+        return;
       case "agent":
       case "files":
         return;

--- a/app/components/chat/workspace-dock/useWorkspacePanels.ts
+++ b/app/components/chat/workspace-dock/useWorkspacePanels.ts
@@ -18,6 +18,8 @@ import {
 import type { WorkspacePanelSelection } from "./types";
 import { useGatewayHostMetricsPanelStore } from "@/stores/gateway-host-metrics/panels";
 import { workspaceLayoutScopeKey } from "@/stores/gateway-workspace-layout";
+import { useFileGitReviewPanelStore } from "@/stores/file-workspace/git/review-panel";
+import { GIT_REVIEW_WORKSPACE_PANEL_ID } from "@/stores/gateway/workspace-panels";
 import { HOST_METRICS_WORKSPACE_PANEL_ID } from "@/stores/gateway/workspace-panels";
 
 export function useWorkspacePanels(selection: WorkspacePanelSelection) {
@@ -28,6 +30,7 @@ export function useWorkspacePanels(selection: WorkspacePanelSelection) {
   const browserStore = useGatewayBrowserStore();
   const tmuxStore = useGatewayTmuxStore();
   const hostMetricsPanels = useGatewayHostMetricsPanelStore();
+  const gitReviewPanels = useFileGitReviewPanelStore();
   const { terminalSessions } = storeToRefs(terminalStore);
   const { threadViews, currentThread, visibleSubAgentPanels } = storeToRefs(threadView);
 
@@ -95,6 +98,14 @@ export function useWorkspacePanels(selection: WorkspacePanelSelection) {
       ? [{ id: HOST_METRICS_WORKSPACE_PANEL_ID, hostId }]
       : [];
   });
+  const gitReviewPanel = computed(() => {
+    const scopeKey = workspaceLayoutScopeKey(
+      selection.selectedHostId.value,
+      selection.selectedProjectId.value,
+      selection.selectedThreadId.value,
+    );
+    return gitReviewPanels.isOpen(scopeKey) ? [{ id: GIT_REVIEW_WORKSPACE_PANEL_ID }] : [];
+  });
 
   const fileWorkspaceRoot = computed(() => {
     const cwd = currentThread.value?.cwd ?? "";
@@ -108,6 +119,7 @@ export function useWorkspacePanels(selection: WorkspacePanelSelection) {
     browserPanels,
     tmuxPanels,
     hostMetricsPanel,
+    gitReviewPanel,
     fileWorkspaceRoot,
   };
 }

--- a/app/components/files/FileTextEditor.vue
+++ b/app/components/files/FileTextEditor.vue
@@ -56,6 +56,16 @@ watch([() => props.document.path, () => props.document.contentType], () => {
   mode.value = defaultMode(props.document);
 });
 
+watch(
+  () => props.document.requestedView,
+  (requestedView) => {
+    if (requestedView === null) return;
+    mode.value = requestedView;
+    fileWorkspace.consumeDocumentViewRequest(props.document);
+  },
+  { immediate: true },
+);
+
 watch(git.hasChanges, (hasChanges) => {
   if (!hasChanges && mode.value === "changes") mode.value = "source";
 });

--- a/app/components/files/FileWorkspacePane.vue
+++ b/app/components/files/FileWorkspacePane.vue
@@ -17,7 +17,7 @@ import FileCloseDialog from "./FileCloseDialog.vue";
 import FileConflictDialog from "./FileConflictDialog.vue";
 import FileWorkspaceSplitPane from "./FileWorkspaceSplitPane.vue";
 import FileWorkspaceTabs from "./FileWorkspaceTabs.vue";
-import RemoteFileTree from "./RemoteFileTree.vue";
+import FileWorkspaceSidebar from "./FileWorkspaceSidebar.vue";
 
 const props = defineProps<{
   layout: "desktop" | "mobile";
@@ -40,13 +40,14 @@ const activeDocument = computed(() =>
   fileWorkspace.activeDocumentFor(props.hostId, props.threadId),
 );
 
-function openFile(path: string) {
+function openFile(path: string, view?: "source" | "changes") {
   mobileTreeOpen.value = false;
   void fileWorkspace.openFile({
     hostId: props.hostId,
     projectId: props.projectId,
     threadId: props.threadId,
     path,
+    view,
   });
 }
 </script>
@@ -55,12 +56,14 @@ function openFile(path: string) {
   <div data-testid="workspace-file-panel" class="flex min-h-0 flex-1 flex-col overflow-hidden">
     <FileWorkspaceSplitPane v-if="layout === 'desktop'">
       <template #tree>
-        <RemoteFileTree
+        <FileWorkspaceSidebar
           :host-id="hostId"
+          :project-id="projectId"
           :thread-id="threadId"
           :root-path="rootPath"
           :visible="active"
           @open="openFile"
+          @review-opened="mobileTreeOpen = false"
         />
       </template>
       <template #preview>
@@ -68,6 +71,9 @@ function openFile(path: string) {
           <FileWorkspaceTabs
             :documents="documents"
             :active-path="scope?.activePath ?? null"
+            :host-id="hostId"
+            :project-id="projectId"
+            :root-path="rootPath"
             @activate="fileWorkspace.activateFile(hostId, threadId, $event)"
             @close="guards.requestClose"
           />
@@ -106,6 +112,9 @@ function openFile(path: string) {
             class="min-w-0 flex-1 border-b-0"
             :documents="documents"
             :active-path="scope?.activePath ?? null"
+            :host-id="hostId"
+            :project-id="projectId"
+            :root-path="rootPath"
             @activate="fileWorkspace.activateFile(hostId, threadId, $event)"
             @close="guards.requestClose"
           />
@@ -132,12 +141,14 @@ function openFile(path: string) {
             <SheetTitle>{{ $t("app.fileTree") }}</SheetTitle>
             <SheetDescription>{{ rootPath }}</SheetDescription>
           </SheetHeader>
-          <RemoteFileTree
+          <FileWorkspaceSidebar
             :host-id="hostId"
+            :project-id="projectId"
             :thread-id="threadId"
             :root-path="rootPath"
             :visible="mobileTreeOpen"
             @open="openFile"
+            @review-opened="mobileTreeOpen = false"
           />
         </SheetContent>
       </Sheet>

--- a/app/components/files/FileWorkspaceSidebar.vue
+++ b/app/components/files/FileWorkspaceSidebar.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { FilesIcon, GitCompareArrowsIcon } from "@lucide/vue";
+import type { RemoteGitWorkspaceFile } from "~~/shared/types";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@codex-gateway/ui/tabs";
+import { useFileGitWorkspace } from "@/composables/files/useFileGitWorkspace";
+import { useFileGitReviewPanelStore } from "@/stores/file-workspace/git/review-panel";
+import {
+  useGatewayWorkspaceLayoutStore,
+  workspaceLayoutScopeKey,
+} from "@/stores/gateway-workspace-layout";
+import { GIT_REVIEW_WORKSPACE_PANEL_ID } from "@/stores/gateway/workspace-panels";
+import RemoteFileTree from "./RemoteFileTree.vue";
+import GitChangesView from "./git/GitChangesView.vue";
+
+const props = defineProps<{
+  hostId: number;
+  projectId: number | null;
+  threadId: string;
+  rootPath: string;
+  visible: boolean;
+}>();
+const emit = defineEmits<{
+  open: [path: string, view?: "source" | "changes"];
+  reviewOpened: [];
+}>();
+const activeView = ref<"files" | "changes">("files");
+const git = useFileGitWorkspace({
+  hostId: () => props.hostId,
+  projectId: () => props.projectId,
+  rootPath: () => props.rootPath,
+});
+const changeCount = computed(() => git.changes.value.length);
+const reviewPanels = useFileGitReviewPanelStore();
+const workspaceLayout = useGatewayWorkspaceLayoutStore();
+
+function openReview(selectedPath: string | null = null) {
+  const scopeKey = workspaceLayoutScopeKey(props.hostId, props.projectId, props.threadId);
+  reviewPanels.open(scopeKey, selectedPath);
+  workspaceLayout.requestPanelActivation(GIT_REVIEW_WORKSPACE_PANEL_ID);
+  emit("reviewOpened");
+}
+
+function openChange(path: string, change: RemoteGitWorkspaceFile) {
+  // A deleted worktree path cannot be opened by the regular remote-file transport. Route that one
+  // status to the shared review panel, which renders HEAD against an empty current document.
+  if (change.status === "deleted") {
+    openReview(path);
+    return;
+  }
+  emit("open", path, "changes");
+}
+</script>
+
+<template>
+  <!--
+    Both views own an internal scrollport, so the Tabs root and active content must complete the
+    flex height chain. Intrinsic block sizing collapses the tree after a narrow Dockview split even
+    though its rows remain mounted; keep inactive content hidden instead of conditionally mounting
+    it so tree expansion and scroll state survive view switches.
+  -->
+  <Tabs v-model="activeView" class="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden">
+    <TabsList variant="line" class="h-9 shrink-0 rounded-none border-b border-hairline px-2">
+      <TabsTrigger value="files" class="gap-1.5">
+        <FilesIcon class="size-3.5" />
+        {{ $t("app.filesTab") }}
+      </TabsTrigger>
+      <TabsTrigger value="changes" class="gap-1.5">
+        <GitCompareArrowsIcon class="size-3.5" />
+        {{ $t("app.fileGitChanges") }}
+        <span v-if="changeCount > 0" class="tabular-nums text-[0.6875rem] text-ink-faint">
+          {{ changeCount }}
+        </span>
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent
+      value="files"
+      :unmount-on-hide="false"
+      class="m-0 flex min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden"
+    >
+      <RemoteFileTree
+        :host-id="hostId"
+        :project-id="projectId"
+        :thread-id="threadId"
+        :root-path="rootPath"
+        :visible="visible && activeView === 'files'"
+        @open="emit('open', $event)"
+      />
+    </TabsContent>
+    <TabsContent
+      value="changes"
+      :unmount-on-hide="false"
+      class="m-0 flex min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden"
+    >
+      <GitChangesView
+        :host-id="hostId"
+        :project-id="projectId"
+        :root-path="rootPath"
+        :can-promote="projectId !== null"
+        @open="openChange"
+        @open-review="openReview"
+      />
+    </TabsContent>
+  </Tabs>
+</template>

--- a/app/components/files/FileWorkspaceTabs.vue
+++ b/app/components/files/FileWorkspaceTabs.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
 import { FileTextIcon, XIcon } from "@lucide/vue";
 import type { FilePreviewDocument } from "~~/shared/types";
+import { useFileGitWorkspace } from "@/composables/files/useFileGitWorkspace";
+import GitStatusBadge from "./git/GitStatusBadge.vue";
 
-defineProps<{
+const props = defineProps<{
   documents: FilePreviewDocument[];
   activePath: string | null;
+  hostId: number;
+  projectId: number | null;
+  rootPath: string;
 }>();
+
+const gitWorkspace = useFileGitWorkspace({
+  hostId: () => props.hostId,
+  projectId: () => props.projectId,
+  rootPath: () => props.rootPath,
+});
 
 const emit = defineEmits<{
   activate: [path: string];
@@ -35,6 +46,7 @@ const emit = defineEmits<{
       >
         <FileTextIcon class="size-3.5 shrink-0" />
         <span class="min-w-0 flex-1 truncate">{{ document.title }}</span>
+        <GitStatusBadge :status="gitWorkspace.changeForPath(document.path)?.status ?? null" />
         <span
           v-if="document.saving"
           class="size-3 shrink-0 animate-spin rounded-full border border-primary border-t-transparent"

--- a/app/components/files/RemoteFileTree.vue
+++ b/app/components/files/RemoteFileTree.vue
@@ -5,6 +5,7 @@ import { computed, nextTick, ref, useTemplateRef } from "vue";
 import type { RemoteDirectoryEntry } from "~~/shared/types";
 import { Button } from "@codex-gateway/ui/button";
 import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
+import { useFileGitWorkspace } from "@/composables/files/useFileGitWorkspace";
 import RemoteFileDeleteDialog from "./RemoteFileDeleteDialog.vue";
 import RemoteFileTreeRow from "./RemoteFileTreeRow.vue";
 import { useRemoteFileTreeActions } from "./useRemoteFileTreeActions";
@@ -19,6 +20,7 @@ interface FileTreeNode {
 
 const props = defineProps<{
   hostId: number;
+  projectId: number | null;
   threadId: string;
   rootPath: string;
   visible: boolean;
@@ -29,6 +31,11 @@ const emit = defineEmits<{
 }>();
 
 const fileWorkspace = useGatewayFileWorkspaceStore();
+const gitWorkspace = useFileGitWorkspace({
+  hostId: () => props.hostId,
+  projectId: () => props.projectId,
+  rootPath: () => props.rootPath,
+});
 const fileActions = useRemoteFileTreeActions({
   hostId: () => props.hostId,
   threadId: () => props.threadId,
@@ -173,6 +180,12 @@ function fileTreeNode(value: unknown) {
           :key="item._id"
           :node="fileTreeNode(item.value)"
           :level="item.level"
+          :git-status="gitWorkspace.changeForPath(fileTreeNode(item.value).path)?.status ?? null"
+          :descendant-change-count="
+            fileTreeNode(item.value).type === 'directory'
+              ? gitWorkspace.descendantChangeCount(fileTreeNode(item.value).path)
+              : 0
+          "
           @download="fileActions.downloadFile"
           @copy-path="fileActions.copyAbsolutePath"
           @delete="fileActions.requestDelete"

--- a/app/components/files/RemoteFileTreeRow.vue
+++ b/app/components/files/RemoteFileTreeRow.vue
@@ -9,7 +9,7 @@ import {
   Trash2Icon,
 } from "@lucide/vue";
 import { TreeItem } from "reka-ui";
-import type { RemoteDirectoryEntry } from "~~/shared/types";
+import type { RemoteDirectoryEntry, RemoteGitFileStatus } from "~~/shared/types";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -17,6 +17,8 @@ import {
   ContextMenuTrigger,
 } from "@codex-gateway/ui/context-menu";
 import { useLongPressContextMenu } from "@/composables/interactions/useLongPressContextMenu";
+import { gitStatusTextClass } from "@/utils/git-status-presentation";
+import GitStatusBadge from "./git/GitStatusBadge.vue";
 
 interface FileTreeNode {
   name: string;
@@ -28,6 +30,8 @@ interface FileTreeNode {
 defineProps<{
   node: FileTreeNode;
   level: number;
+  gitStatus: RemoteGitFileStatus | null;
+  descendantChangeCount: number;
 }>();
 
 const emit = defineEmits<{
@@ -63,7 +67,19 @@ const { longPressContextMenuHandlers } = useLongPressContextMenu({ menuWidthEsti
         />
         <FolderIcon v-else-if="node.type === 'directory'" class="size-4 shrink-0 text-primary" />
         <FileIcon v-else class="size-4 shrink-0 text-ink-faint" />
-        <span class="whitespace-nowrap" :title="node.path">{{ node.name }}</span>
+        <span
+          class="whitespace-nowrap"
+          :class="gitStatus ? gitStatusTextClass(gitStatus) : ''"
+          :title="node.path"
+        >
+          {{ node.name }}
+        </span>
+        <GitStatusBadge v-if="gitStatus" class="ml-auto pl-3" :status="gitStatus" />
+        <span
+          v-else-if="descendantChangeCount > 0"
+          class="ml-auto size-1.5 shrink-0 rounded-full bg-accent-orange"
+          :aria-label="$t('app.fileGitDescendantChanges', { count: descendantChangeCount })"
+        />
       </TreeItem>
     </ContextMenuTrigger>
     <ContextMenuContent

--- a/app/components/files/git/GitChangeDiffViewer.vue
+++ b/app/components/files/git/GitChangeDiffViewer.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { goToNextChunk, goToPreviousChunk } from "@codemirror/merge";
+import type { StateCommand } from "@codemirror/state";
+import {
+  AlertCircleIcon,
+  ArrowDownIcon,
+  ArrowUpIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+} from "@lucide/vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+import type { RemoteGitWorkspaceFile } from "~~/shared/types";
+import { MAX_GIT_DIFF_BYTES } from "~~/shared/file-preview";
+import { Button } from "@codex-gateway/ui/button";
+import CodeEditor from "@/components/common/CodeEditor.vue";
+import { useFileGitComparisonStore } from "@/stores/file-workspace/git";
+import { fetchRemoteFile } from "@/utils/remote-file-transport";
+import { codeEditorLanguageForPath } from "@/utils/code-editor-extensions";
+import { gitUnifiedDiffExtension } from "@/utils/code-editor-git-diff";
+import { gitStatusCode, gitStatusTextClass } from "@/utils/git-status-presentation";
+
+const props = defineProps<{
+  hostId: number;
+  projectId: number;
+  path: string;
+  change: RemoteGitWorkspaceFile;
+}>();
+const comparisonStore = useFileGitComparisonStore();
+const { t } = useI18n();
+const currentText = ref("");
+const loadingContent = ref(false);
+const contentError = ref<string | null>(null);
+const editorRef = ref<{ runCommand: (command: StateCommand) => boolean } | null>(null);
+let controller: AbortController | null = null;
+const target = computed(() => ({
+  hostId: props.hostId,
+  projectId: props.projectId,
+  path: props.path,
+}));
+const state = computed(() => comparisonStore.stateForTarget(target.value));
+const baseline = computed(() => state.value.baselineText);
+const extensions = computed(() =>
+  baseline.value === null ? [] : [gitUnifiedDiffExtension(baseline.value)],
+);
+const loading = computed(() => state.value.loading || loadingContent.value);
+const error = computed(() => state.value.error ?? contentError.value);
+
+watch(
+  () => [props.hostId, props.projectId, props.path, props.change] as const,
+  () => void load(true),
+  { immediate: true },
+);
+onBeforeUnmount(() => controller?.abort());
+
+async function load(force = false) {
+  controller?.abort();
+  controller = new AbortController();
+  const signal = controller.signal;
+  loadingContent.value = true;
+  contentError.value = null;
+  try {
+    const comparison = await comparisonStore.loadTarget(target.value, force);
+    if (signal.aborted || comparison.error !== null) return;
+    if (props.change.status === "deleted") {
+      currentText.value = "";
+      return;
+    }
+    const response = await fetchRemoteFile(props.hostId, props.path, null, signal);
+    if (signal.aborted || response.changed === false) return;
+    if (response.previewKind !== "text" || response.blob.size > MAX_GIT_DIFF_BYTES) {
+      contentError.value = t("app.fileGitDiffTooLarge");
+      return;
+    }
+    currentText.value = await response.blob.text();
+  } catch (loadError: unknown) {
+    if (!signal.aborted) {
+      contentError.value = loadError instanceof Error ? loadError.message : String(loadError);
+    }
+  } finally {
+    if (!signal.aborted) loadingContent.value = false;
+  }
+}
+
+function run(command: StateCommand) {
+  editorRef.value?.runCommand(command);
+}
+</script>
+
+<template>
+  <section class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-surface">
+    <div class="flex h-10 shrink-0 items-center gap-2 border-b border-hairline px-3">
+      <span class="min-w-0 flex-1 truncate text-sm font-medium" :title="path">{{ path }}</span>
+      <span class="text-xs font-semibold" :class="gitStatusTextClass(change.status)">
+        {{ gitStatusCode(change.status) }}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        :aria-label="$t('app.fileGitPreviousChange')"
+        @click="run(goToPreviousChunk)"
+      >
+        <ArrowUpIcon class="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        :aria-label="$t('app.fileGitNextChange')"
+        @click="run(goToNextChunk)"
+      >
+        <ArrowDownIcon class="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        :aria-label="$t('app.fileGitRefresh')"
+        @click="load(true)"
+      >
+        <RefreshCwIcon class="size-3.5" :class="loading ? 'animate-spin' : ''" />
+      </Button>
+    </div>
+    <div v-if="loading" class="flex flex-1 items-center justify-center text-sm text-ink-muted">
+      <Loader2Icon class="mr-2 size-4 animate-spin" />
+      {{ $t("app.fileGitLoading") }}
+    </div>
+    <div
+      v-else-if="error"
+      class="m-4 flex items-start gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive"
+    >
+      <AlertCircleIcon class="mt-0.5 size-4 shrink-0" />
+      <span class="break-words">{{ error }}</span>
+    </div>
+    <CodeEditor
+      v-else-if="baseline !== null"
+      :key="path"
+      ref="editorRef"
+      v-model="currentText"
+      test-id="git-review-diff-editor"
+      class="rounded-none border-0"
+      :language="codeEditorLanguageForPath(path)"
+      :extensions="extensions"
+      :read-only="true"
+      :line-wrapping="false"
+    />
+    <div v-else class="flex flex-1 items-center justify-center text-sm text-ink-muted">
+      {{ $t("app.fileGitDiffTooLarge") }}
+    </div>
+  </section>
+</template>

--- a/app/components/files/git/GitChangeTreeRow.vue
+++ b/app/components/files/git/GitChangeTreeRow.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ChevronRightIcon, FileIcon, FolderIcon, FolderOpenIcon } from "@lucide/vue";
+import { TreeItem } from "reka-ui";
+import { gitStatusTextClass } from "@/utils/git-status-presentation";
+import type { GitChangeTreeNode } from "./git-change-tree";
+import GitStatusBadge from "./GitStatusBadge.vue";
+
+defineProps<{ node: GitChangeTreeNode; level: number }>();
+</script>
+
+<template>
+  <TreeItem
+    v-slot="{ isExpanded }"
+    :value="node"
+    :level="level"
+    :data-git-change-path="node.path"
+    class="flex h-8 w-full min-w-0 cursor-default items-center gap-1.5 rounded-md pr-2 text-sm text-ink-muted outline-none hover:bg-canvas-soft hover:text-ink data-selected:bg-primary/10 data-selected:text-ink"
+    :style="{ paddingInlineStart: `${Math.max(0, level - 1) * 1.125 + 0.5}rem` }"
+  >
+    <ChevronRightIcon
+      v-if="node.kind === 'directory'"
+      class="size-3.5 shrink-0 transition-transform"
+      :class="isExpanded ? 'rotate-90' : ''"
+    />
+    <span v-else class="w-3.5 shrink-0" />
+    <FolderOpenIcon
+      v-if="node.kind === 'directory' && isExpanded"
+      class="size-4 shrink-0 text-primary"
+    />
+    <FolderIcon v-else-if="node.kind === 'directory'" class="size-4 shrink-0 text-primary" />
+    <FileIcon v-else class="size-4 shrink-0 text-ink-faint" />
+    <span
+      class="min-w-0 flex-1 truncate"
+      :class="node.kind === 'file' ? gitStatusTextClass(node.change.status) : ''"
+      :title="node.path"
+    >
+      {{ node.name }}
+    </span>
+    <GitStatusBadge v-if="node.kind === 'file'" :status="node.change.status" />
+  </TreeItem>
+</template>

--- a/app/components/files/git/GitChangesView.vue
+++ b/app/components/files/git/GitChangesView.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import {
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  Maximize2Icon,
+  GitBranchIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+} from "@lucide/vue";
+import { TreeRoot } from "reka-ui";
+import { computed, ref, watch } from "vue";
+import { Button } from "@codex-gateway/ui/button";
+import { useFileGitWorkspace } from "@/composables/files/useFileGitWorkspace";
+import GitChangeTreeRow from "./GitChangeTreeRow.vue";
+import GitChangeDiffViewer from "./GitChangeDiffViewer.vue";
+import {
+  buildGitChangeTree,
+  gitChangeDirectoryPaths,
+  type GitChangeFileNode,
+  type GitChangeTreeNode,
+} from "./git-change-tree";
+
+const props = withDefaults(
+  defineProps<{
+    hostId: number;
+    projectId: number | null;
+    rootPath: string;
+    presentation?: "sidebar" | "review";
+    canPromote?: boolean;
+    selectedPath?: string | null;
+  }>(),
+  { presentation: "sidebar", canPromote: false, selectedPath: null },
+);
+const emit = defineEmits<{
+  open: [path: string, change: RemoteGitWorkspaceFile];
+  openReview: [];
+  select: [path: string];
+}>();
+const git = useFileGitWorkspace({
+  hostId: () => props.hostId,
+  projectId: () => props.projectId,
+  rootPath: () => props.rootPath,
+});
+const selected = ref<GitChangeTreeNode>();
+const expanded = ref<string[]>([]);
+const tree = computed(() =>
+  buildGitChangeTree(git.changes.value, git.pathForChange, props.rootPath),
+);
+const availableSnapshot = computed(() => {
+  const snapshot = git.state.value?.snapshot;
+  return snapshot?.availability === "available" ? snapshot : null;
+});
+const selectedFile = computed(() => (selected.value?.kind === "file" ? selected.value : null));
+
+watch(
+  [tree, () => props.selectedPath],
+  ([nodes, requestedPath]) => {
+    if (props.presentation !== "review") return;
+    const selectedPath = selectedFile.value?.path;
+    const files = flattenFiles(nodes);
+    selected.value =
+      files.find((node) => node.path === requestedPath) ??
+      files.find((node) => node.path === selectedPath) ??
+      files[0];
+  },
+  { immediate: true },
+);
+watch(
+  () => git.state.value?.stale,
+  (stale) => stale === true && void git.load(),
+  { immediate: true },
+);
+
+function selectNode(node: GitChangeTreeNode | undefined) {
+  // Reka emits an empty model value while a newly mounted tree registers its items. That is not a
+  // user deselection and must not erase the path restored by the review scope store.
+  if (node === undefined) return;
+  selected.value = node;
+  if (node.kind !== "file") return;
+  if (props.presentation === "sidebar") emit("open", node.path, node.change);
+  else emit("select", node.path);
+}
+
+function expandAll() {
+  expanded.value = gitChangeDirectoryPaths(tree.value);
+}
+
+function fileNode(value: unknown) {
+  return value as GitChangeTreeNode;
+}
+
+function flattenFiles(nodes: GitChangeTreeNode[]) {
+  return nodes.flatMap((node): GitChangeFileNode[] =>
+    node.kind === "file" ? [node] : flattenFiles(node.children),
+  );
+}
+</script>
+
+<template>
+  <div
+    class="flex min-h-0 flex-1 overflow-hidden"
+    :class="presentation === 'review' ? 'flex-col md:flex-row' : 'flex-col'"
+  >
+    <section
+      class="flex min-h-0 flex-col overflow-hidden bg-canvas-soft/45"
+      :class="
+        presentation === 'review'
+          ? 'h-48 w-full shrink-0 border-b border-hairline md:h-auto md:w-80 md:border-r md:border-b-0'
+          : 'flex-1'
+      "
+    >
+      <div class="flex h-10 shrink-0 items-center gap-2 border-b border-hairline px-3">
+        <GitBranchIcon class="size-4 shrink-0 text-ink-muted" />
+        <span class="min-w-0 flex-1 truncate text-sm font-semibold">
+          {{ availableSnapshot?.branch ?? $t("app.fileGitChanges") }}
+        </span>
+        <Button
+          v-if="canPromote"
+          variant="ghost"
+          size="icon-sm"
+          :aria-label="$t('app.fileGitOpenReview')"
+          @click="emit('openReview')"
+        >
+          <Maximize2Icon class="size-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          :aria-label="$t('app.fileGitCollapseAll')"
+          @click="expanded = []"
+        >
+          <ChevronsDownUpIcon class="size-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          :aria-label="$t('app.fileGitExpandAll')"
+          @click="expandAll"
+        >
+          <ChevronsUpDownIcon class="size-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          :aria-label="$t('app.fileGitRefresh')"
+          @click="git.refresh"
+        >
+          <RefreshCwIcon class="size-3.5" :class="git.state.value?.loading ? 'animate-spin' : ''" />
+        </Button>
+      </div>
+      <div
+        v-if="git.state.value?.error"
+        class="m-3 rounded-lg bg-destructive/10 p-3 text-xs text-destructive"
+      >
+        {{ git.state.value.error }}
+      </div>
+      <div
+        v-else-if="git.state.value?.loading && !git.state.value.loaded"
+        class="flex flex-1 items-center justify-center text-sm text-ink-muted"
+      >
+        <Loader2Icon class="mr-2 size-4 animate-spin" />
+        {{ $t("app.fileGitLoading") }}
+      </div>
+      <div
+        v-else-if="git.state.value?.snapshot?.availability !== 'available'"
+        class="flex flex-1 items-center justify-center px-5 text-center text-sm text-ink-muted"
+      >
+        {{ $t("app.fileGitWorkspaceUnavailable") }}
+      </div>
+      <div
+        v-else-if="tree.length === 0"
+        class="flex flex-1 items-center justify-center px-5 text-center text-sm text-ink-muted"
+      >
+        {{ $t("app.fileGitNoChanges") }}
+      </div>
+      <TreeRoot
+        v-else
+        v-model:expanded="expanded"
+        :model-value="selected"
+        :items="tree"
+        :get-key="(node: GitChangeTreeNode) => node.path"
+        :get-children="
+          (node: GitChangeTreeNode) => (node.kind === 'directory' ? node.children : undefined)
+        "
+        class="min-h-0 flex-1 list-none overflow-auto py-2 outline-none"
+        data-testid="git-changes-tree"
+        @update:model-value="selectNode"
+      >
+        <template #default="{ flattenItems }">
+          <GitChangeTreeRow
+            v-for="item in flattenItems"
+            :key="item._id"
+            :node="fileNode(item.value)"
+            :level="item.level"
+          />
+        </template>
+      </TreeRoot>
+    </section>
+    <GitChangeDiffViewer
+      v-if="presentation === 'review' && selectedFile && projectId !== null"
+      :host-id="hostId"
+      :project-id="projectId"
+      :path="selectedFile.path"
+      :change="selectedFile.change"
+    />
+    <div
+      v-else-if="presentation === 'review'"
+      class="flex min-w-0 flex-1 items-center justify-center text-sm text-ink-muted"
+    >
+      {{ $t("app.fileGitSelectChange") }}
+    </div>
+  </div>
+</template>

--- a/app/components/files/git/GitStatusBadge.vue
+++ b/app/components/files/git/GitStatusBadge.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { RemoteGitFileStatus } from "~~/shared/types";
+import { gitStatusCode, gitStatusTextClass } from "@/utils/git-status-presentation";
+
+defineProps<{ status: RemoteGitFileStatus | null }>();
+</script>
+
+<template>
+  <span
+    v-if="status"
+    class="shrink-0 text-xs font-semibold"
+    :class="gitStatusTextClass(status)"
+    :aria-label="$t(`app.fileGitStatus.${status}`)"
+  >
+    {{ gitStatusCode(status) }}
+  </span>
+</template>

--- a/app/components/files/git/git-change-tree.ts
+++ b/app/components/files/git/git-change-tree.ts
@@ -1,0 +1,98 @@
+import type { RemoteGitWorkspaceFile } from "~~/shared/types";
+
+export type GitChangeTreeNode = GitChangeDirectoryNode | GitChangeFileNode;
+
+export interface GitChangeDirectoryNode {
+  kind: "directory";
+  name: string;
+  path: string;
+  children: GitChangeTreeNode[];
+}
+
+export interface GitChangeFileNode {
+  kind: "file";
+  name: string;
+  path: string;
+  change: RemoteGitWorkspaceFile;
+}
+
+export function buildGitChangeTree(
+  changes: RemoteGitWorkspaceFile[],
+  pathForChange: (change: RemoteGitWorkspaceFile) => string | null,
+  rootPath: string,
+) {
+  const root: GitChangeDirectoryNode = {
+    kind: "directory",
+    name: rootPath,
+    path: rootPath,
+    children: [],
+  };
+  for (const change of changes) {
+    const absolutePath = pathForChange(change);
+    if (absolutePath === null) continue;
+    const relativePath = relativeToRoot(rootPath, absolutePath);
+    if (relativePath === null || relativePath === "") continue;
+    insert(root, relativePath.split("/"), absolutePath, change);
+  }
+  sortChildren(root);
+  return root.children;
+}
+
+export function gitChangeDirectoryPaths(nodes: GitChangeTreeNode[]) {
+  const paths: string[] = [];
+  const visit = (node: GitChangeTreeNode) => {
+    if (node.kind !== "directory") return;
+    paths.push(node.path);
+    node.children.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return paths;
+}
+
+function insert(
+  root: GitChangeDirectoryNode,
+  parts: string[],
+  absolutePath: string,
+  change: RemoteGitWorkspaceFile,
+) {
+  let directory = root;
+  for (const part of parts.slice(0, -1)) {
+    const existing = directory.children.find(
+      (node): node is GitChangeDirectoryNode => node.kind === "directory" && node.name === part,
+    );
+    if (existing !== undefined) {
+      directory = existing;
+      continue;
+    }
+    const next: GitChangeDirectoryNode = {
+      kind: "directory",
+      name: part,
+      path: `${directory.path.replace(/\/$/, "")}/${part}`,
+      children: [],
+    };
+    directory.children.push(next);
+    directory = next;
+  }
+  directory.children.push({
+    kind: "file",
+    name: parts.at(-1) ?? absolutePath,
+    path: absolutePath,
+    change,
+  });
+}
+
+function sortChildren(directory: GitChangeDirectoryNode) {
+  directory.children.sort((left, right) => {
+    if (left.kind !== right.kind) return left.kind === "directory" ? -1 : 1;
+    return left.name.localeCompare(right.name);
+  });
+  for (const child of directory.children) {
+    if (child.kind === "directory") sortChildren(child);
+  }
+}
+
+function relativeToRoot(rootPath: string, path: string) {
+  const root = rootPath.replace(/\/+$/, "") || "/";
+  if (root === "/") return path.replace(/^\/+/, "");
+  return path.startsWith(`${root}/`) ? path.slice(root.length + 1) : null;
+}

--- a/app/composables/files/useFileGitWorkspace.ts
+++ b/app/composables/files/useFileGitWorkspace.ts
@@ -1,0 +1,34 @@
+import { computed, type MaybeRefOrGetter, toValue } from "vue";
+import type { RemoteGitWorkspaceFile } from "~~/shared/types";
+import { useFileGitWorkspaceStore } from "@/stores/file-workspace/git/workspace";
+
+export function useFileGitWorkspace(input: {
+  hostId: MaybeRefOrGetter<number>;
+  projectId: MaybeRefOrGetter<number | null>;
+  rootPath: MaybeRefOrGetter<string>;
+}) {
+  const store = useFileGitWorkspaceStore();
+  const scope = computed(() => {
+    const projectId = toValue(input.projectId);
+    const rootPath = toValue(input.rootPath);
+    return projectId === null || rootPath === ""
+      ? null
+      : { hostId: toValue(input.hostId), projectId, rootPath };
+  });
+  const state = computed(() => (scope.value === null ? null : store.stateFor(scope.value)));
+  const changes = computed(() => (scope.value === null ? [] : store.changesFor(scope.value)));
+
+  return {
+    scope,
+    state,
+    changes,
+    load: () => (scope.value === null ? Promise.resolve(null) : store.load(scope.value)),
+    refresh: () => (scope.value === null ? Promise.resolve(null) : store.load(scope.value, true)),
+    changeForPath: (path: string) =>
+      scope.value === null ? null : store.changeForPath(scope.value, path),
+    descendantChangeCount: (path: string) =>
+      scope.value === null ? 0 : store.descendantChangeCount(scope.value, path),
+    pathForChange: (change: RemoteGitWorkspaceFile) =>
+      scope.value === null ? null : store.pathForChange(scope.value, change),
+  };
+}

--- a/app/composables/files/useFileWorkspaceLifecycle.ts
+++ b/app/composables/files/useFileWorkspaceLifecycle.ts
@@ -3,6 +3,7 @@ import type { MaybeRefOrGetter } from "vue";
 import { toValue, watch } from "vue";
 import { useAuthStore } from "@/stores/auth";
 import { useGatewayFileWorkspaceStore } from "@/stores/file-workspace";
+import { useFileGitWorkspaceStore } from "@/stores/file-workspace/git/workspace";
 
 export function useFileWorkspaceLifecycle(input: {
   hostId: MaybeRefOrGetter<number>;
@@ -12,6 +13,7 @@ export function useFileWorkspaceLifecycle(input: {
   active: MaybeRefOrGetter<boolean>;
 }) {
   const workspace = useGatewayFileWorkspaceStore();
+  const gitWorkspace = useFileGitWorkspaceStore();
   const auth = useAuthStore();
   auth.hydrate();
 
@@ -20,7 +22,15 @@ export function useFileWorkspaceLifecycle(input: {
     return Promise.all([
       workspace.revalidateActiveFile(toValue(input.hostId), toValue(input.threadId)),
       workspace.refreshExpandedDirectories(toValue(input.hostId), toValue(input.threadId)),
+      refreshGitWorkspace(),
     ]);
+  };
+
+  const refreshGitWorkspace = () => {
+    const projectId = toValue(input.projectId);
+    const rootPath = toValue(input.rootPath);
+    if (projectId === null || rootPath === "") return Promise.resolve(null);
+    return gitWorkspace.load({ hostId: toValue(input.hostId), projectId, rootPath });
   };
 
   watch(
@@ -36,6 +46,7 @@ export function useFileWorkspaceLifecycle(input: {
       if (!rootPath || !authenticated) return;
       workspace.setScopeRoot({ hostId, projectId, threadId, rootPath });
       await workspace.restoreScope(hostId, threadId);
+      if (projectId !== null) await gitWorkspace.load({ hostId, projectId, rootPath });
     },
     { immediate: true },
   );

--- a/app/plugins/workspace-dock.ts
+++ b/app/plugins/workspace-dock.ts
@@ -10,6 +10,9 @@ const asyncPanels = {
   WorkspaceDockFilesPanel: defineAsyncComponent(
     () => import("@/components/chat/workspace-dock/WorkspaceDockFilesPanel.vue"),
   ),
+  WorkspaceDockGitReviewPanel: defineAsyncComponent(
+    () => import("@/components/chat/workspace-dock/WorkspaceDockGitReviewPanel.vue"),
+  ),
   WorkspaceDockHostMetricsPanel: defineAsyncComponent(
     () => import("@/components/chat/workspace-dock/WorkspaceDockHostMetricsPanel.vue"),
   ),

--- a/app/stores/file-workspace/document-actions.ts
+++ b/app/stores/file-workspace/document-actions.ts
@@ -40,6 +40,7 @@ export function createFileDocumentActions(options: FileDocumentActionsOptions) {
     };
     const document = ensureDocument(input);
     document.line = input.line ?? document.line;
+    document.requestedView = input.view ?? document.requestedView;
     document.updatedAt = Date.now();
     if (document.objectUrl === "" && !document.loading) await loadDocument(document);
   }
@@ -67,8 +68,8 @@ export function createFileDocumentActions(options: FileDocumentActionsOptions) {
     const index = scope.openPaths.indexOf(path);
     if (index < 0) return;
     const key = fileDocumentKey(hostId, threadId, path);
-    const document = documents.value[key];
-    if (document !== undefined) gitComparisons.remove(document);
+    // Git comparisons are path-scoped and may still be rendered by the Changes review panel.
+    // Closing one editor owns only its document; page-level resetRuntime clears shared baselines.
     loadControllers.get(key)?.abort();
     loadControllers.delete(key);
     disposeFileDocument(documents.value[key]);
@@ -120,6 +121,10 @@ export function createFileDocumentActions(options: FileDocumentActionsOptions) {
     position: { left: number; top: number },
   ) {
     viewPositions.value = { ...viewPositions.value, [`${documentKey}:${view}`]: position };
+  }
+
+  function consumeDocumentViewRequest(document: FilePreviewDocument) {
+    document.requestedView = null;
   }
 
   async function restoreScopeDocuments(hostId: number, threadId: string) {
@@ -203,6 +208,7 @@ export function createFileDocumentActions(options: FileDocumentActionsOptions) {
     fileForDocument,
     viewPositionFor,
     rememberViewPosition,
+    consumeDocumentViewRequest,
     restoreScopeDocuments,
     reloadDocument,
     revalidateActiveFile,

--- a/app/stores/file-workspace/document-runtime.ts
+++ b/app/stores/file-workspace/document-runtime.ts
@@ -35,6 +35,7 @@ export function createFileDocument(input: OpenWorkspaceFileInput) {
     etag: null,
     lastModified: null,
     stale: true,
+    requestedView: input.view ?? null,
   });
 }
 

--- a/app/stores/file-workspace/git/index.ts
+++ b/app/stores/file-workspace/git/index.ts
@@ -3,131 +3,145 @@ import { reactive, shallowRef } from "vue";
 import { MAX_EDITABLE_FILE_BYTES } from "~~/shared/file-preview";
 import type { FilePreviewDocument, RemoteGitFileComparison } from "~~/shared/types";
 import { compareRemoteGitFile } from "./transport";
-import type { FileGitComparisonState } from "./types";
+import type { FileGitComparisonState, FileGitComparisonTarget } from "./types";
 
 export const useFileGitComparisonStore = defineStore("file-git-comparisons", () => {
   const states = shallowRef<Record<string, FileGitComparisonState>>({});
-  const owners = new Map<string, FilePreviewDocument>();
   const requestTokens = new Map<string, symbol>();
   const pendingLoads = new Map<string, Promise<FileGitComparisonState>>();
 
-  function register(document: FilePreviewDocument): FileGitComparisonState {
-    if (owners.get(document.key) === document) return stateFor(document);
-    supersede(document.key);
-    pendingLoads.delete(document.key);
-    owners.set(document.key, document);
-    const state = createState(document.key);
-    states.value = { ...states.value, [document.key]: state };
+  function register(document: FilePreviewDocument) {
+    return document.projectId === null
+      ? stateForUnavailableDocument(document.key)
+      : stateForTarget(target(document));
+  }
+
+  function stateFor(document: FilePreviewDocument) {
+    return register(document);
+  }
+
+  function stateForTarget(input: FileGitComparisonTarget) {
+    const key = comparisonKey(input);
+    const existing = states.value[key];
+    if (existing !== undefined) return existing;
+    const state = createState(key);
+    states.value = { ...states.value, [key]: state };
     return state;
   }
 
-  function stateFor(document: FilePreviewDocument): FileGitComparisonState {
-    const owner = owners.get(document.key);
-    if (owner === undefined) return register(document);
-    const existing = states.value[document.key];
-    if (existing === undefined) return register(document);
-    return existing;
+  function stateForUnavailableDocument(documentKey: string) {
+    const key = `unavailable:${documentKey}`;
+    const existing = states.value[key];
+    if (existing !== undefined) return existing;
+    const state = createState(key);
+    states.value = { ...states.value, [key]: state };
+    return state;
   }
 
-  function load(document: FilePreviewDocument, force = false): Promise<FileGitComparisonState> {
+  function load(document: FilePreviewDocument, force = false) {
     const state = stateFor(document);
-    // File keys are stable across close/reopen, but each document object is one lifecycle
-    // generation. Late save/load continuations from a closed generation must never invalidate or
-    // replace the comparison owned by the reopened editor.
-    if (owners.get(document.key) !== document) return Promise.resolve(state);
-    if (force) invalidate(document.key);
-    if (!canCompare(document)) {
-      supersede(document.key);
+    if (!canCompare(document) || document.projectId === null) {
       clearResult(state);
       state.stale = false;
       state.loading = false;
       return Promise.resolve(state);
     }
+    return loadTarget(target(document), force);
+  }
+
+  function loadTarget(
+    input: FileGitComparisonTarget,
+    force = false,
+  ): Promise<FileGitComparisonState> {
+    const state = stateForTarget(input);
+    if (force) invalidateTarget(input);
     if (!force && state.loaded && !state.stale) return Promise.resolve(state);
-    const pending = pendingLoads.get(document.key);
+    const pending = pendingLoads.get(state.key);
     if (pending !== undefined) {
-      // A save or remote file event can invalidate an in-flight request. Wait for its SSH channel
-      // to close, then start one fresh comparison instead of opening competing exec channels.
-      return pending.then(() => (state.stale ? load(document) : state));
+      // One path has one browser-side comparison request regardless of whether the Files editor or
+      // the review panel asked first. Invalidations wait for that request to settle before issuing
+      // a fresh read, matching the server's per-host SSH singleflight.
+      return pending.then(() => (state.stale ? loadTarget(input) : state));
     }
 
-    const token = Symbol(document.key);
-    requestTokens.set(document.key, token);
+    const token = Symbol(state.key);
+    requestTokens.set(state.key, token);
     state.loading = true;
     state.error = null;
-    const operation = performLoad(document, state, token);
     let tracked: Promise<FileGitComparisonState>;
-    tracked = operation.finally(() => {
-      if (pendingLoads.get(document.key) === tracked) pendingLoads.delete(document.key);
+    tracked = performLoad(input, state, token).finally(() => {
+      if (pendingLoads.get(state.key) === tracked) pendingLoads.delete(state.key);
     });
-    pendingLoads.set(document.key, tracked);
+    pendingLoads.set(state.key, tracked);
     return tracked;
   }
 
   async function performLoad(
-    document: FilePreviewDocument,
+    input: FileGitComparisonTarget,
     state: FileGitComparisonState,
     token: symbol,
   ) {
     try {
-      const comparison = await compareRemoteGitFile({
-        hostId: document.hostId,
-        projectId: document.projectId!,
-        path: document.path,
-      });
-      if (requestTokens.get(document.key) !== token) return state;
+      const comparison = await compareRemoteGitFile(input);
+      if (requestTokens.get(state.key) !== token) return state;
       state.comparison = comparison;
       state.baselineText = baselineText(comparison);
       state.loaded = true;
       state.stale = false;
       return state;
     } catch (error: unknown) {
-      if (requestTokens.get(document.key) !== token) return state;
+      if (requestTokens.get(state.key) !== token) return state;
       state.error = error instanceof Error ? error.message : String(error);
       state.stale = true;
       return state;
     } finally {
-      if (requestTokens.get(document.key) === token) {
-        requestTokens.delete(document.key);
+      if (requestTokens.get(state.key) === token) {
+        requestTokens.delete(state.key);
         state.loading = false;
       }
     }
   }
 
-  function invalidate(key: string) {
-    const state = states.value[key];
-    if (state !== undefined) state.stale = true;
-    supersede(key);
+  function invalidate(document: FilePreviewDocument) {
+    if (document.projectId !== null) invalidateTarget(target(document));
   }
 
-  function supersede(key: string) {
+  function invalidateTarget(input: FileGitComparisonTarget) {
+    const key = comparisonKey(input);
+    const state = states.value[key];
+    if (state !== undefined) state.stale = true;
     requestTokens.delete(key);
   }
 
-  function remove(document: FilePreviewDocument) {
-    if (owners.get(document.key) !== document) return;
-    owners.delete(document.key);
-    supersede(document.key);
-    // Closing a file ends the UI lifecycle of its request. The WebSocket response may still arrive,
-    // but a quick reopen must create a loading state and a fresh generation instead of waiting on
-    // an invisible promise owned by the removed document. Server-side singleflight deduplicates the
-    // underlying SSH comparison while both generations overlap.
-    pendingLoads.delete(document.key);
-    if (states.value[document.key] === undefined) return;
-    const next = { ...states.value };
-    delete next[document.key];
-    states.value = next;
-  }
-
   function reset() {
-    owners.clear();
     requestTokens.clear();
     pendingLoads.clear();
     states.value = {};
   }
 
-  return { states, register, stateFor, load, invalidate, remove, reset };
+  return {
+    states,
+    register,
+    stateFor,
+    stateForTarget,
+    load,
+    loadTarget,
+    invalidate,
+    invalidateTarget,
+    reset,
+  };
 });
+
+function target(document: FilePreviewDocument): FileGitComparisonTarget {
+  if (document.projectId === null) {
+    throw new Error("A project is required to compare a remote Git file");
+  }
+  return { hostId: document.hostId, projectId: document.projectId, path: document.path };
+}
+
+function comparisonKey(input: FileGitComparisonTarget) {
+  return `${input.hostId}:${input.projectId}:${input.path}`;
+}
 
 function createState(key: string) {
   return reactive<FileGitComparisonState>({

--- a/app/stores/file-workspace/git/review-panel.ts
+++ b/app/stores/file-workspace/git/review-panel.ts
@@ -1,0 +1,41 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const useFileGitReviewPanelStore = defineStore("file-git-review-panels", () => {
+  const scopes = ref<Record<string, { selectedPath: string | null }>>({});
+
+  function open(scopeKey: string, selectedPath: string | null = null) {
+    scopes.value = {
+      ...scopes.value,
+      [scopeKey]: {
+        selectedPath: selectedPath ?? scopes.value[scopeKey]?.selectedPath ?? null,
+      },
+    };
+  }
+
+  function select(scopeKey: string, selectedPath: string) {
+    if (scopes.value[scopeKey] === undefined) return;
+    scopes.value = { ...scopes.value, [scopeKey]: { selectedPath } };
+  }
+
+  function close(scopeKey: string) {
+    if (scopes.value[scopeKey] === undefined) return;
+    const next = { ...scopes.value };
+    delete next[scopeKey];
+    scopes.value = next;
+  }
+
+  function isOpen(scopeKey: string) {
+    return scopes.value[scopeKey] !== undefined;
+  }
+
+  function selectedPathFor(scopeKey: string) {
+    return scopes.value[scopeKey]?.selectedPath ?? null;
+  }
+
+  function reset() {
+    scopes.value = {};
+  }
+
+  return { scopes, open, select, close, isOpen, selectedPathFor, reset };
+});

--- a/app/stores/file-workspace/git/types.ts
+++ b/app/stores/file-workspace/git/types.ts
@@ -9,3 +9,9 @@ export interface FileGitComparisonState {
   comparison: RemoteGitFileComparison | null;
   baselineText: string | null;
 }
+
+export interface FileGitComparisonTarget {
+  hostId: number;
+  projectId: number;
+  path: string;
+}

--- a/app/stores/file-workspace/git/workspace-index.ts
+++ b/app/stores/file-workspace/git/workspace-index.ts
@@ -1,0 +1,52 @@
+import type { RemoteGitWorkspaceFile, RemoteGitWorkspaceSnapshot } from "~~/shared/types";
+import { changeIsInWorkspace, workspacePathForGitChange } from "./workspace-paths";
+import type { GitWorkspaceScopeInput } from "./workspace-types";
+
+export interface GitWorkspaceIndex {
+  changes: RemoteGitWorkspaceFile[];
+  changeByPath: ReadonlyMap<string, RemoteGitWorkspaceFile>;
+  descendantChangeCountByPath: ReadonlyMap<string, number>;
+}
+
+export function indexGitWorkspaceSnapshot(
+  input: GitWorkspaceScopeInput,
+  snapshot: RemoteGitWorkspaceSnapshot,
+): GitWorkspaceIndex {
+  if (snapshot.availability !== "available") return emptyGitWorkspaceIndex();
+  const changes = snapshot.files.filter((change) => changeIsInWorkspace(snapshot, change));
+  const changeByPath = new Map<string, RemoteGitWorkspaceFile>();
+  const descendantChangeCountByPath = new Map<string, number>();
+  const rootPath = normalize(input.rootPath);
+
+  for (const change of changes) {
+    const path = workspacePathForGitChange(input, snapshot, change);
+    if (path === null) continue;
+    changeByPath.set(path, change);
+    for (let parent = parentPath(path); parent !== null; parent = parentPath(parent)) {
+      if (parent !== rootPath && !parent.startsWith(`${rootPath === "/" ? "" : rootPath}/`)) break;
+      descendantChangeCountByPath.set(parent, (descendantChangeCountByPath.get(parent) ?? 0) + 1);
+      if (parent === rootPath) break;
+    }
+  }
+
+  return { changes, changeByPath, descendantChangeCountByPath };
+}
+
+export function emptyGitWorkspaceIndex(): GitWorkspaceIndex {
+  return {
+    changes: [],
+    changeByPath: new Map(),
+    descendantChangeCountByPath: new Map(),
+  };
+}
+
+function parentPath(path: string) {
+  if (path === "/") return null;
+  const separator = path.lastIndexOf("/");
+  return separator <= 0 ? "/" : path.slice(0, separator);
+}
+
+function normalize(path: string) {
+  const normalized = path.replace(/\/+$/, "");
+  return normalized === "" ? "/" : normalized;
+}

--- a/app/stores/file-workspace/git/workspace-paths.ts
+++ b/app/stores/file-workspace/git/workspace-paths.ts
@@ -1,0 +1,48 @@
+import type { RemoteGitWorkspaceFile, RemoteGitWorkspaceSnapshot } from "~~/shared/types";
+import type { GitWorkspaceScopeInput } from "./workspace-types";
+
+export function gitWorkspaceKey(input: GitWorkspaceScopeInput) {
+  return `${input.hostId}:${input.projectId}:${normalize(input.rootPath)}`;
+}
+
+export function workspacePathForGitChange(
+  input: GitWorkspaceScopeInput,
+  snapshot: Extract<RemoteGitWorkspaceSnapshot, { availability: "available" }>,
+  change: RemoteGitWorkspaceFile,
+) {
+  const relative = stripWorkspacePrefix(snapshot.workspaceRelativePath, change.relativePath);
+  return relative === null ? null : joinAbsolute(input.rootPath, relative);
+}
+
+export function changeIsInWorkspace(
+  snapshot: Extract<RemoteGitWorkspaceSnapshot, { availability: "available" }>,
+  change: RemoteGitWorkspaceFile,
+) {
+  return stripWorkspacePrefix(snapshot.workspaceRelativePath, change.relativePath) !== null;
+}
+
+function stripWorkspacePrefix(prefix: string, path: string) {
+  const normalizedPrefix = trimSlashes(prefix);
+  const normalizedPath = trimSlashes(path);
+  if (normalizedPrefix === "") return normalizedPath;
+  if (normalizedPath === normalizedPrefix) return "";
+  return normalizedPath.startsWith(`${normalizedPrefix}/`)
+    ? normalizedPath.slice(normalizedPrefix.length + 1)
+    : null;
+}
+
+function joinAbsolute(root: string, relative: string) {
+  const normalizedRoot = normalize(root);
+  return relative === ""
+    ? normalizedRoot
+    : `${normalizedRoot === "/" ? "" : normalizedRoot}/${relative}`;
+}
+
+function trimSlashes(path: string) {
+  return path.replace(/^\/+|\/+$/g, "");
+}
+
+function normalize(path: string) {
+  const normalized = path.replace(/\/+$/, "");
+  return normalized === "" ? "/" : normalized;
+}

--- a/app/stores/file-workspace/git/workspace-transport.ts
+++ b/app/stores/file-workspace/git/workspace-transport.ts
@@ -1,0 +1,18 @@
+import type { RemoteGitWorkspaceSnapshot } from "~~/shared/types";
+import { useGatewayRealtimeStore } from "@/stores/gateway-realtime";
+import { expectFileGitWorkspaceSnapshot } from "@/stores/gateway-realtime/response-parsers";
+import type { GitWorkspaceScopeInput } from "./workspace-types";
+
+export async function inspectRemoteGitWorkspace(
+  input: GitWorkspaceScopeInput,
+): Promise<RemoteGitWorkspaceSnapshot> {
+  const response = await useGatewayRealtimeStore().request(
+    (requestId) => ({
+      type: "file.git.workspace.inspect",
+      requestId,
+      ...input,
+    }),
+    expectFileGitWorkspaceSnapshot,
+  );
+  return response.snapshot;
+}

--- a/app/stores/file-workspace/git/workspace-types.ts
+++ b/app/stores/file-workspace/git/workspace-types.ts
@@ -1,0 +1,19 @@
+import type { RemoteGitWorkspaceFile, RemoteGitWorkspaceSnapshot } from "~~/shared/types";
+
+export interface GitWorkspaceScopeInput {
+  hostId: number;
+  projectId: number;
+  rootPath: string;
+}
+
+export interface FileGitWorkspaceState extends GitWorkspaceScopeInput {
+  key: string;
+  loading: boolean;
+  loaded: boolean;
+  stale: boolean;
+  error: string | null;
+  snapshot: RemoteGitWorkspaceSnapshot | null;
+  changes: RemoteGitWorkspaceFile[];
+  changeByPath: ReadonlyMap<string, RemoteGitWorkspaceFile>;
+  descendantChangeCountByPath: ReadonlyMap<string, number>;
+}

--- a/app/stores/file-workspace/git/workspace.ts
+++ b/app/stores/file-workspace/git/workspace.ts
@@ -1,0 +1,123 @@
+import { defineStore } from "pinia";
+import { reactive, shallowRef } from "vue";
+import type { RemoteGitWorkspaceFile } from "~~/shared/types";
+import { inspectRemoteGitWorkspace } from "./workspace-transport";
+import { gitWorkspaceKey, workspacePathForGitChange } from "./workspace-paths";
+import type { FileGitWorkspaceState, GitWorkspaceScopeInput } from "./workspace-types";
+import { emptyGitWorkspaceIndex, indexGitWorkspaceSnapshot } from "./workspace-index";
+
+export const useFileGitWorkspaceStore = defineStore("file-git-workspaces", () => {
+  const states = shallowRef<Record<string, FileGitWorkspaceState>>({});
+  const pending = new Map<string, Promise<FileGitWorkspaceState>>();
+  const versions = new Map<string, number>();
+
+  function stateFor(input: GitWorkspaceScopeInput) {
+    const key = gitWorkspaceKey(input);
+    const existing = states.value[key];
+    if (existing !== undefined) return existing;
+    const state = reactive<FileGitWorkspaceState>({
+      ...input,
+      key,
+      loading: false,
+      loaded: false,
+      stale: true,
+      error: null,
+      snapshot: null,
+      ...emptyGitWorkspaceIndex(),
+    });
+    states.value = { ...states.value, [key]: state };
+    return state;
+  }
+
+  function load(input: GitWorkspaceScopeInput, force = false): Promise<FileGitWorkspaceState> {
+    const state = stateFor(input);
+    if (force) invalidate(input);
+    if (!state.stale && state.loaded) return Promise.resolve(state);
+    const active = pending.get(state.key);
+    if (active !== undefined) return active;
+    state.loading = true;
+    state.error = null;
+    let tracked: Promise<FileGitWorkspaceState>;
+    tracked = loadCurrentVersion(input, state).finally(() => {
+      state.loading = false;
+      if (pending.get(state.key) === tracked) pending.delete(state.key);
+    });
+    pending.set(state.key, tracked);
+    return tracked;
+  }
+
+  function invalidate(input: GitWorkspaceScopeInput) {
+    const state = stateFor(input);
+    versions.set(state.key, versionFor(state.key) + 1);
+    state.stale = true;
+  }
+
+  async function loadCurrentVersion(
+    input: GitWorkspaceScopeInput,
+    state: FileGitWorkspaceState,
+  ): Promise<FileGitWorkspaceState> {
+    // A save/delete event can invalidate Git while the previous SSH status command is still in
+    // flight. Keep one browser request pipeline and immediately repeat inside it until the version
+    // observed before the request is still current. Do not let a late response clear `stale`, and
+    // do not launch parallel status commands to compensate for that race.
+    while (true) {
+      const requestedVersion = versionFor(state.key);
+      try {
+        const snapshot = await inspectRemoteGitWorkspace(input);
+        if (requestedVersion !== versionFor(state.key)) continue;
+        state.snapshot = snapshot;
+        Object.assign(state, indexGitWorkspaceSnapshot(input, snapshot));
+        state.loaded = true;
+        state.stale = false;
+        state.error = null;
+        return state;
+      } catch (error: unknown) {
+        if (requestedVersion !== versionFor(state.key)) continue;
+        state.error = error instanceof Error ? error.message : String(error);
+        state.stale = true;
+        return state;
+      }
+    }
+  }
+
+  function versionFor(key: string) {
+    return versions.get(key) ?? 0;
+  }
+
+  function changesFor(input: GitWorkspaceScopeInput) {
+    return stateFor(input).changes;
+  }
+
+  function changeForPath(input: GitWorkspaceScopeInput, path: string) {
+    return stateFor(input).changeByPath.get(path) ?? null;
+  }
+
+  function descendantChangeCount(input: GitWorkspaceScopeInput, path: string) {
+    return stateFor(input).descendantChangeCountByPath.get(path) ?? 0;
+  }
+
+  function pathForChange(input: GitWorkspaceScopeInput, change: RemoteGitWorkspaceFile) {
+    const snapshot = stateFor(input).snapshot;
+    return snapshot?.availability === "available"
+      ? workspacePathForGitChange(input, snapshot, change)
+      : null;
+  }
+
+  function reset() {
+    pending.clear();
+    versions.clear();
+    states.value = {};
+  }
+
+  return {
+    states,
+    stateFor,
+    load,
+    invalidate,
+    changesFor,
+    changeForPath,
+    descendantChangeCount,
+    pathForChange,
+    reset,
+  };
+});

--- a/app/stores/file-workspace/index.ts
+++ b/app/stores/file-workspace/index.ts
@@ -21,6 +21,7 @@ import {
 import type { RemoteDirectoryState } from "./types";
 import type { FileWorkspaceScope } from "./types";
 import { useFileGitComparisonStore } from "./git";
+import { useFileGitWorkspaceStore } from "./git/workspace";
 
 export { fileWorkspaceScopeKey } from "./paths";
 
@@ -28,6 +29,7 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
   const directories = shallowRef<Record<string, RemoteDirectoryState>>({});
   const directoryLoader = new RemoteDirectoryLoader();
   const gitComparisons = useFileGitComparisonStore();
+  const gitWorkspaces = useFileGitWorkspaceStore();
   const scopes = useAccountLocalStorage<Record<string, FileWorkspaceScope>>(
     "file-workspace-scopes",
     {},
@@ -129,12 +131,14 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
       directory.stale = true;
       await loadDirectory(hostId, threadId, directoryPath, true);
     }
+    invalidateGitWorkspace(hostId, threadId);
   }
 
   async function saveDocument(document: Parameters<typeof saveFileDocument>[0], force = false) {
     const result = await saveFileDocument(document, force);
     if (result.ok && result.wrote) {
       void gitComparisons.load(document, true);
+      invalidateGitWorkspace(document.hostId, document.threadId);
     }
     return result.ok;
   }
@@ -142,6 +146,7 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
   async function discardDocumentDraft(document: Parameters<typeof discardFileDocumentDraft>[0]) {
     const result = await discardFileDocumentDraft(document);
     void gitComparisons.load(document, true);
+    invalidateGitWorkspace(document.hostId, document.threadId);
     return result;
   }
 
@@ -150,13 +155,20 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
     if (!scope) {
       return;
     }
+    if (scope.projectId !== null) {
+      gitWorkspaces.invalidate({
+        hostId: scope.hostId,
+        projectId: scope.projectId,
+        rootPath: scope.rootPath,
+      });
+    }
     const directoriesToRefresh = new Set<string>();
     for (const sourcePath of paths) {
       const path = absolutePath(scope.rootPath, sourcePath);
       const document = documentActions.documentFor(hostId, threadId, path);
       if (document) {
         document.stale = true;
-        gitComparisons.invalidate(document.key);
+        gitComparisons.invalidate(document);
       }
       for (const parent of parentPaths(path)) {
         const directory = directoryFor(hostId, threadId, parent);
@@ -181,6 +193,16 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
     return state;
   }
 
+  function invalidateGitWorkspace(hostId: number, threadId: string) {
+    const scope = scopeFor(hostId, threadId);
+    if (scope?.projectId === null || scope?.projectId === undefined) return;
+    gitWorkspaces.invalidate({
+      hostId: scope.hostId,
+      projectId: scope.projectId,
+      rootPath: scope.rootPath,
+    });
+  }
+
   function clearScopeDirectories(scope: string) {
     directories.value = Object.fromEntries(
       Object.entries(directories.value).filter(([key]) => !key.startsWith(`${scope}:`)),
@@ -192,6 +214,7 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
     directories.value = {};
     documentActions.resetRuntime();
     gitComparisons.reset();
+    gitWorkspaces.reset();
   }
 
   return {
@@ -207,6 +230,7 @@ export const useGatewayFileWorkspaceStore = defineStore("gateway-file-workspace"
     fileForDocument: documentActions.fileForDocument,
     viewPositionFor: documentActions.viewPositionFor,
     rememberViewPosition: documentActions.rememberViewPosition,
+    consumeDocumentViewRequest: documentActions.consumeDocumentViewRequest,
     restoreScope,
     reloadDocument: documentActions.reloadDocument,
     revalidateActiveFile: documentActions.revalidateActiveFile,

--- a/app/stores/file-workspace/types.ts
+++ b/app/stores/file-workspace/types.ts
@@ -25,4 +25,5 @@ export interface OpenWorkspaceFileInput {
   threadId: string;
   path: string;
   line?: number | null;
+  view?: "source" | "changes";
 }

--- a/app/stores/gateway-bootstrap/session-reset.ts
+++ b/app/stores/gateway-bootstrap/session-reset.ts
@@ -12,6 +12,7 @@ import { useGatewayThreadTurnsStore } from "@/stores/gateway-thread-turns";
 import { useGatewayThreadViewStore } from "@/stores/gateway-thread-view";
 import { useGatewayTmuxStore } from "@/stores/gateway-tmux";
 import { useGatewayWorkspaceLayoutStore } from "@/stores/gateway-workspace-layout";
+import { useFileGitReviewPanelStore } from "@/stores/file-workspace/git/review-panel";
 import { useGatewayBootstrapStore } from ".";
 
 /**
@@ -37,5 +38,6 @@ export function resetGatewayClientSession() {
   useGatewayBrowserStore().resetRuntime();
   useGatewayTmuxStore().resetState();
   useGatewayFileWorkspaceStore().resetRuntime();
+  useFileGitReviewPanelStore().reset();
   useGatewayWorkspaceLayoutStore().resetRuntimeState();
 }

--- a/app/stores/gateway-realtime/response-parsers.ts
+++ b/app/stores/gateway-realtime/response-parsers.ts
@@ -19,6 +19,13 @@ export function expectFileGitComparison(message: RealtimeResponseMessage) {
   return message;
 }
 
+export function expectFileGitWorkspaceSnapshot(message: RealtimeResponseMessage) {
+  if (message.type !== "file.git.workspace.snapshot") {
+    unexpectedResponse("file.git.workspace.snapshot", message.type);
+  }
+  return message;
+}
+
 export function expectThreadGoalUpdated(message: RealtimeResponseMessage) {
   if (message.type !== "thread.goal.updated") {
     unexpectedResponse("thread.goal.updated", message.type);

--- a/app/stores/gateway-realtime/server-message-handlers.ts
+++ b/app/stores/gateway-realtime/server-message-handlers.ts
@@ -51,6 +51,7 @@ export function createRealtimeServerMessageDispatcher(ctx: RealtimeServerMessage
       .with({ type: "browser.framePolicyWarning" }, browser["browser.framePolicyWarning"])
       .with({ type: "browser.resourceFailed" }, browser["browser.resourceFailed"])
       .with({ type: "file.git.comparison" }, (response) => ctx.resolveRequest(response))
+      .with({ type: "file.git.workspace.snapshot" }, (response) => ctx.resolveRequest(response))
       .with({ type: "notification.published" }, notifications["notification.published"])
       .with({ type: "host.lifecycle" }, notifications["host.lifecycle"])
       .with({ type: "host.metrics.snapshot" }, hostMetrics["host.metrics.snapshot"])

--- a/app/stores/gateway/workspace-panels.ts
+++ b/app/stores/gateway/workspace-panels.ts
@@ -1,5 +1,6 @@
 export const AGENT_WORKSPACE_PANEL_ID = "agent";
 export const FILES_WORKSPACE_PANEL_ID = "files";
+export const GIT_REVIEW_WORKSPACE_PANEL_ID = "git-review";
 export const TMUX_WORKSPACE_PANEL_ID = "tmux";
 export const HOST_METRICS_WORKSPACE_PANEL_ID = "host-metrics";
 

--- a/app/utils/git-status-presentation.ts
+++ b/app/utils/git-status-presentation.ts
@@ -1,0 +1,42 @@
+import type { RemoteGitFileStatus } from "~~/shared/types";
+
+export function gitStatusCode(status: RemoteGitFileStatus) {
+  switch (status) {
+    case "modified":
+      return "M";
+    case "added":
+      return "A";
+    case "deleted":
+      return "D";
+    case "renamed":
+      return "R";
+    case "copied":
+      return "C";
+    case "untracked":
+      return "U";
+    case "conflicted":
+      return "!";
+    case "clean":
+    case "ignored":
+      return "";
+  }
+}
+
+export function gitStatusTextClass(status: RemoteGitFileStatus) {
+  switch (status) {
+    case "added":
+    case "untracked":
+      return "text-accent-green";
+    case "deleted":
+    case "conflicted":
+      return "text-destructive";
+    case "renamed":
+    case "copied":
+      return "text-primary";
+    case "modified":
+      return "text-accent-orange";
+    case "clean":
+    case "ignored":
+      return "text-ink-muted";
+  }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -62,6 +62,13 @@
     "fileGitRefresh": "Refresh Git changes",
     "fileGitPreviousChange": "Previous change",
     "fileGitNextChange": "Next change",
+    "fileGitExpandAll": "Expand all change folders",
+    "fileGitCollapseAll": "Collapse all change folders",
+    "fileGitWorkspaceUnavailable": "The workspace is not inside a Git repository",
+    "fileGitDescendantChanges": "{count} changed files in this folder",
+    "fileGitSelectChange": "Select a changed file to review",
+    "fileGitOpenReview": "Open full change review",
+    "fileGitReviewTab": "Review Changes",
     "fileGitStatus": {
       "clean": "Unmodified",
       "modified": "Modified",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -62,6 +62,13 @@
     "fileGitRefresh": "刷新 Git 变更",
     "fileGitPreviousChange": "上一处变更",
     "fileGitNextChange": "下一处变更",
+    "fileGitExpandAll": "展开所有变更目录",
+    "fileGitCollapseAll": "折叠所有变更目录",
+    "fileGitWorkspaceUnavailable": "当前工作区不在 Git 仓库中",
+    "fileGitDescendantChanges": "此文件夹包含 {count} 个变更文件",
+    "fileGitSelectChange": "选择一个变更文件进行审查",
+    "fileGitOpenReview": "打开完整变更审查",
+    "fileGitReviewTab": "审查变更",
     "fileGitStatus": {
       "clean": "未修改",
       "modified": "已修改",

--- a/server/utils/gateway/infra/git/git-status-parser.ts
+++ b/server/utils/gateway/infra/git/git-status-parser.ts
@@ -1,0 +1,92 @@
+import type { RemoteGitFileStatus, RemoteGitWorkspaceFile } from "~~/shared/types";
+
+export interface ParsedGitStatusRecord extends RemoteGitWorkspaceFile {}
+
+/** Parse `git status --porcelain=v2 -z` without splitting paths on whitespace.
+ *
+ * Porcelain v2 gives each ordinary record a fixed number of metadata fields. Rename/copy records
+ * additionally put the original path in the following NUL record. Keeping this parser at the SSH
+ * boundary gives single-file comparison and workspace review one interpretation of Git state; UI
+ * code must never infer status from labels or run one Git command per tree row.
+ */
+export function parseGitStatusRecords(records: string[]): ParsedGitStatusRecord[] {
+  const parsed: ParsedGitStatusRecord[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (record === undefined || record === "") continue;
+    if (record.startsWith("? ")) {
+      const relativePath = record.slice(2);
+      // Even with `--untracked-files=all`, Git reports an embedded repository as one directory
+      // entry. The file review protocol intentionally models files only; exposing that directory as
+      // a file would make the tree attempt an invalid read and compare it against the outer repo.
+      if (!relativePath.endsWith("/")) {
+        parsed.push(change(relativePath, null, "untracked", false, true));
+      }
+      continue;
+    }
+    if (record.startsWith("! ")) continue;
+
+    const kind = record[0];
+    const fields = fixedFields(record, kind === "2" ? 10 : kind === "u" ? 11 : 9);
+    const xy = fields[1];
+    const relativePath = fields.at(-1);
+    if (xy === undefined || relativePath === undefined || relativePath === "") {
+      throw new Error("Remote Git status returned an incomplete porcelain v2 record");
+    }
+    const staged = xy[0] !== ".";
+    const unstaged = xy[1] !== ".";
+    if (kind === "u") {
+      parsed.push(change(relativePath, null, "conflicted", staged, unstaged));
+      continue;
+    }
+    if (kind === "2") {
+      const originalPath = records[index + 1];
+      if (originalPath === undefined || originalPath === "") {
+        throw new Error("Remote Git rename record omitted its original path");
+      }
+      index += 1;
+      parsed.push(
+        change(
+          relativePath,
+          originalPath,
+          xy.includes("R") ? "renamed" : "copied",
+          staged,
+          unstaged,
+        ),
+      );
+      continue;
+    }
+    if (kind !== "1") throw new Error("Remote Git status returned an unsupported record");
+    parsed.push(change(relativePath, null, statusFromXY(xy), staged, unstaged));
+  }
+  return parsed;
+}
+
+function fixedFields(record: string, count: number) {
+  const fields: string[] = [];
+  let offset = 0;
+  for (let index = 0; index < count - 1; index += 1) {
+    const separator = record.indexOf(" ", offset);
+    if (separator < 0) throw new Error("Remote Git status returned malformed porcelain v2 data");
+    fields.push(record.slice(offset, separator));
+    offset = separator + 1;
+  }
+  fields.push(record.slice(offset));
+  return fields;
+}
+
+function statusFromXY(xy: string): "modified" | "added" | "deleted" {
+  if (xy.includes("D")) return "deleted";
+  if (xy.includes("A")) return "added";
+  return "modified";
+}
+
+function change(
+  relativePath: string,
+  originalPath: string | null,
+  status: Exclude<RemoteGitFileStatus, "clean" | "ignored">,
+  staged: boolean,
+  unstaged: boolean,
+): ParsedGitStatusRecord {
+  return { relativePath, originalPath, status, staged, unstaged };
+}

--- a/server/utils/gateway/infra/git/remote-git-files.ts
+++ b/server/utils/gateway/infra/git/remote-git-files.ts
@@ -4,6 +4,7 @@ import type {
   RemoteGitFileBaseline,
   RemoteGitFileComparison,
   RemoteGitFileStatus,
+  RemoteGitWorkspaceSnapshot,
 } from "~~/shared/types";
 import { MAX_GIT_DIFF_BYTES } from "~~/shared/file-preview";
 import { remoteLoginShellCommand } from "../ssh/remote-command";
@@ -11,8 +12,12 @@ import { shellQuote } from "../ssh/shell";
 import type { SshConnectionPool } from "../ssh/ssh-connection";
 import type { HostWithSecret } from "../ssh/ssh-types";
 import { KeyedTaskLimiter } from "../concurrency/keyed-task-limiter";
+import { parseGitStatusRecords } from "./git-status-parser";
 
 const GIT_COMMAND_TIMEOUT_MS = 30_000;
+const MAX_GIT_METADATA_OUTPUT_BYTES = 256 * 1024;
+const MAX_GIT_WORKSPACE_OUTPUT_BYTES = 4 * 1024 * 1024;
+const MAX_GIT_WORKSPACE_FILES = 20_000;
 
 interface GitMetadata {
   repositoryRoot: string;
@@ -27,6 +32,7 @@ interface GitMetadata {
 
 export class RemoteGitFileService {
   private readonly pending = new Map<string, Promise<RemoteGitFileComparison>>();
+  private readonly pendingWorkspace = new Map<string, Promise<RemoteGitWorkspaceSnapshot>>();
   private readonly transportLimiter = new KeyedTaskLimiter(2);
 
   constructor(private readonly ssh: SshConnectionPool) {}
@@ -50,7 +56,9 @@ export class RemoteGitFileService {
     const signal = AbortSignal.timeout(GIT_COMMAND_TIMEOUT_MS);
     let tracked: Promise<RemoteGitFileComparison>;
     tracked = this.transportLimiter
-      .run(transportKey, () => this.compareOnce(host, projectPath, path, deadline), { signal })
+      .run(transportKey, () => this.compareOnce(host, projectPath, path, deadline, signal), {
+        signal,
+      })
       .catch((error: unknown) => {
         if (signal.aborted) {
           throw new Error(`Remote Git comparison timed out after ${GIT_COMMAND_TIMEOUT_MS}ms`, {
@@ -66,28 +74,97 @@ export class RemoteGitFileService {
     return await tracked;
   }
 
+  async inspectWorkspace(
+    host: HostWithSecret,
+    project: ProjectRecord,
+    requestedRootPath: string,
+  ): Promise<RemoteGitWorkspaceSnapshot> {
+    const rootPath = posix.normalize(requestedRootPath.trim());
+    const projectPath = posix.normalize(project.remotePath.trim());
+    if (!rootPath.startsWith("/") || !projectPath.startsWith("/")) {
+      return { availability: "outsideWorktree" };
+    }
+    const transportKey = this.ssh.connectionKeyFor(host);
+    const requestKey = `${transportKey}\0${projectPath}\0${rootPath}`;
+    const existing = this.pendingWorkspace.get(requestKey);
+    if (existing !== undefined) return await existing;
+
+    const signal = AbortSignal.timeout(GIT_COMMAND_TIMEOUT_MS);
+    const deadline = Date.now() + GIT_COMMAND_TIMEOUT_MS;
+    let tracked: Promise<RemoteGitWorkspaceSnapshot>;
+    tracked = this.transportLimiter
+      .run(
+        transportKey,
+        () => this.inspectWorkspaceOnce(host, projectPath, rootPath, deadline, signal),
+        { signal },
+      )
+      .catch((error: unknown) => {
+        if (signal.aborted) {
+          throw new Error(
+            `Remote Git workspace inspection timed out after ${GIT_COMMAND_TIMEOUT_MS}ms`,
+            {
+              cause: error,
+            },
+          );
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (this.pendingWorkspace.get(requestKey) === tracked) {
+          this.pendingWorkspace.delete(requestKey);
+        }
+      });
+    this.pendingWorkspace.set(requestKey, tracked);
+    return await tracked;
+  }
+
   private async compareOnce(
     host: HostWithSecret,
     projectPath: string,
     path: string,
     deadline: number,
+    signal: AbortSignal,
   ) {
     const result = await this.ssh.exec(host, metadataCommand(projectPath, path), {
       timeoutMs: remainingTimeout(deadline),
+      signal,
+      maxOutputBytes: MAX_GIT_METADATA_OUTPUT_BYTES,
     });
     if (result.code !== 0) {
       throw new Error(result.stderr.trim() || "Failed to inspect remote Git file state");
     }
     const parsed = parseMetadata(result.stdout);
     if (parsed.availability !== "available") return parsed;
-    const baseline = await this.readBaseline(host, parsed.metadata, deadline);
+    const baseline = await this.readBaseline(host, parsed.metadata, deadline, signal);
     return comparisonFromMetadata(parsed.metadata, baseline);
+  }
+
+  private async inspectWorkspaceOnce(
+    host: HostWithSecret,
+    projectPath: string,
+    rootPath: string,
+    deadline: number,
+    signal: AbortSignal,
+  ): Promise<RemoteGitWorkspaceSnapshot> {
+    const result = await this.ssh.exec(host, workspaceCommand(projectPath, rootPath), {
+      timeoutMs: remainingTimeout(deadline),
+      signal,
+      // Porcelain output is machine-readable but unbounded. A generated directory with hundreds of
+      // thousands of untracked files must fail as one inspection instead of exhausting Gateway
+      // memory or producing a WebSocket frame that the browser cannot safely materialize.
+      maxOutputBytes: MAX_GIT_WORKSPACE_OUTPUT_BYTES,
+    });
+    if (result.code !== 0) {
+      throw new Error(result.stderr.trim() || "Failed to inspect remote Git workspace");
+    }
+    return parseWorkspaceSnapshot(result.stdout);
   }
 
   private async readBaseline(
     host: HostWithSecret,
     metadata: GitMetadata,
     deadline: number,
+    signal: AbortSignal,
   ): Promise<RemoteGitFileBaseline> {
     if (metadata.status === "ignored") {
       return { kind: "unavailable", reason: "ignored" };
@@ -102,6 +179,8 @@ export class RemoteGitFileService {
     const object = `${metadata.headOid}:${objectPath}`;
     const result = await this.ssh.exec(host, baselineCommand(metadata.repositoryRoot, object), {
       timeoutMs: remainingTimeout(deadline),
+      signal,
+      maxOutputBytes: MAX_GIT_DIFF_BYTES,
     });
     if (result.code === 45) return { kind: "empty", revision: metadata.headOid };
     if (result.code === 46) return { kind: "unavailable", reason: "tooLarge" };
@@ -341,54 +420,20 @@ function statusMetadata(
       null,
     );
   }
-  const kind = record[0];
-  const parts = record.split(" ");
-  const xy = parts[1] ?? "..";
-  const staged = xy[0] !== ".";
-  const unstaged = xy[1] !== ".";
-  if (kind === "u") {
-    return baseMetadata(
-      repositoryRoot,
-      relativePath,
-      headOid,
-      fileSize,
-      "conflicted",
-      staged,
-      unstaged,
-      null,
-    );
+  const statusRecord = parseGitStatusRecords(records)[0];
+  if (statusRecord === undefined) {
+    throw new Error("Remote Git status did not describe the requested changed file");
   }
-  if (kind === "2") {
-    const code = xy.includes("R") ? "renamed" : "copied";
-    return baseMetadata(
-      repositoryRoot,
-      relativePath,
-      headOid,
-      fileSize,
-      code,
-      staged,
-      unstaged,
-      records[1] === undefined || records[1] === "" ? null : records[1],
-    );
-  }
-  if (kind !== "1") throw new Error("Remote Git status returned an unsupported record");
-  const status = statusFromXY(xy);
   return baseMetadata(
     repositoryRoot,
     relativePath,
     headOid,
     fileSize,
-    status,
-    staged,
-    unstaged,
-    null,
+    statusRecord.status,
+    statusRecord.staged,
+    statusRecord.unstaged,
+    statusRecord.originalPath,
   );
-}
-
-function statusFromXY(xy: string): RemoteGitFileStatus {
-  if (xy.includes("D")) return "deleted";
-  if (xy.includes("A")) return "added";
-  return "modified";
 }
 
 function baseMetadata(
@@ -410,5 +455,92 @@ function baseMetadata(
     status,
     staged,
     unstaged,
+  };
+}
+
+function workspaceCommand(projectPath: string, rootPath: string) {
+  const script = `
+set -eu
+project_path=$1
+requested_root_path=$2
+if ! command -v git >/dev/null 2>&1; then
+  printf 'gitUnavailable\\0'
+  exit 0
+fi
+if [ "$project_path" != / ]; then
+  case "$requested_root_path" in
+    "$project_path"|"$project_path"/*) ;;
+    *) printf 'outsideWorktree\\0'; exit 0 ;;
+  esac
+fi
+if ! cd -- "$requested_root_path" 2>/dev/null; then
+  printf 'outsideWorktree\\0'
+  exit 0
+fi
+physical_root=$(pwd -P)
+repo_root=$(GIT_OPTIONAL_LOCKS=0 git --no-optional-locks -C "$physical_root" rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$repo_root" ]; then
+  printf 'notRepository\\0'
+  exit 0
+fi
+repo_root=$(cd -- "$repo_root" && pwd -P)
+head_oid=$(GIT_OPTIONAL_LOCKS=0 git --no-optional-locks -C "$repo_root" rev-parse --verify HEAD 2>/dev/null || true)
+branch=$(GIT_OPTIONAL_LOCKS=0 git --no-optional-locks -C "$repo_root" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+if [ "$repo_root" = "$physical_root" ]; then
+  workspace_relative=
+else
+  case "$physical_root" in
+    "$repo_root"/*) workspace_relative=\${physical_root#"$repo_root"/} ;;
+    *) printf 'outsideWorktree\\0'; exit 0 ;;
+  esac
+fi
+printf 'available\\0%s\\0%s\\0%s\\0%s\\0' "$repo_root" "$workspace_relative" "$head_oid" "$branch"
+if [ -n "$workspace_relative" ]; then
+  GIT_OPTIONAL_LOCKS=0 git --no-optional-locks -C "$repo_root" status --porcelain=v2 -z --untracked-files=all -- "$workspace_relative"
+else
+  GIT_OPTIONAL_LOCKS=0 git --no-optional-locks -C "$repo_root" status --porcelain=v2 -z --untracked-files=all
+fi
+`;
+  return remoteLoginShellCommand(
+    `sh -c ${shellQuote(script)} sh ${shellQuote(projectPath)} ${shellQuote(rootPath)}`,
+  );
+}
+
+function parseWorkspaceSnapshot(output: string): RemoteGitWorkspaceSnapshot {
+  const fields = output.split("\0");
+  const availability = fields[0];
+  if (
+    availability === "gitUnavailable" ||
+    availability === "notRepository" ||
+    availability === "outsideWorktree"
+  ) {
+    return { availability };
+  }
+  if (availability !== "available") {
+    throw new Error("Remote Git workspace inspection returned an invalid capability state");
+  }
+  const repositoryRoot = fields[1];
+  if (repositoryRoot === undefined || repositoryRoot === "") {
+    throw new Error("Remote Git workspace inspection omitted the repository root");
+  }
+  const workspaceRelativePath = fields[2];
+  if (workspaceRelativePath === undefined) {
+    throw new Error("Remote Git workspace inspection omitted the workspace path");
+  }
+  const headOid = fields[3] === undefined || fields[3] === "" ? null : fields[3];
+  const branch = fields[4] === undefined || fields[4] === "" ? null : fields[4];
+  const files = parseGitStatusRecords(fields.slice(5)).sort((left, right) =>
+    left.relativePath.localeCompare(right.relativePath),
+  );
+  if (files.length > MAX_GIT_WORKSPACE_FILES) {
+    throw new Error(`Remote Git workspace contains more than ${MAX_GIT_WORKSPACE_FILES} changes`);
+  }
+  return {
+    availability: "available",
+    repositoryRoot,
+    workspaceRelativePath,
+    headOid,
+    branch,
+    files,
   };
 }

--- a/server/utils/gateway/infra/ssh/ssh-connection.ts
+++ b/server/utils/gateway/infra/ssh/ssh-connection.ts
@@ -20,6 +20,26 @@ const SSH_READY_TIMEOUT_MS = 30_000;
 const SSH_KEEPALIVE_INTERVAL_MS = 30_000;
 const SSH_KEEPALIVE_COUNT_MAX = 10;
 
+interface ExecOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  maxOutputBytes?: number;
+}
+
+function abortReason(signal: AbortSignal | undefined) {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new Error("Remote command was aborted", { cause: signal?.reason });
+}
+
+function outputLimitExceeded(outputBytes: number, maxOutputBytes: number | undefined) {
+  return maxOutputBytes !== undefined && outputBytes > maxOutputBytes;
+}
+
+function outputLimitError(maxOutputBytes: number | undefined) {
+  return new Error(`Remote command output exceeded the ${maxOutputBytes ?? 0} byte limit`);
+}
+
 type SshConnectionPoolEvents = {
   ready: { userId: number; host: HostWithSecret };
 };
@@ -81,10 +101,15 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
   async exec(
     host: HostWithSecret,
     command: string,
-    options: { timeoutMs?: number } = {},
+    options: ExecOptions = {},
   ): Promise<CommandResult> {
     const startedAt = Date.now();
-    const channel = await this.openExecChannelWithin(host, command, options.timeoutMs);
+    const channel = await this.openExecChannelWithin(
+      host,
+      command,
+      options.timeoutMs,
+      options.signal,
+    );
     const remainingMs =
       options.timeoutMs === undefined
         ? undefined
@@ -93,6 +118,7 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
     return new Promise((resolve, reject) => {
       let stdout = "";
       let stderr = "";
+      let outputBytes = 0;
       const stdoutDecoder = new StringDecoder("utf8");
       const stderrDecoder = new StringDecoder("utf8");
       let settled = false;
@@ -100,7 +126,12 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
         if (settled) return;
         settled = true;
         if (timer !== undefined) clearTimeout(timer);
+        options.signal?.removeEventListener("abort", abort);
         callback();
+      };
+      const abort = () => {
+        finish(() => reject(abortReason(options.signal)));
+        channel.close();
       };
       const timer =
         remainingMs === undefined
@@ -111,10 +142,27 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
               );
               channel.close();
             }, remainingMs);
+      options.signal?.addEventListener("abort", abort, { once: true });
+      if (options.signal?.aborted === true) {
+        abort();
+        return;
+      }
       channel.on("data", (chunk: Buffer) => {
+        outputBytes += chunk.length;
+        if (outputLimitExceeded(outputBytes, options.maxOutputBytes)) {
+          finish(() => reject(outputLimitError(options.maxOutputBytes)));
+          channel.close();
+          return;
+        }
         stdout += stdoutDecoder.write(chunk);
       });
       channel.stderr.on("data", (chunk: Buffer) => {
+        outputBytes += chunk.length;
+        if (outputLimitExceeded(outputBytes, options.maxOutputBytes)) {
+          finish(() => reject(outputLimitError(options.maxOutputBytes)));
+          channel.close();
+          return;
+        }
         stderr += stderrDecoder.write(chunk);
       });
       channel.on("error", (error: Error) => finish(() => reject(error)));
@@ -132,14 +180,34 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
     host: HostWithSecret,
     command: string,
     timeoutMs: number | undefined,
+    signal: AbortSignal | undefined,
   ) {
-    if (timeoutMs === undefined) return await this.execChannel(host, command);
+    if (timeoutMs === undefined && signal === undefined)
+      return await this.execChannel(host, command);
     return await new Promise<ClientChannel>((resolve, reject) => {
       let settled = false;
-      const timer = setTimeout(() => {
+      const cleanup = () => {
+        if (timer !== undefined) clearTimeout(timer);
+        signal?.removeEventListener("abort", abort);
+      };
+      const fail = (error: Error) => {
+        if (settled) return;
         settled = true;
-        reject(new Error(`Remote command timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
+        cleanup();
+        reject(error);
+      };
+      const abort = () => fail(abortReason(signal));
+      const timer =
+        timeoutMs === undefined
+          ? undefined
+          : setTimeout(() => {
+              fail(new Error(`Remote command timed out after ${timeoutMs}ms`));
+            }, timeoutMs);
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) {
+        abort();
+        return;
+      }
       void this.execChannel(host, command).then(
         (channel) => {
           if (settled) {
@@ -149,13 +217,13 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
             return;
           }
           settled = true;
-          clearTimeout(timer);
+          cleanup();
           resolve(channel);
         },
         (error: unknown) => {
           if (settled) return;
           settled = true;
-          clearTimeout(timer);
+          cleanup();
           reject(
             error instanceof Error
               ? error

--- a/server/utils/gateway/realtime/handlers/file-git.ts
+++ b/server/utils/gateway/realtime/handlers/file-git.ts
@@ -24,3 +24,23 @@ export async function compareGitFile(
     comparison,
   });
 }
+
+export async function inspectGitWorkspace(
+  peer: RealtimePeer,
+  request: Extract<RealtimeClientMessage, { type: "file.git.workspace.inspect" }>,
+) {
+  const host = requireRecord(hostStore.getWithSecret(request.hostId), "Host not found");
+  const project = requireRecord(projectStore.get(request.projectId), "Project not found");
+  if (project.hostId !== host.id) {
+    throw new Error(`Project ${project.id} does not belong to host ${host.id}`);
+  }
+  const snapshot = await remoteGitFiles.inspectWorkspace(host, project, request.rootPath);
+  sendRealtimePeerMessage(peer, {
+    type: "file.git.workspace.snapshot",
+    requestId: request.requestId,
+    hostId: host.id,
+    projectId: project.id,
+    rootPath: request.rootPath,
+    snapshot,
+  });
+}

--- a/server/utils/gateway/realtime/message-dispatcher.ts
+++ b/server/utils/gateway/realtime/message-dispatcher.ts
@@ -58,6 +58,9 @@ export class RealtimeMessageDispatcher {
       .with({ type: "file.git.compare" }, (value) =>
         this.dispatchEntry(peer, value, this.handlers[value.type]),
       )
+      .with({ type: "file.git.workspace.inspect" }, (value) =>
+        this.dispatchEntry(peer, value, this.handlers[value.type]),
+      )
       .with({ type: "host.lifecycle.unsubscribe" }, (value) =>
         this.dispatchEntry(peer, value, this.handlers[value.type]),
       )

--- a/server/utils/gateway/realtime/message-handlers.ts
+++ b/server/utils/gateway/realtime/message-handlers.ts
@@ -34,7 +34,7 @@ import {
   subscribeTmuxSessions,
   unsubscribeTmuxSessions,
 } from "./handlers/tmux-sessions";
-import { compareGitFile } from "./handlers/file-git";
+import { compareGitFile, inspectGitWorkspace } from "./handlers/file-git";
 
 export const realtimeMessageDispatcher = new RealtimeMessageDispatcher({
   "auth.authenticate": { auth: "public", handler: authenticatePeer },
@@ -66,5 +66,6 @@ export const realtimeMessageDispatcher = new RealtimeMessageDispatcher({
   "browser.close": closeBrowserPreview,
   "browser.allowInsecureTls": allowInsecureBrowserPreviewTls,
   "file.git.compare": compareGitFile,
+  "file.git.workspace.inspect": inspectGitWorkspace,
   ping,
 });

--- a/shared/runtime/realtime/client-message-schema.ts
+++ b/shared/runtime/realtime/client-message-schema.ts
@@ -229,6 +229,15 @@ export const realtimeClientMessageSchema: z.ZodType<RealtimeClientMessage> = z.d
         path: nonEmptyString,
       })
       .strict(),
+    z
+      .object({
+        type: z.literal("file.git.workspace.inspect"),
+        ...requestIdField,
+        hostId: positiveId,
+        projectId: positiveId,
+        rootPath: nonEmptyString,
+      })
+      .strict(),
     z.object({ type: z.literal("ping"), nonce: z.string().optional() }).strict(),
   ],
 );

--- a/shared/runtime/realtime/server-message-schema.ts
+++ b/shared/runtime/realtime/server-message-schema.ts
@@ -345,6 +345,38 @@ const remoteGitComparisonSchema = z.discriminatedUnion("availability", [
     })
     .strict(),
 ]);
+const remoteGitWorkspaceFileSchema = z
+  .object({
+    relativePath: nonEmptyString,
+    originalPath: z.string().nullable(),
+    status: z.enum([
+      "modified",
+      "added",
+      "renamed",
+      "copied",
+      "untracked",
+      "conflicted",
+      "deleted",
+    ]),
+    staged: z.boolean(),
+    unstaged: z.boolean(),
+  })
+  .strict();
+const remoteGitWorkspaceSnapshotSchema = z.discriminatedUnion("availability", [
+  z.object({ availability: z.literal("gitUnavailable") }).strict(),
+  z.object({ availability: z.literal("notRepository") }).strict(),
+  z.object({ availability: z.literal("outsideWorktree") }).strict(),
+  z
+    .object({
+      availability: z.literal("available"),
+      repositoryRoot: nonEmptyString,
+      workspaceRelativePath: z.string(),
+      headOid: z.string().nullable(),
+      branch: z.string().nullable(),
+      files: z.array(remoteGitWorkspaceFileSchema),
+    })
+    .strict(),
+]);
 
 // Top-level Gateway messages are closed protocol objects. Nested app-server thread/envelope
 // records intentionally remain extensible because upstream adds fields between releases; their
@@ -424,6 +456,16 @@ export const realtimeServerMessageSchema: z.ZodType<RealtimeServerMessage> = z.d
         projectId: positiveId,
         path: nonEmptyString,
         comparison: remoteGitComparisonSchema,
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("file.git.workspace.snapshot"),
+        ...requestIdField,
+        hostId: positiveId,
+        projectId: positiveId,
+        rootPath: nonEmptyString,
+        snapshot: remoteGitWorkspaceSnapshotSchema,
       })
       .strict(),
     z

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -80,6 +80,8 @@ export type {
   RemoteGitFileBaseline,
   RemoteGitFileComparison,
   RemoteGitFileStatus,
+  RemoteGitWorkspaceFile,
+  RemoteGitWorkspaceSnapshot,
   RemoteDirectoryEntry,
   RemoteDirectoryResult,
   UploadedFileRecord,

--- a/shared/types/files.ts
+++ b/shared/types/files.ts
@@ -47,6 +47,7 @@ export interface FilePreviewDocument {
   etag: string | null;
   lastModified: string | null;
   stale: boolean;
+  requestedView: "source" | "changes" | null;
 }
 
 export interface RemoteFileConflict {
@@ -90,4 +91,25 @@ export type RemoteGitFileComparison =
       staged: boolean;
       unstaged: boolean;
       baseline: RemoteGitFileBaseline;
+    };
+
+export interface RemoteGitWorkspaceFile {
+  relativePath: string;
+  originalPath: string | null;
+  status: Exclude<RemoteGitFileStatus, "clean" | "ignored">;
+  staged: boolean;
+  unstaged: boolean;
+}
+
+export type RemoteGitWorkspaceSnapshot =
+  | {
+      availability: "gitUnavailable" | "notRepository" | "outsideWorktree";
+    }
+  | {
+      availability: "available";
+      repositoryRoot: string;
+      workspaceRelativePath: string;
+      headOid: string | null;
+      branch: string | null;
+      files: RemoteGitWorkspaceFile[];
     };

--- a/shared/types/realtime.ts
+++ b/shared/types/realtime.ts
@@ -21,7 +21,7 @@ import type {
   HostMetricsSample,
 } from "./host-metrics";
 import type { TmuxSessionsSnapshot } from "./tmux";
-import type { RemoteGitFileComparison } from "./files";
+import type { RemoteGitFileComparison, RemoteGitWorkspaceSnapshot } from "./files";
 
 export type RealtimeClientMessage =
   | {
@@ -200,6 +200,13 @@ export type RealtimeClientMessage =
       hostId: number;
       projectId: number;
       path: string;
+    }
+  | {
+      type: "file.git.workspace.inspect";
+      requestId: string;
+      hostId: number;
+      projectId: number;
+      rootPath: string;
     }
   | {
       type: "ping";
@@ -393,6 +400,14 @@ export type RealtimeServerMessage =
       projectId: number;
       path: string;
       comparison: RemoteGitFileComparison;
+    }
+  | {
+      type: "file.git.workspace.snapshot";
+      requestId: string;
+      hostId: number;
+      projectId: number;
+      rootPath: string;
+      snapshot: RemoteGitWorkspaceSnapshot;
     }
   | { type: "browser.closed"; requestId: string; sessionId: string }
   | { type: "browser.error"; requestId?: string; sessionId?: string; message: string }

--- a/tests/e2e/mobile-layout.mobile.spec.ts
+++ b/tests/e2e/mobile-layout.mobile.spec.ts
@@ -747,6 +747,24 @@ printf '%s\n' '# Mobile File Workspace' 'Rendered from the remote tree.' > ${she
   await page.getByRole("button", { name: "文件树", exact: true }).click();
   const tree = page.getByTestId("remote-file-tree");
   await expect(tree).toBeVisible();
+  await page.getByRole("tab", { name: /变更/ }).click();
+  await expect(
+    page.getByTestId("git-changes-tree").locator(`[data-git-change-path=${JSON.stringify(path)}]`),
+  ).toContainText("M");
+  await page.getByRole("button", { name: "打开完整变更审查" }).click();
+  const reviewPanel = page.getByTestId("git-review-panel");
+  await expect(reviewPanel).toBeVisible();
+  await expect(tree).toBeHidden();
+  await expect(reviewPanel.getByTestId("git-review-diff-editor")).toContainText(
+    "Mobile File Baseline",
+  );
+  await page
+    .getByRole("region", { name: "审查变更" })
+    .getByRole("button", { name: "关闭标签页" })
+    .click();
+  await page.getByRole("button", { name: "文件树", exact: true }).click();
+  await expect(tree).toBeVisible();
+  await page.getByRole("tab", { name: "文件", exact: true }).click();
   await tree.getByText(path.split("/").pop()!, { exact: true }).click();
   await expect(panel.locator(".markdown-content h1")).toHaveText("Mobile File Workspace");
   await panel.getByRole("button", { name: "源码" }).click();
@@ -764,6 +782,37 @@ printf '%s\n' '# Mobile File Workspace' 'Rendered from the remote tree.' > ${she
         .evaluate((element) => element.scrollWidth <= element.clientWidth),
     )
     .toBe(true);
+
+  const plainRootPath = `/home/${remote.username}/mobile-plain-project-${Date.now()}`;
+  await execRemoteSsh(remote, `mkdir -p ${shellQuote(plainRootPath)}`);
+  const plainProject = await authenticatedFetch(
+    page,
+    {
+      url: "/api/projects",
+      method: "POST",
+      body: {
+        hostId: host.id,
+        name: `mobile-plain-project-${Date.now()}`,
+        remotePath: plainRootPath,
+      },
+    },
+    (value) => projectRecordSchema.parse(value),
+  );
+  const plainThreadId = `mobile-plain-thread-${Date.now()}`;
+  await seedGatewayThread(page, {
+    hostId: host.id,
+    projectId: plainProject.id,
+    host: { ...host },
+    project: { ...plainProject },
+    threadId: plainThreadId,
+    currentThread: { id: plainThreadId, name: "Mobile Plain Files", cwd: plainRootPath },
+    history: { thread: { id: plainThreadId, turns: [] } },
+    status: "completed",
+  });
+  await page.locator('[data-testid="workspace-dock-tab"][data-panel-kind="files"]').click();
+  await page.getByRole("button", { name: "文件树", exact: true }).click();
+  await page.getByRole("tab", { name: /变更/ }).click();
+  await expect(page.getByText("当前工作区不在 Git 仓库中", { exact: true })).toBeVisible();
 });
 
 async function openIntermediateSteps(page: Page) {

--- a/tests/e2e/thread-file-preview.spec.ts
+++ b/tests/e2e/thread-file-preview.spec.ts
@@ -27,6 +27,10 @@ test("the unified file workspace browses, restores, and refreshes real remote fi
   const nestedRepositoryFilePath = `${nestedRepositoryPath}/nested-change.ts`;
   const deletedWorktreeDirectoryPath = `${projectPath}/deleted-after-open-${Date.now()}`;
   const deletedWorktreeFilePath = `${deletedWorktreeDirectoryPath}/tracked.txt`;
+  const reviewRenamedOriginalPath = `${projectPath}/rename-before-review.txt`;
+  const reviewRenamedPath = `${projectPath}/rename-after-review.txt`;
+  const reviewDeletedPath = `${projectPath}/deleted-before-review.txt`;
+  const reviewAddedPath = `${projectPath}/added-before-review.txt`;
   const wideTable = `| metric | sample-a | sample-b | sample-c |
 | --- | --- | --- | --- |
 | very-long-column | ${"unbroken-value-".repeat(12)}a | ${"unbroken-value-".repeat(12)}b | ${"unbroken-value-".repeat(12)}c |`;
@@ -65,12 +69,18 @@ mkdir -p ${shellQuote(deletedWorktreeDirectoryPath)}
 cat > ${shellQuote(deletedWorktreeFilePath)} <<'EOF'
 tracked file remains open while it is deleted remotely
 EOF
+printf '%s\n' 'renamed file baseline' > ${shellQuote(reviewRenamedOriginalPath)}
+printf '%s\n' 'deleted file baseline' > ${shellQuote(reviewDeletedPath)}
 for line in $(seq 1 120); do printf '# source line %s\n' "$line" >> ${shellQuote(nestedPythonPath)}; done
 git -C ${shellQuote(projectPath)} init -q
 git -C ${shellQuote(projectPath)} config user.email codex-gateway-e2e@example.invalid
 git -C ${shellQuote(projectPath)} config user.name 'Codex Gateway E2E'
-git -C ${shellQuote(projectPath)} add -- ${shellQuote(remotePath)} ${shellQuote(markdownPath)} ${shellQuote(nestedPythonPath)} ${shellQuote(deletedWorktreeFilePath)}
+git -C ${shellQuote(projectPath)} add -- ${shellQuote(remotePath)} ${shellQuote(markdownPath)} ${shellQuote(nestedPythonPath)} ${shellQuote(deletedWorktreeFilePath)} ${shellQuote(reviewRenamedOriginalPath)} ${shellQuote(reviewDeletedPath)}
 git -C ${shellQuote(projectPath)} commit -qm 'test: establish file preview baseline'
+git -C ${shellQuote(projectPath)} mv -- ${shellQuote(reviewRenamedOriginalPath)} ${shellQuote(reviewRenamedPath)}
+rm -- ${shellQuote(reviewDeletedPath)}
+printf '%s\n' 'staged added file' > ${shellQuote(reviewAddedPath)}
+git -C ${shellQuote(projectPath)} add -- ${shellQuote(reviewAddedPath)}
 cat > ${shellQuote(remotePath)} <<'EOF'
 export function previewMarker() {
   return "codex-gateway-file-preview";
@@ -221,6 +231,55 @@ done
   const symlinkDirectoryRow = symlinkDirectoryLabel.locator("xpath=..");
   await expect(longFileLabel).toBeVisible();
   await expect(symlinkDirectoryLabel).toBeVisible();
+  await expect(tree.getByTitle(remotePath, { exact: true }).locator("xpath=..")).toContainText("M");
+
+  await panel.getByRole("tab", { name: /变更/ }).click();
+  const changesTree = panel.getByTestId("git-changes-tree");
+  await expect(changesTree).toBeVisible();
+  await expect(
+    changesTree.locator(`[data-git-change-path=${JSON.stringify(remotePath)}]`),
+  ).toContainText("M");
+  await expect(
+    changesTree.locator(`[data-git-change-path=${JSON.stringify(reviewRenamedPath)}]`),
+  ).toContainText("R");
+  await expect(
+    changesTree.locator(`[data-git-change-path=${JSON.stringify(reviewDeletedPath)}]`),
+  ).toContainText("D");
+  await expect(
+    changesTree.locator(`[data-git-change-path=${JSON.stringify(reviewAddedPath)}]`),
+  ).toContainText("A");
+  await expect(
+    changesTree.locator(`[data-git-change-path=${JSON.stringify(unknownTextPath)}]`),
+  ).toContainText("U");
+  await changesTree.locator(`[data-git-change-path=${JSON.stringify(remotePath)}]`).click();
+  await expect(panel.getByTestId("remote-file-diff-editor")).toContainText(
+    "codex-gateway-file-baseline",
+  );
+
+  await panel.getByRole("button", { name: "打开完整变更审查" }).click();
+  const reviewPanel = page.getByTestId("git-review-panel");
+  await expect(reviewPanel).toBeVisible();
+  await page
+    .getByRole("region", { name: "审查变更" })
+    .getByRole("button", { name: "关闭标签页" })
+    .click();
+  await expect(reviewPanel).toBeHidden();
+  await changesTree.locator(`[data-git-change-path=${JSON.stringify(reviewDeletedPath)}]`).click();
+  await expect(reviewPanel).toBeVisible();
+  await reviewPanel
+    .getByTestId("git-changes-tree")
+    .locator(`[data-git-change-path=${JSON.stringify(reviewDeletedPath)}]`)
+    .click();
+  await expect(reviewPanel.getByTestId("git-review-diff-editor")).toContainText(
+    "deleted file baseline",
+  );
+  await page
+    .getByRole("region", { name: "审查变更" })
+    .getByRole("button", { name: "关闭标签页" })
+    .click();
+  await expect(reviewPanel).toBeHidden();
+  await filesWorkspaceTab(page).click();
+  await panel.getByRole("tab", { name: "文件", exact: true }).click();
   await symlinkDirectoryRow.click({ button: "right", position: { x: 20, y: 16 } });
   await page.getByRole("menuitem", { name: "复制绝对路径" }).click();
   await expect(


### PR DESCRIPTION
## Summary

- add a workspace-level Git status snapshot over the existing realtime WebSocket and shared SSH connection
- add VS Code-style file tree and tab decorations plus a Files/Changes sidebar
- add a Dockview Git Review panel using the existing CodeMirror comparison editor
- support deleted files, responsive mobile review, bounded scans, cancellation, and nested repository handling

## Verification

- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`81 passed`)

## Architecture

- no new HTTP Git endpoints or database state
- no per-file SSH scans or polling
- workspace snapshots are scope-keyed in Pinia and invalidated by existing file lifecycle events