### PR TITLE
fix: isolate remote app server logs by user

### DIFF
--- a/server/utils/gateway/infra/codex/codex-install-errors.ts
+++ b/server/utils/gateway/infra/codex/codex-install-errors.ts
@@ -1,14 +1,9 @@
-// Codex install and app-server startup failures share one recovery policy.
+// Reinstallation is destructive and bandwidth-heavy, so only classify failures that prove the
+// npm-managed executable or its official platform package is absent. Socket and transport errors
+// describe app-server startup/connectivity, not a corrupt installation.
 export function isRecoverableCodexInstallError(error: unknown) {
   const message = messageFromError(error);
-  return /codex executable not found|Missing optional dependency @openai\/codex-|Cannot find module .*@openai\/codex-|Failed to read remote Codex version|failed to connect to socket at .*app-server-control\.sock|app-server proxy.*not found|codex app-server proxy/i.test(
-    message,
-  );
-}
-
-export function isAppServerProxyStartupFailure(error: unknown) {
-  const message = messageFromError(error);
-  return /Codex RPC remote proxy WebSocket handshake failed|Codex RPC transport closed|socket hang up|ECONNRESET|EPIPE/i.test(
+  return /codex executable not found|Missing optional dependency @openai\/codex-|Cannot find module .*@openai\/codex-/i.test(
     message,
   );
 }

--- a/server/utils/gateway/infra/codex/codex-runtime.ts
+++ b/server/utils/gateway/infra/codex/codex-runtime.ts
@@ -1,8 +1,5 @@
 import type { HostWithSecret, RemoteCodexVersionState } from "../ssh/ssh-types";
-import {
-  isAppServerProxyStartupFailure,
-  isRecoverableCodexInstallError,
-} from "./codex-install-errors";
+import { isRecoverableCodexInstallError } from "./codex-install-errors";
 import { isCodexVersionAtLeast, SUPPORTED_CODEX_VERSION } from "./codex-version";
 import { hostLifecycleBus } from "../../state/host-events";
 import { currentGatewayUserId } from "../../state/memory";
@@ -172,7 +169,7 @@ export class CodexRuntimeService {
     host: HostWithSecret,
     error: unknown,
   ): Promise<RemoteCodexVersionState> {
-    if (!isRecoverableCodexInstallError(error) && !isAppServerProxyStartupFailure(error)) {
+    if (!isRecoverableCodexInstallError(error)) {
       throw error;
     }
 

--- a/server/utils/gateway/infra/ssh/remote-command.ts
+++ b/server/utils/gateway/infra/ssh/remote-command.ts
@@ -61,14 +61,19 @@ export function codexRemoteAppServerProxyPayload() {
   return codexRemotePayload(`
 set -eu
 socket="\${CODEX_HOME:-$HOME/.codex}/app-server-control/app-server-control.sock"
+control_dir="$(dirname "$socket")"
+log_file="$control_dir/codex-gateway-app-server.log"
 ${ensureGatewayCodexConfigFeatureSnippet()}
 ${appServerSocketHasListenerSnippet()}
 if [ -S "$socket" ] && ! codex_gateway_socket_has_listener; then
   rm -f "$socket"
 fi
 if ! [ -S "$socket" ]; then
-  mkdir -p "$(dirname "$socket")"
-  nohup "$CODEX_BIN" app-server --listen unix:// >/tmp/codex-gateway-app-server.log 2>&1 </dev/null &
+  # The official socket is already scoped by CODEX_HOME/HOME. Keep the detached process log
+  # beside it as well: /tmp is shared by every Unix user, so a fixed filename there lets one
+  # user's app-server block another user's launch before Codex can create its private socket.
+  mkdir -p "$control_dir"
+  nohup "$CODEX_BIN" app-server --listen unix:// >"$log_file" 2>&1 </dev/null &
   for i in $(seq 1 100); do
     if [ -S "$socket" ] && codex_gateway_socket_has_listener; then
       break
@@ -76,7 +81,14 @@ if ! [ -S "$socket" ]; then
     sleep 0.1
   done
 fi
-[ -S "$socket" ] && codex_gateway_socket_has_listener
+if ! [ -S "$socket" ] || ! codex_gateway_socket_has_listener; then
+  echo "Codex app-server did not create a listening socket: $socket" >&2
+  if [ -r "$log_file" ]; then
+    echo "Codex app-server stderr (last 80 lines from $log_file):" >&2
+    tail -n 80 "$log_file" >&2 || true
+  fi
+  exit 1
+fi
 exec "$CODEX_BIN" app-server proxy
 `);
 }


### PR DESCRIPTION
## Summary
- store detached remote app-server stderr beside the user-scoped official socket instead of a shared `/tmp` filename
- include a bounded stderr tail when the remote listener fails to start
- reinstall Codex only for confirmed executable/platform-package absence, not socket or transport failures

## Root cause
Two Unix users on one SSH host could contend for `/tmp/codex-gateway-app-server.log`. Shell redirection failed before the second user could start their own user-scoped app-server socket, and the generic proxy recovery path then incorrectly uploaded and reinstalled Codex.

## Verification
- `pnpm lint`
- `git diff --check`
- `pnpm test:e2e` (`82 passed`)
