### PR TITLE
fix: hydrate legacy thread items from turn pages

### DIFF
--- a/app/stores/gateway-thread-turns/turn-items.ts
+++ b/app/stores/gateway-thread-turns/turn-items.ts
@@ -70,7 +70,7 @@ export async function loadTurnItems(t: Translate, turnId: string) {
   } catch (error: unknown) {
     if (sessionIsCurrent()) {
       useGatewayBootstrapStore().setError(
-        messageFromError(error, t("app.loadOlderTurnsFailed"), errorMessageLabels(t)),
+        messageFromError(error, t("app.loadTurnItemsFailed"), errorMessageLabels(t)),
         { hostId, threadId, turnId },
       );
     }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -357,6 +357,7 @@
     "interruptTurnFailed": "Failed to stop generation",
     "noActiveTurnToInterrupt": "No active turn to stop",
     "loadOlderTurnsFailed": "Failed to load older messages",
+    "loadTurnItemsFailed": "Failed to load Turn content",
     "misalignmentRecoveryTitle": "Codex needs confirmation to continue",
     "misalignmentRecoveryConfirm": "Send correction",
     "mcpConnections": "MCP connections",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -357,6 +357,7 @@
     "interruptTurnFailed": "停止生成失败",
     "noActiveTurnToInterrupt": "没有正在运行的回合可停止",
     "loadOlderTurnsFailed": "加载更早消息失败",
+    "loadTurnItemsFailed": "加载回合内容失败",
     "misalignmentRecoveryTitle": "Codex 需要确认后继续",
     "misalignmentRecoveryConfirm": "发送修正内容",
     "mcpConnections": "MCP 连接",

--- a/server/utils/gateway/realtime/connection.ts
+++ b/server/utils/gateway/realtime/connection.ts
@@ -31,9 +31,9 @@ export async function handleRealtimePeerMessage(peer: RealtimePeer, rawMessage: 
     request = parseClientMessage(rawMessage);
     await realtimeMessageDispatcher.dispatch(peer, request);
   } catch (error: unknown) {
+    const details = realtimeErrorDetails(peer, request, error);
     console.error("[gateway] realtime message failed", {
-      requestType: request?.type ?? null,
-      requestId: request && "requestId" in request ? request.requestId : null,
+      ...details,
       message: error instanceof Error ? error.message : String(error),
     });
     if (error instanceof RealtimeAuthenticationRequiredError) {
@@ -46,7 +46,7 @@ export async function handleRealtimePeerMessage(peer: RealtimePeer, rawMessage: 
       requestId: request && "requestId" in request ? request.requestId : undefined,
       request,
       code: realtimeErrorCode(error),
-      details: realtimeErrorDetails(peer, request, error),
+      details,
     });
   }
 }
@@ -112,6 +112,8 @@ function realtimeErrorDetails(
     errorName: typeof errorRecord?.name === "string" ? errorRecord.name : null,
     statusCode: errorRecord?.statusCode ?? cause?.statusCode ?? null,
     statusMessage: errorRecord?.statusMessage ?? cause?.statusMessage ?? null,
+    rpcMethod: errorRecord?.rpcMethod ?? null,
+    rpcCode: errorRecord?.rpcCode ?? null,
   };
 }
 

