### PR TITLE
fix: search project files without optional tools

### DIFF
--- a/server/utils/gateway/project-files/project-file-index.ts
+++ b/server/utils/gateway/project-files/project-file-index.ts
@@ -152,8 +152,19 @@ elif command -v rg >/dev/null 2>&1; then
     -g '!.git/**' -g '!node_modules/**' -g '!dist/**' -g '!build/**' \\
     -g '!.next/**' -g '!coverage/**' -g '!__pycache__/**' -g '!vendor/**' \\
     -g '!venv/**' -g '!.venv/**'
+elif command -v find >/dev/null 2>&1; then
+  # File mentions are a baseline remote-files feature, so they cannot require
+  # optional developer tools. Keep git and rg as the fast paths, then use the
+  # standard remote filesystem walker for plain directories and minimal hosts.
+  find . \\
+    \\( -type d \\( \\
+      -name .git -o -name node_modules -o -name dist -o -name build -o \\
+      -name .next -o -name coverage -o -name __pycache__ -o -name vendor -o \\
+      -name venv -o -name .venv \\
+    \\) -prune \\) -o \\
+    -type f -exec printf '%s\\0' {} +
 else
-  echo 'Project file search requires git or ripgrep on the remote host' >&2
+  echo 'Project file search requires a usable find command on the remote host' >&2
   exit 127
 fi
 `;

--- a/tests/e2e/remote-host-project.spec.ts
+++ b/tests/e2e/remote-host-project.spec.ts
@@ -29,10 +29,9 @@ test("references real project files as structured turn context", async ({
   await openApp(page);
   const { remote } = remoteWorkspace;
   const projectPath = `/tmp/codex-gateway-file-reference-${Date.now()}`;
-  await execRemoteSsh(
-    remote,
-    `mkdir -p -- ${shellQuote(projectPath)} && git init -q -- ${shellQuote(projectPath)}`,
-  );
+  // This deliberately remains a plain directory. File mentions must work on
+  // minimal remote hosts without relying on a Git worktree or ripgrep.
+  await execRemoteSsh(remote, `mkdir -p -- ${shellQuote(projectPath)}`);
   const { host, project } = await remoteWorkspace.provision({
     hostName: `file-reference-host-${Date.now()}`,
     remotePath: projectPath,


### PR DESCRIPTION
Fix project file mention search on remote hosts that do not have Git or ripgrep.

- retain git and rg fast paths
- add POSIX find fallback for plain/minimal directories
- cover the fallback with real SSH E2E

Verification: pnpm lint passed; project file reference and concurrent cache E2E passed. Full pnpm test:e2e still has four unrelated existing Bark/realtime/long-history timing failures.