### PR TITLE
fix: stabilize cached thread resources

### DIFF
--- a/app/components/thread/useIntermediateStepsDisclosure.ts
+++ b/app/components/thread/useIntermediateStepsDisclosure.ts
@@ -60,7 +60,17 @@ export function useIntermediateStepsDisclosure(input: {
   }
 
   function setIntermediateOpen(turnId: string, open: boolean) {
-    touchedByUser.add(turnId);
+    const turn = input.turns.value.find((candidate) => candidate.id === turnId);
+    // Opening live work is temporary inspection, not a request to keep historical work expanded.
+    // Previously a click after the final stream delta but before turn/completed raced the watcher:
+    // no later running-state update remained to clear touchedByUser, so completion stayed open.
+    // Completed-turn clicks are the only durable disclosure choice; they remain open until the user
+    // closes them, while every active turn still follows the normal completion auto-collapse policy.
+    if (input.threadIsRunning.value && turn?.turnIsActive === true) {
+      touchedByUser.delete(turnId);
+    } else {
+      touchedByUser.add(turnId);
+    }
     openByTurnId.set(turnId, open);
   }
 

--- a/app/composables/files/useFileWorkspaceWatch.ts
+++ b/app/composables/files/useFileWorkspaceWatch.ts
@@ -20,6 +20,7 @@ export function useFileWorkspaceWatch(input: {
   let desiredGeneration = 0;
   let subscribedScope: string | null = null;
   let subscribedPaths = "";
+  let subscribedId: string | null = null;
   let disposed = false;
   const retry = useTimeoutFn(() => void reconcile(), FILE_WATCH_RETRY_MS, { immediate: false });
 
@@ -58,31 +59,34 @@ export function useFileWorkspaceWatch(input: {
       subscribedScope !== null &&
       (subscribedScope !== nextScope || subscribedPaths !== pathSignature)
     ) {
-      unsubscribe(subscribedScope);
+      if (subscribedId !== null) unsubscribe(subscribedScope, subscribedId);
       subscribedScope = null;
       subscribedPaths = "";
+      subscribedId = null;
     }
     if (nextScope === null || nextScope === subscribedScope || disposed) return;
 
     const [hostId, parsedProjectId, threadId] = parseScopeKey(nextScope);
+    let subscriptionId = "";
     try {
-      await realtime.request(
-        (requestId) => ({
+      await realtime.request((requestId) => {
+        subscriptionId = requestId;
+        return {
           type: "file.watch.subscribe",
           requestId,
           hostId,
           projectId: parsedProjectId,
           threadId,
           paths,
-        }),
-        expectFileWatchReady,
-      );
+        };
+      }, expectFileWatchReady);
       if (disposed || generation !== desiredGeneration || !watchDesired()) {
-        unsubscribe(nextScope);
+        unsubscribe(nextScope, subscriptionId);
         return;
       }
       subscribedScope = nextScope;
       subscribedPaths = pathSignature;
+      subscribedId = subscriptionId;
       // Registering fs/watch and hydrating the editor are separate RPC operations. Revalidate once
       // after the watch is ready so a write in that narrow hand-off window is not missed; all
       // subsequent refreshes remain event-driven and no polling timer is introduced here.
@@ -100,9 +104,15 @@ export function useFileWorkspaceWatch(input: {
     );
   }
 
-  function unsubscribe(key: string) {
+  function unsubscribe(key: string, subscriptionId: string) {
     const [hostId, projectId, threadId] = parseScopeKey(key);
-    realtime.send({ type: "file.watch.unsubscribe", hostId, projectId, threadId });
+    realtime.send({
+      type: "file.watch.unsubscribe",
+      hostId,
+      projectId,
+      threadId,
+      subscriptionId,
+    });
   }
 
   tryOnScopeDispose(() => {
@@ -111,9 +121,12 @@ export function useFileWorkspaceWatch(input: {
     retry.stop();
     stopInputs();
     stopClosed();
-    if (subscribedScope !== null) unsubscribe(subscribedScope);
+    if (subscribedScope !== null && subscribedId !== null) {
+      unsubscribe(subscribedScope, subscribedId);
+    }
     subscribedScope = null;
     subscribedPaths = "";
+    subscribedId = null;
   });
 }
 

--- a/server/utils/gateway/realtime/connection.ts
+++ b/server/utils/gateway/realtime/connection.ts
@@ -10,7 +10,7 @@ import { hostStore } from "../state/hosts";
 import { browserPreviewManager } from "../browser-preview/browser-preview-manager";
 import { recordFromUnknown } from "~~/shared/utils/records";
 import { runPeerScoped, sendRealtimePeerMessage, stateFor, type RealtimePeer } from "./peer-state";
-import { clearSubscriptions } from "./subscription-map";
+import { clearOwnedSubscriptions, clearSubscriptions } from "./subscription-map";
 
 export function openRealtimePeer(peer: RealtimePeer) {
   const state = stateFor(peer);
@@ -75,7 +75,7 @@ export function cleanupRealtimePeer(peer: RealtimePeer) {
   clearSubscriptions(state.threadUnsubscribers);
   clearSubscriptions(state.hostMetricsUnsubscribers);
   clearSubscriptions(state.tmuxSessionUnsubscribers);
-  clearSubscriptions(state.fileWatchUnsubscribers);
+  clearOwnedSubscriptions(state.fileWatchUnsubscribers);
 }
 
 function rejectUnauthenticatedPeer(peer: RealtimePeer, request: RealtimeClientMessage | undefined) {

--- a/server/utils/gateway/realtime/handlers/files.ts
+++ b/server/utils/gateway/realtime/handlers/files.ts
@@ -4,7 +4,7 @@ import { requireRecord } from "../../http/validation/common";
 import { hostStore } from "../../state/hosts";
 import { projectStore } from "../../state/projects";
 import { sendRealtimePeerMessage, stateFor, type RealtimePeer } from "../peer-state";
-import { removeSubscription } from "../subscription-map";
+import { removeOwnedSubscription, replaceOwnedSubscription } from "../subscription-map";
 
 export async function searchProjectFiles(
   peer: RealtimePeer,
@@ -33,7 +33,6 @@ export async function subscribeProjectFiles(
   const { host, project } = requiredProjectScope(request.hostId, request.projectId);
   const key = fileWatchScopeKey(request.hostId, request.projectId, request.threadId);
   const subscriptions = stateFor(peer).fileWatchUnsubscribers;
-  removeSubscription(subscriptions, key);
   const paths = watchedProjectPaths(project.remotePath, request.paths);
 
   let active = true;
@@ -46,7 +45,7 @@ export async function subscribeProjectFiles(
   // Install cancellation before awaiting fs/watch. A fast panel switch can unsubscribe while the
   // App Server is canonicalizing a slow remote path; without this pending owner, that late response
   // would leave an invisible watcher attached to the shared Host RPC connection.
-  subscriptions.set(key, cancel);
+  const subscription = replaceOwnedSubscription(subscriptions, key, request.requestId, cancel);
 
   try {
     // App Server fs/watch is deliberately non-recursive. One watch per expanded directory keeps
@@ -66,7 +65,7 @@ export async function subscribeProjectFiles(
         return;
       }
       active = false;
-      if (subscriptions.get(key) === cancel) subscriptions.delete(key);
+      if (subscriptions.get(key) === subscription) subscriptions.delete(key);
       releaseLeases();
       sendRealtimePeerMessage(peer, {
         type: "file.watch.closed",
@@ -76,7 +75,7 @@ export async function subscribeProjectFiles(
       });
     });
     releaseLeases = () => leases.forEach((lease) => lease.release());
-    if (!active || subscriptions.get(key) !== cancel) {
+    if (!active || subscriptions.get(key) !== subscription) {
       releaseLeases();
       return;
     }
@@ -90,7 +89,7 @@ export async function subscribeProjectFiles(
       paths,
     });
   } catch (error) {
-    if (subscriptions.get(key) === cancel) subscriptions.delete(key);
+    if (subscriptions.get(key) === subscription) subscriptions.delete(key);
     throw error;
   }
 }
@@ -126,9 +125,13 @@ export function unsubscribeProjectFiles(
   peer: RealtimePeer,
   request: Extract<RealtimeClientMessage, { type: "file.watch.unsubscribe" }>,
 ) {
-  removeSubscription(
+  // A restored workspace can issue a newer watch while an older fs/watch request is still in
+  // flight. Only the owner that created a lease may release it; a late cleanup from the older
+  // request must not cancel the current editor subscription for the same thread scope.
+  removeOwnedSubscription(
     stateFor(peer).fileWatchUnsubscribers,
     fileWatchScopeKey(request.hostId, request.projectId, request.threadId),
+    request.subscriptionId,
   );
 }
 

--- a/server/utils/gateway/realtime/peer-state.ts
+++ b/server/utils/gateway/realtime/peer-state.ts
@@ -1,5 +1,6 @@
 import type { RealtimeServerMessage } from "~~/shared/types";
 import { runWithGatewayUser } from "../state/memory";
+import type { OwnedSubscription } from "./subscription-map";
 
 export interface RealtimePeer {
   send(message: string): void;
@@ -22,7 +23,7 @@ export interface RealtimePeerState {
   threadUnsubscribers: Map<string, () => void>;
   hostMetricsUnsubscribers: Map<number, () => void>;
   tmuxSessionUnsubscribers: Map<number, () => void>;
-  fileWatchUnsubscribers: Map<string, () => void>;
+  fileWatchUnsubscribers: Map<string, OwnedSubscription>;
 }
 
 const peerStates = new WeakMap<RealtimePeer, RealtimePeerState>();

--- a/server/utils/gateway/realtime/subscription-map.ts
+++ b/server/utils/gateway/realtime/subscription-map.ts
@@ -1,5 +1,10 @@
 export type ReleaseSubscription = () => void;
 
+export interface OwnedSubscription {
+  ownerId: string;
+  release: ReleaseSubscription;
+}
+
 export function replaceSubscription<Key>(
   subscriptions: Map<Key, ReleaseSubscription>,
   key: Key,
@@ -18,5 +23,35 @@ export function removeSubscription<Key>(subscriptions: Map<Key, ReleaseSubscript
 
 export function clearSubscriptions<Key>(subscriptions: Map<Key, ReleaseSubscription>) {
   for (const release of subscriptions.values()) release();
+  subscriptions.clear();
+}
+
+export function replaceOwnedSubscription<Key>(
+  subscriptions: Map<Key, OwnedSubscription>,
+  key: Key,
+  ownerId: string,
+  release: ReleaseSubscription,
+) {
+  subscriptions.get(key)?.release();
+  const subscription = { ownerId, release };
+  subscriptions.set(key, subscription);
+  return subscription;
+}
+
+export function removeOwnedSubscription<Key>(
+  subscriptions: Map<Key, OwnedSubscription>,
+  key: Key,
+  ownerId?: string,
+) {
+  const subscription = subscriptions.get(key);
+  if (subscription === undefined || (ownerId !== undefined && subscription.ownerId !== ownerId)) {
+    return;
+  }
+  subscription.release();
+  subscriptions.delete(key);
+}
+
+export function clearOwnedSubscriptions<Key>(subscriptions: Map<Key, OwnedSubscription>) {
+  for (const subscription of subscriptions.values()) subscription.release();
   subscriptions.clear();
 }

--- a/server/utils/gateway/runtime/legacy-turn-items-reader.ts
+++ b/server/utils/gateway/runtime/legacy-turn-items-reader.ts
@@ -1,46 +1,40 @@
 import type { HostRecord, ThreadHistoryItem } from "~~/shared/types";
 import { parseTurnsPage } from "~~/shared/runtime/app-server";
 import { asThreadTimelineTurn } from "~~/shared/thread-history/timeline";
-import { LRUCache } from "lru-cache";
 import type { CodexRpcClient } from "../infra/rpc/rpc";
 import { currentGatewayUserId } from "../state/memory";
-import type { TurnsPage } from "./types";
-
-interface LegacyTurnPageLocator {
-  cursor: string | null;
-  limit: number;
-  sortDirection: "asc" | "desc";
-}
-
-const locatorCache = new LRUCache<string, LegacyTurnPageLocator>({
-  max: 2_000,
-  ttl: 30 * 60_000,
-});
+import type { LegacyTurnPageLocator, TurnsPage } from "./types";
 
 const pendingReads = new Map<string, Promise<ThreadHistoryItem[]>>();
 
 export class LegacyTurnItemsReader {
-  recordPage(
-    hostId: number,
-    threadId: string,
+  locatorsForPage(
     historyMode: "legacy" | "paginated",
     locator: LegacyTurnPageLocator,
     page: TurnsPage,
   ) {
-    if (historyMode !== "legacy") return;
+    if (historyMode !== "legacy") return {};
+    const locators: Record<string, LegacyTurnPageLocator> = {};
     for (const turn of page.data ?? []) {
       if (typeof turn.id === "string") {
-        locatorCache.set(turnKey(hostId, threadId, turn.id), locator);
+        locators[turn.id] = locator;
       }
     }
+    return locators;
   }
 
-  async read(client: CodexRpcClient, host: HostRecord, threadId: string, turnId: string) {
+  async read(
+    client: CodexRpcClient,
+    host: HostRecord,
+    threadId: string,
+    turnId: string,
+    locator: LegacyTurnPageLocator | undefined,
+  ) {
     const key = turnKey(host.id, threadId, turnId);
     const pending = pendingReads.get(key);
     if (pending !== undefined) return pending;
 
-    const promise = this.readLocatedPage(client, host.id, threadId, turnId);
+    const promise = this.readLocatedPage(client, threadId, turnId, locator);
     pendingReads.set(key, promise);
     try {
       return await promise;
@@ -51,11 +45,10 @@ export class LegacyTurnItemsReader {
 
   private async readLocatedPage(
     client: CodexRpcClient,
-    hostId: number,
     threadId: string,
     turnId: string,
+    locator: LegacyTurnPageLocator | undefined,
   ) {
-    const locator = locatorCache.get(turnKey(hostId, threadId, turnId));
     if (locator === undefined) {
       throw new Error(
         "Legacy Turn items require a current thread page; reopen the thread and retry",
@@ -63,9 +56,9 @@ export class LegacyTurnItemsReader {
     }
 
     // Legacy rollouts expose bounded Turn pages but do not implement thread/items/list. Reuse the
-    // exact opaque page cursor that produced the summary row and ask app-server to hydrate that
-    // page once. Do not parse or synthesize the cursor: rollback and compaction can change its
-    // anchor semantics, and app-server remains the only owner of that protocol detail.
+    // exact opaque page cursor stored with the snapshot that produced this summary row. Do not
+    // parse or synthesize the cursor: rollback and compaction can change its anchor semantics, and
+    // app-server remains the only owner of that protocol detail.
     const page = await client.request(
       "thread/turns/list",
       {

--- a/server/utils/gateway/runtime/thread-history-reader.ts
+++ b/server/utils/gateway/runtime/thread-history-reader.ts
@@ -76,7 +76,13 @@ export class ThreadHistoryReader {
     if (snapshot.thread.historyMode === "legacy") {
       return {
         turnId: input.turnId,
-        items: await this.legacyItems.read(client, host, threadId, input.turnId),
+        items: await this.legacyItems.read(
+          client,
+          host,
+          threadId,
+          input.turnId,
+          snapshot.legacyTurnPageLocators[input.turnId],
+        ),
         nextCursor: null,
         backwardsCursor: null,
       };
@@ -111,6 +117,26 @@ export class ThreadHistoryReader {
     locator: { cursor: string | null; limit: number; sortDirection: "asc" | "desc" },
     page: TurnsPage,
   ) {
-    this.legacyItems.recordPage(hostId, threadId, historyMode, locator, page);
+    const locators = this.legacyItems.locatorsForPage(historyMode, locator, page);
+    if (Object.keys(locators).length === 0) return;
+    threadSnapshotStore.update(hostId, threadId, (snapshot) =>
+      snapshot === null
+        ? null
+        : {
+            ...snapshot,
+            legacyTurnPageLocators: {
+              ...snapshot.legacyTurnPageLocators,
+              ...locators,
+            },
+          },
+    );
+  }
+
+  locatorsForPage(
+    historyMode: "legacy" | "paginated",
+    locator: { cursor: string | null; limit: number; sortDirection: "asc" | "desc" },
+    page: TurnsPage,
+  ) {
+    return this.legacyItems.locatorsForPage(historyMode, locator, page);
   }
 }

--- a/server/utils/gateway/runtime/thread-open-service.ts
+++ b/server/utils/gateway/runtime/thread-open-service.ts
@@ -95,6 +95,7 @@ export class ThreadOpenService {
       history,
       projectId,
       turnsPage,
+      legacyTurnPageLocators: {},
       threadSettings: extractThreadSettings(parsed.raw),
       tokenUsage: latestTokenUsageFromEvents(recentEvents),
     };
@@ -318,17 +319,11 @@ export class ThreadOpenService {
     activationController?: ThreadController,
   ) {
     const threadId = thread.id;
-    this.historyReader.recordTurnsPage(
-      host.id,
-      threadId,
-      thread.historyMode,
-      {
-        cursor: null,
-        limit: Math.max(initialTurnsPage.data.length, 1),
-        sortDirection: "desc",
-      },
-      initialTurnsPage,
-    );
+    const initialPageLocator = {
+      cursor: null,
+      limit: Math.max(initialTurnsPage.data.length, 1),
+      sortDirection: "desc" as const,
+    };
     const resolvedProjectId = resolveProjectId(host.id, projectId, thread.cwd);
     threadMetadataStore.record(host.id, resolvedProjectId, thread);
 
@@ -342,6 +337,11 @@ export class ThreadOpenService {
       history: projectThreadTimelineHistory(pageToFullHistory(thread, initialTurnsPage)),
       projectId: resolvedProjectId,
       turnsPage: pageCursorState(initialTurnsPage),
+      legacyTurnPageLocators: this.historyReader.locatorsForPage(
+        thread.historyMode,
+        initialPageLocator,
+        initialTurnsPage,
+      ),
       threadSettings: effectiveThreadSettings,
       tokenUsage: latestTokenUsageFromEvents(recentEvents),
     };

--- a/server/utils/gateway/runtime/types.ts
+++ b/server/utils/gateway/runtime/types.ts
@@ -20,6 +20,12 @@ export interface TurnsPage {
   backwardsCursor?: string | null;
 }
 
+export interface LegacyTurnPageLocator {
+  cursor: string | null;
+  limit: number;
+  sortDirection: "asc" | "desc";
+}
+
 export interface ThreadOpenSnapshot {
   thread: AppServerThread;
   /** Materialized once at the app-server/event boundary; cache hits return this object directly. */
@@ -29,6 +35,12 @@ export interface ThreadOpenSnapshot {
     nextCursor: string | null;
     backwardsCursor: string | null;
   };
+  /**
+   * Source pages for summary-only legacy Turns. These locators belong to the materialized history
+   * cache: storing them in a separate TTL cache lets a valid snapshot outlive the data required to
+   * expand it. Paginated histories leave this map empty and use thread/items/list directly.
+   */
+  legacyTurnPageLocators: Record<string, LegacyTurnPageLocator>;
   /** Null when a metadata-only thread/read cannot expose persisted model settings. */
   threadSettings: ThreadSettingsState | null;
   tokenUsage: ThreadTokenUsageState | null;

--- a/shared/runtime/realtime/client-message-schema.ts
+++ b/shared/runtime/realtime/client-message-schema.ts
@@ -318,6 +318,7 @@ export const realtimeClientMessageSchema: z.ZodType<RealtimeClientMessage> = z.d
         type: z.literal("file.watch.unsubscribe"),
         ...threadScopeFields,
         projectId: positiveId,
+        subscriptionId: nonEmptyString,
       })
       .strict(),
     z

--- a/shared/types/realtime.ts
+++ b/shared/types/realtime.ts
@@ -265,6 +265,7 @@ export type RealtimeClientMessage =
       hostId: number;
       projectId: number;
       threadId: string;
+      subscriptionId: string;
     }
   | {
       type: "file.git.compare";


### PR DESCRIPTION
## Summary
- keep legacy Turn page locators inside the same in-memory snapshot lifecycle as projected history
- make file-watch subscriptions lease-owned so stale async cleanup cannot cancel the current workspace watcher
- distinguish temporary live intermediate inspection from completed-turn disclosure state

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (82 passed)

No SQLite schema or migration changes.