--- a/server/utils/gateway/runtime/broker.ts
+++ b/server/utils/gateway/runtime/broker.ts
@@ -13,12 +13,12 @@ import { AppServerFileService } from "./app-server-files";
 
 class ThreadBroker {
   private readonly registry = new ControllerRegistry();
-  private readonly openService = new ThreadOpenService(this.registry);
+  private readonly historyReader = new ThreadHistoryReader(this.registry);
+  private readonly openService = new ThreadOpenService(this.registry, this.historyReader);
   private readonly turnCommands = new ThreadTurnCommandService(this.registry, this.openService);
   private readonly goals = new ThreadGoalService(this.registry);
   private readonly settings = new ThreadSettingsService(this.registry);
   private readonly catalog = new ThreadCatalogService(this.registry);
-  private readonly historyReader = new ThreadHistoryReader(this.registry);
   private readonly mcp = new McpRuntimeService(this.registry);
   private readonly files = new AppServerFileService(this.registry);
 

--- a/server/utils/gateway/runtime/legacy-turn-items-reader.ts
+++ b/server/utils/gateway/runtime/legacy-turn-items-reader.ts
@@ -1,0 +1,93 @@
+import type { HostRecord, ThreadHistoryItem } from "~~/shared/types";
+import { parseTurnsPage } from "~~/shared/runtime/app-server";
+import { asThreadTimelineTurn } from "~~/shared/thread-history/timeline";
+import { LRUCache } from "lru-cache";
+import type { CodexRpcClient } from "../infra/rpc/rpc";
+import { currentGatewayUserId } from "../state/memory";
+import type { TurnsPage } from "./types";
+
+interface LegacyTurnPageLocator {
+  cursor: string | null;
+  limit: number;
+  sortDirection: "asc" | "desc";
+}
+
+const locatorCache = new LRUCache<string, LegacyTurnPageLocator>({
+  max: 2_000,
+  ttl: 30 * 60_000,
+});
+
+const pendingReads = new Map<string, Promise<ThreadHistoryItem[]>>();
+
+export class LegacyTurnItemsReader {
+  recordPage(
+    hostId: number,
+    threadId: string,
+    historyMode: "legacy" | "paginated",
+    locator: LegacyTurnPageLocator,
+    page: TurnsPage,
+  ) {
+    if (historyMode !== "legacy") return;
+    for (const turn of page.data ?? []) {
+      if (typeof turn.id === "string") {
+        locatorCache.set(turnKey(hostId, threadId, turn.id), locator);
+      }
+    }
+  }
+
+  async read(client: CodexRpcClient, host: HostRecord, threadId: string, turnId: string) {
+    const key = turnKey(host.id, threadId, turnId);
+    const pending = pendingReads.get(key);
+    if (pending !== undefined) return pending;
+
+    const promise = this.readLocatedPage(client, host.id, threadId, turnId);
+    pendingReads.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      if (pendingReads.get(key) === promise) pendingReads.delete(key);
+    }
+  }
+
+  private async readLocatedPage(
+    client: CodexRpcClient,
+    hostId: number,
+    threadId: string,
+    turnId: string,
+  ) {
+    const locator = locatorCache.get(turnKey(hostId, threadId, turnId));
+    if (locator === undefined) {
+      throw new Error(
+        "Legacy Turn items require a current thread page; reopen the thread and retry",
+      );
+    }
+
+    // Legacy rollouts expose bounded Turn pages but do not implement thread/items/list. Reuse the
+    // exact opaque page cursor that produced the summary row and ask app-server to hydrate that
+    // page once. Do not parse or synthesize the cursor: rollback and compaction can change its
+    // anchor semantics, and app-server remains the only owner of that protocol detail.
+    const page = await client.request(
+      "thread/turns/list",
+      {
+        threadId,
+        cursor: locator.cursor,
+        limit: locator.limit,
+        sortDirection: locator.sortDirection,
+        itemsView: "full",
+      },
+      120_000,
+      parseTurnsPage,
+    );
+    const turn = page.data.find((candidate) => candidate.id === turnId);
+    if (turn === undefined) {
+      throw new Error("Legacy Turn is no longer present in its source page; reopen the thread");
+    }
+    return asThreadTimelineTurn(turn)?.items ?? [];
+  }
+}
+
+function turnKey(hostId: number, threadId: string, turnId: string) {
+  const userId = currentGatewayUserId();
+  if (userId === null) throw new Error("Legacy Turn paging requires an authenticated user scope");
+  return `${userId}:${hostId}:${threadId}:${turnId}`;
+}

--- a/server/utils/gateway/runtime/thread-history-reader.ts
+++ b/server/utils/gateway/runtime/thread-history-reader.ts
@@ -1,10 +1,12 @@
 import type { HostRecord } from "~~/shared/types";
 import type { ControllerRegistry } from "./controller-registry";
 import { pageCursorState, pageToFullHistory } from "./thread-history-pages";
-import { DEFAULT_TURN_PAGE_LIMIT } from "./types";
+import { DEFAULT_TURN_PAGE_LIMIT, type TurnsPage } from "./types";
 import { parseThreadItemsPage, parseTurnsPage } from "~~/shared/runtime/app-server";
 import { projectThreadTimelineHistory } from "~~/shared/thread-history/timeline";
 import { asThreadTimelineItem } from "~~/shared/thread-history/timeline";
+import { threadSnapshotStore } from "../state/thread-snapshots";
+import { LegacyTurnItemsReader } from "./legacy-turn-items-reader";
 
 export interface ThreadTurnsListInput {
   cursor?: string | null;
@@ -13,7 +15,10 @@ export interface ThreadTurnsListInput {
 }
 
 export class ThreadHistoryReader {
-  constructor(private readonly registry: ControllerRegistry) {}
+  constructor(
+    private readonly registry: ControllerRegistry,
+    private readonly legacyItems = new LegacyTurnItemsReader(),
+  ) {}
 
   async listThreadTurns(host: HostRecord, threadId: string, input: ThreadTurnsListInput) {
     const client = await this.registry.getHostClient(host);
@@ -30,6 +35,21 @@ export class ThreadHistoryReader {
       },
       120_000,
       parseTurnsPage,
+    );
+    const snapshot = threadSnapshotStore.get(host.id, threadId);
+    if (snapshot === null) {
+      throw new Error("Thread snapshot is unavailable while paging history");
+    }
+    this.recordTurnsPage(
+      host.id,
+      threadId,
+      snapshot.thread.historyMode,
+      {
+        cursor: input.cursor ?? null,
+        limit: input.limit ?? DEFAULT_TURN_PAGE_LIMIT,
+        sortDirection: input.sortDirection ?? "desc",
+      },
+      page,
     );
 
     return {
@@ -49,6 +69,18 @@ export class ThreadHistoryReader {
     },
   ) {
     const client = await this.registry.getHostClient(host);
+    const snapshot = threadSnapshotStore.get(host.id, threadId);
+    if (snapshot === null) {
+      throw new Error("Thread snapshot is unavailable while loading Turn items");
+    }
+    if (snapshot.thread.historyMode === "legacy") {
+      return {
+        turnId: input.turnId,
+        items: await this.legacyItems.read(client, host, threadId, input.turnId),
+        nextCursor: null,
+        backwardsCursor: null,
+      };
+    }
     const page = await client.request(
       "thread/items/list",
       {
@@ -70,5 +102,15 @@ export class ThreadHistoryReader {
       nextCursor: page.nextCursor,
       backwardsCursor: page.backwardsCursor,
     };
+  }
+
+  recordTurnsPage(
+    hostId: number,
+    threadId: string,
+    historyMode: "legacy" | "paginated",
+    locator: { cursor: string | null; limit: number; sortDirection: "asc" | "desc" },
+    page: TurnsPage,
+  ) {
+    this.legacyItems.recordPage(hostId, threadId, historyMode, locator, page);
   }
 }

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -28,6 +28,7 @@ import {
   parseTurnsPage,
 } from "~~/shared/runtime/app-server";
 import { gatewayThreadFromAppServer } from "../protocol/gateway-thread";
+import type { ThreadHistoryReader } from "./thread-history-reader";
 
 export class ThreadOpenService {
   private readonly pendingRefreshes = new Map<
@@ -35,7 +36,10 @@ export class ThreadOpenService {
     { limit: number; promise: Promise<ReturnTypeResult> }
   >();
 
-  constructor(private readonly registry: ControllerRegistry) {}
+  constructor(
+    private readonly registry: ControllerRegistry,
+    private readonly historyReader: ThreadHistoryReader,
+  ) {}
 
   async openThread(
     host: HostRecord,
@@ -314,6 +318,17 @@ export class ThreadOpenService {
     activationController?: ThreadController,
   ) {
     const threadId = thread.id;
+    this.historyReader.recordTurnsPage(
+      host.id,
+      threadId,
+      thread.historyMode,
+      {
+        cursor: null,
+        limit: Math.max(initialTurnsPage.data.length, 1),
+        sortDirection: "desc",
+      },
+      initialTurnsPage,
+    );
     const resolvedProjectId = resolveProjectId(host.id, projectId, thread.cwd);
     threadMetadataStore.record(host.id, resolvedProjectId, thread);
 


### PR DESCRIPTION
## Summary
- hydrate legacy Turn summaries through their source `thread/turns/list` page because legacy histories do not implement `thread/items/list`
- retain official opaque cursors in a bounded per-user locator cache and singleflight duplicate hydration reads
- distinguish Turn item failures from older-history failures and include host/RPC context in server logs

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`82 passed`)
- reproduced against a real production legacy conversation through the Gateway WebSocket: Turn pages load while direct `thread/items/list` reports unsupported