### PR TITLE
fix: requeue stalled Codex upgrades and simplify wait items

### DIFF
--- a/app/components/thread/items/SleepItem.vue
+++ b/app/components/thread/items/SleepItem.vue
@@ -1,54 +1,24 @@
 <script setup lang="ts">
 import type { ThreadHistoryItem } from "~~/shared/types";
-import { useTimestamp } from "@vueuse/core";
-import { CheckCircle2Icon, Loader2Icon, TimerIcon } from "@lucide/vue";
-import { computed, ref, watch } from "vue";
+import { Loader2Icon, TimerIcon } from "@lucide/vue";
+import { computed } from "vue";
+import { Checkpoint, CheckpointIcon } from "@codex-gateway/ai-elements/checkpoint";
 import { isItemInProgress } from "@/utils/thread-items";
-import { formatDurationMs, itemCompletedAtMs, itemStartedAtMs } from "@/utils/item-timing";
 
 const props = defineProps<{ item: ThreadHistoryItem }>();
 
 const { t } = useI18n();
-const { timestamp: now, pause, resume } = useTimestamp({ controls: true, interval: 250 });
-const localStartedAt = ref(Date.now());
-
 const inProgress = computed(() => isItemInProgress(props.item));
-const durationMs = computed(() => Number(props.item.durationMs || props.item.duration_ms || 0));
-const startedAt = computed(() => itemStartedAtMs(props.item) ?? localStartedAt.value);
-const completedAt = computed(() => itemCompletedAtMs(props.item));
-const elapsedMs = computed(() =>
-  Math.max(0, (inProgress.value ? now.value : (completedAt.value ?? now.value)) - startedAt.value),
-);
-const progressPercent = computed(() => {
-  if (!durationMs.value) return inProgress.value ? 18 : 100;
-  return Math.max(0, Math.min(100, (elapsedMs.value / durationMs.value) * 100));
-});
-const timeLabel = computed(() => {
-  if (!durationMs.value) return formatDurationMs(elapsedMs.value);
-  return `${formatDurationMs(elapsedMs.value)} / ${formatDurationMs(durationMs.value)}`;
-});
-
-watch(inProgress, (active) => (active ? resume() : pause()), { immediate: true });
 </script>
 
 <template>
-  <div
-    class="max-w-4xl overflow-hidden rounded-lg border border-accent-orange/20 bg-accent-orange/10 text-accent-orange-deep"
-  >
-    <div class="relative">
-      <div
-        class="absolute inset-y-0 left-0 bg-accent-orange/20 transition-[width] duration-300"
-        :style="{ width: `${progressPercent}%` }"
-      />
-      <div class="relative flex items-center gap-2 px-3 py-2 text-[0.9375rem]">
-        <Loader2Icon v-if="inProgress" class="size-4 shrink-0 animate-spin text-accent-orange" />
-        <CheckCircle2Icon v-else class="size-4 shrink-0 text-accent-green" />
-        <span class="min-w-0 flex-1 truncate">{{ t("app.sleep") }}</span>
-        <span class="rounded-full bg-surface/80 px-2 py-0.5 font-mono text-xs text-ink-secondary">{{
-          timeLabel
-        }}</span>
-        <TimerIcon class="size-4 shrink-0 text-ink-muted" />
-      </div>
-    </div>
-  </div>
+  <!-- Waiting is a routine timeline checkpoint. It has no measured completion percentage, so
+       a progress bar and a local countdown would imply precision the server does not provide. -->
+  <Checkpoint class="max-w-4xl gap-2 py-1 text-[0.9375rem] text-ink-muted">
+    <CheckpointIcon>
+      <Loader2Icon v-if="inProgress" class="size-4 shrink-0 animate-spin" />
+      <TimerIcon v-else class="size-4 shrink-0" />
+    </CheckpointIcon>
+    <span>{{ t("app.sleep") }}</span>
+  </Checkpoint>
 </template>

--- a/server/utils/gateway/infra/codex/codex-artifacts.ts
+++ b/server/utils/gateway/infra/codex/codex-artifacts.ts
@@ -47,12 +47,7 @@ interface PreparedBundle {
 export class CodexArtifactProvider {
   private readonly shared = new Map<string, SharedBundle>();
 
-  async withArtifacts<T>(
-    version: string,
-    platform: CodexRemotePlatform,
-    options: { includeNode: boolean },
-    callback: (artifacts: CodexArtifactBundle) => Promise<T>,
-  ) {
+  async acquire(version: string, platform: CodexRemotePlatform, options: { includeNode: boolean }) {
     const key = `${version}:${platform.packageName}:${options.includeNode}`;
     let entry = this.shared.get(key);
     if (entry === undefined) {
@@ -70,10 +65,17 @@ export class CodexArtifactProvider {
     entry.users += 1;
     try {
       const prepared = await entry.promise;
-      return await callback(prepared.artifacts);
-    } finally {
+      return {
+        artifacts: prepared.artifacts,
+        release: () => {
+          entry.users -= 1;
+          if (entry.users === 0) this.scheduleCleanup(key, entry);
+        },
+      };
+    } catch (error) {
       entry.users -= 1;
       if (entry.users === 0) this.scheduleCleanup(key, entry);
+      throw error;
     }
   }
 

--- a/server/utils/gateway/infra/codex/codex-install-errors.ts
+++ b/server/utils/gateway/infra/codex/codex-install-errors.ts
@@ -1,3 +1,12 @@
+import { isTransientSftpTransferError } from "../ssh/ssh-transfer";
+
+export function isTransientUpgradeError(error: unknown) {
+  if (isTransientSftpTransferError(error)) return true;
+  return /SSH channel closed before remote exit status|Timed out installing remote Codex|Remote command timed out/i.test(
+    messageFromError(error),
+  );
+}
+
 // Reinstallation is destructive and bandwidth-heavy, so only classify failures that prove the
 // npm-managed executable or its official platform package is absent. Socket and transport errors
 // describe app-server startup/connectivity, not a corrupt installation.

--- a/server/utils/gateway/infra/codex/codex-upgrade-queue.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-queue.ts
@@ -1,7 +1,10 @@
 import pLimit from "p-limit";
+import pRetry from "p-retry";
 import { currentGatewayUserId, runWithGatewayUser } from "../../state/memory";
 import type { HostWithSecret } from "../ssh/ssh-types";
 import { codexUpgradeError, codexUpgradeLog } from "./codex-upgrade-log";
+import { isTransientUpgradeError } from "./codex-install-errors";
+import { hostLifecycleBus } from "../../state/host-events";
 
 const UPGRADE_CONCURRENCY = 3;
 
@@ -17,10 +20,39 @@ export class CodexUpgradeQueue {
     return this.limit.activeCount > 0 || this.limit.pendingCount > 0;
   }
 
-  async run<T>(host: HostWithSecret, work: () => Promise<T>) {
+  async run<T>(host: HostWithSecret, work: (attempt: number) => Promise<T>) {
+    // Retry wraps admission, never the work inside a slot. Every rejected attempt releases p-limit
+    // before backoff/re-enqueue, allowing other Hosts to proceed even if three uploads stall at once.
+    return await pRetry((attempt) => this.runAttempt(host, work, attempt), {
+      retries: 2,
+      minTimeout: 1_000,
+      factor: 2,
+      shouldRetry: ({ error, attemptNumber, retriesLeft }) => {
+        if (!isTransientUpgradeError(error)) return false;
+        codexUpgradeLog("workflow retry scheduled", host, {
+          attempt: attemptNumber,
+          retriesLeft,
+          message: error.message,
+        });
+        hostLifecycleBus.emit({
+          hostId: host.id,
+          status: "upgrading",
+          message: `${host.name || host.sshHost} 升级暂时失败，将重新排到队尾重试`,
+        });
+        return true;
+      },
+    });
+  }
+
+  private async runAttempt<T>(
+    host: HostWithSecret,
+    work: (attempt: number) => Promise<T>,
+    attempt: number,
+  ) {
     const userId = currentGatewayUserId();
     const queuedAt = Date.now();
     codexUpgradeLog("workflow queued", host, {
+      attempt,
       queuePosition: this.limit.activeCount + this.limit.pendingCount + 1,
     });
     return await this.limit(async () => {
@@ -28,7 +60,7 @@ export class CodexUpgradeQueue {
         const startedAt = Date.now();
         codexUpgradeLog("workflow started", host, { queueWaitMs: startedAt - queuedAt });
         try {
-          const result = await work();
+          const result = await work(attempt);
           codexUpgradeLog("workflow completed", host, { durationMs: Date.now() - startedAt });
           return result;
         } catch (error: unknown) {

--- a/server/utils/gateway/infra/codex/codex-upgrade-remote.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-remote.ts
@@ -34,7 +34,8 @@ export function codexRemoteCreateUpgradeStagePayload() {
 set -eu
 stage_root="$HOME/.cache/codex-gateway/upgrades"
 mkdir -p "$stage_root"
-find "$stage_root" -mindepth 1 -maxdepth 1 -type d -mmin +60 -name 'upgrade.*' -exec rm -rf {} + 2>/dev/null || true
+# A slow upload or queued retry may legitimately own a directory older than an hour.
+# The owning Gateway workflow cleans its staging directory when all attempts finish.
 mktemp -d "$stage_root/upgrade.XXXXXX"
 `,
     { requireCodex: false },
@@ -59,10 +60,7 @@ export function codexRemoteOfflineInstallPayload(input: {
 set -eu
 stage=${shellQuote(input.stagePath)}
 verify_prefix="$stage/verify-prefix"
-cleanup() {
-  rm -rf -- "$stage"
-}
-trap cleanup EXIT HUP INT TERM
+# Keep verified archives for a queued retry. Gateway owns final cleanup, including failed installs.
 
 archive_file=${shellQuote(archiveFile)}
 expected_archive_sha=${shellQuote(input.artifacts.cacheArchive.sha512)}

--- a/server/utils/gateway/infra/codex/codex-upgrade-resources.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-resources.ts
@@ -1,0 +1,61 @@
+import type { CodexArtifactProvider } from "./codex-artifacts";
+import type { SshConnectionPool } from "../ssh/ssh-connection";
+import type { HostWithSecret } from "../ssh/ssh-types";
+import { remoteLoginShellCommand } from "../ssh/remote-command";
+import {
+  codexRemoteCreateUpgradeStagePayload,
+  codexRemoteCleanupUpgradeStagePayload,
+} from "./codex-upgrade-remote";
+import { codexUpgradeError } from "./codex-upgrade-log";
+
+export type CodexArtifactLease = Awaited<ReturnType<CodexArtifactProvider["acquire"]>>;
+
+// One workflow owns these resources across queue attempts. Rebuilding the tarball can change its
+// bytes even at the same version, so a resumed .part must keep the exact original local artifact.
+export class CodexUpgradeResources {
+  artifactLease: CodexArtifactLease | null = null;
+  private stagePath: string | null = null;
+
+  constructor(
+    private readonly ssh: SshConnectionPool,
+    private readonly host: HostWithSecret,
+  ) {}
+
+  async stage() {
+    if (this.stagePath !== null) return this.stagePath;
+    const result = await this.ssh.exec(
+      this.host,
+      remoteLoginShellCommand(codexRemoteCreateUpgradeStagePayload()),
+      { timeoutMs: 30_000 },
+    );
+    const path = result.stdout.trim();
+    if (
+      result.code !== 0 ||
+      !/^\/[A-Za-z0-9_./-]+\/\.cache\/codex-gateway\/upgrades\/upgrade\.[A-Za-z0-9]+$/.test(path)
+    ) {
+      throw new Error(
+        result.stderr || result.stdout || "Failed to create remote upgrade staging directory",
+      );
+    }
+    this.stagePath = path;
+    return path;
+  }
+
+  async dispose() {
+    try {
+      if (this.stagePath !== null) {
+        await this.ssh.exec(
+          this.host,
+          remoteLoginShellCommand(codexRemoteCleanupUpgradeStagePayload(this.stagePath)),
+          { timeoutMs: 30_000 },
+        );
+      }
+    } catch (error) {
+      codexUpgradeError("remote staging cleanup failed", this.host, error);
+    } finally {
+      this.artifactLease?.release();
+      this.artifactLease = null;
+      this.stagePath = null;
+    }
+  }
+}

--- a/server/utils/gateway/infra/codex/codex-upgrade-workflow.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrade-workflow.ts
@@ -6,6 +6,7 @@ import type { CodexUpgrader } from "./codex-upgrader";
 import { CodexUpgradeQueue } from "./codex-upgrade-queue";
 import type { CodexVersionChecker } from "./codex-version-checker";
 import { codexUpgradeLog } from "./codex-upgrade-log";
+import type { CodexUpgradeResources } from "./codex-upgrade-resources";
 
 export class CodexUpgradeWorkflow {
   private readonly queue = new CodexUpgradeQueue();
@@ -17,10 +18,15 @@ export class CodexUpgradeWorkflow {
   ) {}
 
   async repair(host: HostWithSecret): Promise<RemoteCodexVersionState> {
-    return await this.runExclusive(host, async () => {
+    return await this.runExclusive(host, async (resources, attempt) => {
       const beforeVersion = await this.readVersionForRepair(host);
       await this.stopRuntimeIfPresent(host);
-      const version = await this.upgrader.upgrade(host, SUPPORTED_CODEX_VERSION);
+      const version = await this.upgrader.upgrade(
+        host,
+        SUPPORTED_CODEX_VERSION,
+        resources,
+        attempt,
+      );
       await this.runtime.ensureStoppedAfterUpgrade(host);
 
       return {
@@ -38,7 +44,7 @@ export class CodexUpgradeWorkflow {
     supportedVersion: string,
     observedBeforeVersion: string,
   ): Promise<RemoteCodexVersionState> {
-    return await this.runExclusive(host, async () => {
+    return await this.runExclusive(host, async (resources, attempt) => {
       // Hosts can wait in this queue for several minutes. Re-read both CLI and app-server state
       // when this Host reaches the front so a newly started thread is never interrupted and an
       // externally completed upgrade is not repeated.
@@ -91,7 +97,7 @@ export class CodexUpgradeWorkflow {
         };
       }
 
-      const version = await this.install(host, supportedVersion, beforeVersion);
+      const version = await this.install(host, supportedVersion, beforeVersion, resources, attempt);
       return {
         version,
         appServerVersion: null,
@@ -102,7 +108,13 @@ export class CodexUpgradeWorkflow {
     });
   }
 
-  private async install(host: HostWithSecret, supportedVersion: string, beforeVersion: string) {
+  private async install(
+    host: HostWithSecret,
+    supportedVersion: string,
+    beforeVersion: string,
+    resources: CodexUpgradeResources,
+    attempt: number,
+  ) {
     codexUpgradeLog("upgrade required", host, {
       observedVersion: beforeVersion,
       targetVersion: supportedVersion,
@@ -115,6 +127,8 @@ export class CodexUpgradeWorkflow {
     const version = await this.upgrader.withPreparedUpgrade(
       host,
       supportedVersion,
+      resources,
+      attempt,
       async (install) => {
         const latestRuntimeState = await this.runtime.readState(host);
         if (latestRuntimeState.running) {
@@ -147,7 +161,10 @@ export class CodexUpgradeWorkflow {
     return version;
   }
 
-  private async runExclusive<T>(host: HostWithSecret, work: () => Promise<T>) {
+  private async runExclusive<T>(
+    host: HostWithSecret,
+    work: (resources: CodexUpgradeResources, attempt: number) => Promise<T>,
+  ) {
     if (this.queue.busy) {
       hostLifecycleBus.emit({
         hostId: host.id,
@@ -155,7 +172,12 @@ export class CodexUpgradeWorkflow {
         message: `${hostDisplayName(host)} 正在等待 Codex 升级队列`,
       });
     }
-    return await this.queue.run(host, work);
+    const resources = this.upgrader.createResources(host);
+    try {
+      return await this.queue.run(host, (attempt) => work(resources, attempt));
+    } finally {
+      await resources.dispose();
+    }
   }
 
   private async readVersionForRepair(host: HostWithSecret) {

--- a/server/utils/gateway/infra/codex/codex-upgrader.ts
+++ b/server/utils/gateway/infra/codex/codex-upgrader.ts
@@ -1,9 +1,6 @@
-import pRetry from "p-retry";
 import { CodexArtifactProvider, type CodexArtifactBundle } from "./codex-artifacts";
 import { parseCodexRemotePlatform } from "./codex-platform";
 import {
-  codexRemoteCleanupUpgradeStagePayload,
-  codexRemoteCreateUpgradeStagePayload,
   codexRemoteOfflineInstallPayload,
   codexRemoteNodeRuntimeProbePayload,
   codexRemotePlatformProbePayload,
@@ -13,8 +10,8 @@ import { remoteLoginShellCommand } from "../ssh/remote-command";
 import type { SshConnectionPool } from "../ssh/ssh-connection";
 import type { CommandResult, HostWithSecret } from "../ssh/ssh-types";
 import { codexUpgradeError, codexUpgradeLog } from "./codex-upgrade-log";
+import { CodexUpgradeResources } from "./codex-upgrade-resources";
 
-const UPGRADE_ATTEMPTS = 3;
 const UPGRADE_IDLE_TIMEOUT_MS = 90_000;
 const UPGRADE_TOTAL_TIMEOUT_MS = 10 * 60_000;
 const artifactProvider = new CodexArtifactProvider();
@@ -29,15 +26,32 @@ interface UpgradeCommandResult extends CommandResult {
 export class CodexUpgrader {
   constructor(private readonly ssh: SshConnectionPool) {}
 
-  async upgrade(host: HostWithSecret, version: string) {
-    return await this.withPreparedUpgrade(host, version, (install) => install());
+  createResources(host: HostWithSecret) {
+    return new CodexUpgradeResources(this.ssh, host);
+  }
+
+  async upgrade(
+    host: HostWithSecret,
+    version: string,
+    resources: CodexUpgradeResources,
+    attempt: number,
+  ) {
+    return await this.withPreparedUpgrade(host, version, resources, attempt, (install) =>
+      install(),
+    );
   }
 
   async withPreparedUpgrade<T>(
     host: HostWithSecret,
     version: string,
+    resources: CodexUpgradeResources,
+    attempt: number,
     callback: (install: () => Promise<string>) => Promise<T>,
   ) {
+    if (resources.artifactLease !== null) {
+      const artifacts = resources.artifactLease.artifacts;
+      return await callback(() => this.installOnce(host, version, artifacts, attempt, resources));
+    }
     const platformProbeStartedAt = Date.now();
     codexUpgradeLog("remote platform probe started", host, { targetVersion: version });
     const platform = await this.readRemotePlatform(host);
@@ -60,26 +74,22 @@ export class CodexUpgrader {
       platformPackage: platform.packageName,
       includeNode,
     });
-    return await artifactProvider.withArtifacts(
-      version,
-      platform,
-      { includeNode },
-      async (artifacts) => {
-        codexUpgradeLog("artifact preparation completed", host, {
-          targetVersion: version,
-          durationMs: Date.now() - artifactStartedAt,
-          codexArchiveBytes: artifacts.cacheArchive.size,
-          nodeArchiveBytes: artifacts.nodeArchive?.size ?? 0,
-        });
-        return await callback(() => this.installWithRetries(host, version, artifacts));
-      },
-    );
+    resources.artifactLease = await artifactProvider.acquire(version, platform, { includeNode });
+    const artifacts = resources.artifactLease.artifacts;
+    codexUpgradeLog("artifact preparation completed", host, {
+      targetVersion: version,
+      durationMs: Date.now() - artifactStartedAt,
+      codexArchiveBytes: artifacts.cacheArchive.size,
+      nodeArchiveBytes: artifacts.nodeArchive?.size ?? 0,
+    });
+    return await callback(() => this.installOnce(host, version, artifacts, attempt, resources));
   }
 
   private async requiresNodeBootstrap(host: HostWithSecret) {
     const result = await this.ssh.exec(
       host,
       remoteLoginShellCommand(codexRemoteNodeRuntimeProbePayload()),
+      { timeoutMs: 30_000 },
     );
     return result.code !== 0;
   }
@@ -88,6 +98,7 @@ export class CodexUpgrader {
     const result = await this.ssh.exec(
       host,
       remoteLoginShellCommand(codexRemotePlatformProbePayload()),
+      { timeoutMs: 30_000 },
     );
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "Failed to detect remote Codex platform");
@@ -95,38 +106,16 @@ export class CodexUpgrader {
     return parseCodexRemotePlatform(result.stdout);
   }
 
-  private async installWithRetries(
-    host: HostWithSecret,
-    version: string,
-    artifacts: CodexArtifactBundle,
-  ) {
-    return await pRetry(
-      (attemptNumber) => this.installOnce(host, version, artifacts, attemptNumber),
-      {
-        retries: UPGRADE_ATTEMPTS - 1,
-        minTimeout: 1_000,
-        factor: 2,
-        shouldRetry: ({ error }) => isTransientUpgradeError(error),
-        onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
-          codexUpgradeLog("installation retry scheduled", host, {
-            attempt: attemptNumber,
-            retriesLeft,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        },
-      },
-    );
-  }
-
   private async installOnce(
     host: HostWithSecret,
     version: string,
     artifacts: CodexArtifactBundle,
     attempt: number,
+    resources: CodexUpgradeResources,
   ) {
     const attemptStartedAt = Date.now();
     codexUpgradeLog("installation attempt started", host, { targetVersion: version, attempt });
-    const stagePath = await this.createRemoteStage(host);
+    const stagePath = await resources.stage();
     try {
       const nodeArtifact = artifacts.nodeArchive;
       if (nodeArtifact !== null) {
@@ -177,8 +166,6 @@ export class CodexUpgrader {
         durationMs: Date.now() - attemptStartedAt,
       });
       throw error;
-    } finally {
-      await this.cleanupRemoteStage(host, stagePath);
     }
   }
 
@@ -196,31 +183,6 @@ export class CodexUpgrader {
       bytes,
       durationMs: Date.now() - startedAt,
     });
-  }
-
-  private async createRemoteStage(host: HostWithSecret) {
-    const result = await this.ssh.exec(
-      host,
-      remoteLoginShellCommand(codexRemoteCreateUpgradeStagePayload()),
-    );
-    const stagePath = result.stdout.trim();
-    if (result.code !== 0 || !isSafeRemoteStagePath(stagePath)) {
-      throw new Error(
-        result.stderr || result.stdout || "Failed to create remote upgrade staging directory",
-      );
-    }
-    return stagePath;
-  }
-
-  private async cleanupRemoteStage(host: HostWithSecret, stagePath: string) {
-    try {
-      await this.ssh.exec(
-        host,
-        remoteLoginShellCommand(codexRemoteCleanupUpgradeStagePayload(stagePath)),
-      );
-    } catch (error) {
-      codexUpgradeError("remote staging cleanup failed", host, error);
-    }
   }
 
   private async execInstallCommand(host: HostWithSecret, command: string) {
@@ -317,10 +279,6 @@ export class CodexUpgrader {
   }
 }
 
-function isSafeRemoteStagePath(path: string) {
-  return /^\/[A-Za-z0-9_./-]+\/\.cache\/codex-gateway\/upgrades\/upgrade\.[A-Za-z0-9]+$/.test(path);
-}
-
 function tail(value: string, maxLength: number) {
   return value.length <= maxLength ? value.trim() : value.slice(-maxLength).trim();
 }
@@ -344,11 +302,4 @@ function upgradeExitSummary(result: UpgradeCommandResult) {
   const description =
     result.exitDescription !== null ? `, description: ${result.exitDescription}` : "";
   return `Failed to install remote Codex (exit ${result.code ?? "null"}${signal}${coreDumped}${description})`;
-}
-
-function isTransientUpgradeError(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  return /SSH channel closed before remote exit status|Timed out installing remote Codex|socket hang up|ECONNRESET|EPIPE|ETIMEDOUT|No response from server|Not connected|Connection lost/i.test(
-    message,
-  );
 }

--- a/server/utils/gateway/infra/ssh/ssh-connection.ts
+++ b/server/utils/gateway/infra/ssh/ssh-connection.ts
@@ -324,6 +324,10 @@ export class SshConnectionPool extends EventEmitter<SshConnectionPoolEvents> {
     return await uploadFile(this, host, localPath, remotePath);
   }
 
+  closeSftp(host: HostWithSecret) {
+    this.sftpChannels.close(this.connectionKeyFor(host));
+  }
+
   async uploadFileResumable(host: HostWithSecret, localPath: string, remotePath: string) {
     return await uploadFileResumable(this, host, localPath, remotePath);
   }

--- a/server/utils/gateway/infra/ssh/ssh-transfer.ts
+++ b/server/utils/gateway/infra/ssh/ssh-transfer.ts
@@ -1,13 +1,22 @@
 import { createReadStream } from "node:fs";
 import { stat as statLocal } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
-import pRetry from "p-retry";
 import type { SFTPWrapper } from "ssh2";
 import type { HostWithSecret } from "./ssh-types";
 import { isConnectionLevelSshError } from "./ssh-errors";
+import { withSftpUploadProgress } from "./ssh-upload-progress";
+
+// @types/ssh2 omits the public counter maintained by SFTP WriteStream._write/_writev.
+// Declare the actual library field so progress tracking needs neither a cast nor a second counter.
+declare module "ssh2" {
+  interface WriteStream {
+    bytesWritten: number;
+  }
+}
 
 interface SftpTransferConnection {
   sftp(host: HostWithSecret): Promise<SFTPWrapper>;
+  closeSftp(host: HostWithSecret): void;
   disconnectHost(host: HostWithSecret): void;
 }
 
@@ -38,13 +47,23 @@ export async function uploadFileResumable(
   const localSize = (await statLocal(localPath)).size;
   const partialPath = `${remotePath}.part`;
 
-  await pRetry(
-    async () => {
-      try {
+  // Queue admission owns retries. A transfer failure must release its upgrade slot immediately.
+  try {
+    await withSftpUploadProgress(
+      host,
+      localSize,
+      () => connection.closeSftp(host),
+      async (monitor) => {
         const sftp = await connection.sftp(host);
-        let offset = await remoteFileSize(sftp, partialPath);
+        monitor.phase("stat");
+        const completeSize = await remoteFileSize(sftp, remotePath);
+        monitor.phase("stat partial");
+        if (completeSize === localSize) return;
+        let offset = (await remoteFileSize(sftp, partialPath)) ?? 0;
+        monitor.phase("prepare upload");
         if (offset > localSize) {
           await unlinkRemoteFile(sftp, partialPath);
+          monitor.phase("restart upload");
           offset = 0;
         }
         if (offset < localSize) {
@@ -54,48 +73,40 @@ export async function uploadFileResumable(
             mode: 0o600,
             start: offset,
           });
-          await pipeline(reader, writer);
+          // ssh2 counts bytesWritten after remote WRITE acknowledgement. Local reader/Transform
+          // data events only measure buffering and must not reset an upload's idle deadline.
+          monitor.track(() => offset + writer.bytesWritten);
+          await pipeline(reader, writer, { signal: monitor.signal });
         }
+        monitor.phase("verify upload");
         const uploadedSize = await remoteFileSize(sftp, partialPath);
+        monitor.phase("rename upload");
         if (uploadedSize !== localSize) {
           throw new Error(
-            `Incomplete SFTP upload for ${remotePath}: ${uploadedSize}/${localSize} bytes`,
+            `Incomplete SFTP upload for ${remotePath}: ${uploadedSize ?? 0}/${localSize} bytes`,
           );
         }
         await renameRemoteFile(sftp, partialPath, remotePath);
-      } catch (error) {
-        if (isTransientSftpTransferError(error)) connection.disconnectHost(host);
-        throw error;
-      }
-    },
-    {
-      retries: 4,
-      minTimeout: 1_000,
-      factor: 2,
-      shouldRetry: ({ error }) => isTransientSftpTransferError(error),
-      onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
-        console.info("[gateway-ssh] retrying resumable SFTP upload", {
-          hostId: host.id,
-          hostName: host.name,
-          attempt: attemptNumber,
-          retriesLeft,
-          message: error instanceof Error ? error.message : String(error),
-        });
+        monitor.phase("completed");
       },
-    },
-  );
+    );
+  } catch (error) {
+    // A stalled SFTP request does not prove the shared Agent/Terminal transport is dead.
+    if (isConnectionLevelSshError(error)) connection.disconnectHost(host);
+    throw error;
+  }
   return remotePath;
 }
 
 async function remoteFileSize(sftp: SFTPWrapper, path: string) {
-  return await new Promise<number>((resolve, reject) => {
+  return await new Promise<number | null>((resolve, reject) => {
     sftp.stat(path, (error, stats) => {
       if (!error) {
         resolve(stats.size);
         return;
       }
       if (isMissingSftpFile(error)) {
-        resolve(0);
+        resolve(null);
         return;
       }
       reject(error);
@@ -119,10 +130,10 @@ function isMissingSftpFile(error: unknown) {
   return typeof error === "object" && error !== null && "code" in error && error.code === 2;
 }
 
-function isTransientSftpTransferError(error: unknown) {
+export function isTransientSftpTransferError(error: unknown) {
   if (isConnectionLevelSshError(error)) return true;
   const message = error instanceof Error ? error.message : String(error);
-  return /SSH channel closed|socket hang up|ECONNRESET|EPIPE|ETIMEDOUT|Incomplete SFTP upload/i.test(
+  return /SSH channel closed|socket hang up|ECONNRESET|EPIPE|ETIMEDOUT|SFTP upload timed out|Incomplete SFTP upload/i.test(
     message,
   );
 }

--- a/server/utils/gateway/infra/ssh/ssh-upload-progress.ts
+++ b/server/utils/gateway/infra/ssh/ssh-upload-progress.ts
@@ -1,0 +1,82 @@
+import type { HostWithSecret } from "./ssh-types";
+
+const UPLOAD_IDLE_TIMEOUT_MS = 120_000;
+const PROGRESS_LOG_INTERVAL_MS = 30_000;
+
+interface UploadMonitor {
+  signal: AbortSignal;
+  phase(name: string): void;
+  track(readAcknowledgedBytes: () => number): void;
+}
+
+export async function withSftpUploadProgress(
+  host: HostWithSecret,
+  totalBytes: number,
+  closeChannel: () => void,
+  upload: (monitor: UploadMonitor) => Promise<void>,
+) {
+  const controller = new AbortController();
+  const idle = Promise.withResolvers<never>();
+  let phase = "open SFTP";
+  let bytes = 0;
+  let readBytes = () => bytes;
+  let lastProgressAt = Date.now();
+  let lastLogAt = lastProgressAt;
+  const details = () => ({
+    hostId: host.id,
+    hostName: host.name,
+    phase,
+    bytes,
+    totalBytes,
+    idleMs: Date.now() - lastProgressAt,
+  });
+  // Bound every SFTP phase, including channel open/stat/rename. A live SSH keepalive cannot prove
+  // that a particular SFTP request is making progress. Slow uploads may run indefinitely while
+  // acknowledgements advance; a fixed total deadline would discard their valid progress.
+  const timer = setInterval(() => {
+    const acknowledged = readBytes();
+    if (acknowledged > bytes) {
+      bytes = acknowledged;
+      lastProgressAt = Date.now();
+    }
+    if (Date.now() - lastLogAt >= PROGRESS_LOG_INTERVAL_MS) {
+      console.info("[gateway-ssh] SFTP upload progress", details());
+      lastLogAt = Date.now();
+    }
+    if (Date.now() - lastProgressAt >= UPLOAD_IDLE_TIMEOUT_MS) {
+      const error = new Error(
+        `SFTP upload timed out in ${phase} after 120s without progress (${bytes}/${totalBytes} bytes)`,
+      );
+      console.warn("[gateway-ssh] SFTP upload stalled", details());
+      // Settle with the retryable timeout before pipeline emits its generic AbortError. Abort plus
+      // the checks after each await prevent a late callback from starting writes in a retired attempt.
+      idle.reject(error);
+      controller.abort(error);
+      closeChannel();
+      clearInterval(timer);
+    }
+  }, 1_000);
+  try {
+    await Promise.race([
+      idle.promise,
+      upload({
+        signal: controller.signal,
+        phase(name) {
+          controller.signal.throwIfAborted();
+          phase = name;
+          lastProgressAt = Date.now();
+        },
+        track(readAcknowledgedBytes) {
+          controller.signal.throwIfAborted();
+          phase = "write";
+          readBytes = readAcknowledgedBytes;
+          bytes = readBytes();
+          lastProgressAt = Date.now();
+          console.info("[gateway-ssh] SFTP upload resumed", details());
+        },
+      }),
+    ]);
+  } finally {
+    clearInterval(timer);
+  }
+}

--- a/tests/e2e/00-codex-upgrade.spec.ts
+++ b/tests/e2e/00-codex-upgrade.spec.ts
@@ -73,7 +73,7 @@ test("upgrades empty, legacy Node, and legacy Codex SSH hosts with bounded concu
       })
       .toContain(environment.supportedCodexVersion!);
     // Seeing the binary version only proves npm has replaced the package. Wait for the
-    // install shell's cleanup trap instead of coupling this backend test to sidebar state.
+    // workflow's final cleanup instead of coupling this backend test to sidebar state.
     await verifyOfficialNpmLayout(environment);
   }
 


### PR DESCRIPTION
## Changes

An SFTP upload could remain pending indefinitely, occupying all three Codex upgrade slots and preventing later hosts from upgrading. Bound SFTP phases with a 120-second idle deadline based on remotely acknowledged writes, and log transfer phase, bytes and idle time. A stalled SFTP channel is retired without disconnecting healthy Agent/Terminal SSH traffic.

Retry attempts now release their slot and rejoin the queue tail, with three attempts per workflow. Preserve the exact local artifact and remote staging directory across attempts for resumption, then clean up when the workflow finishes. Remove per-install cleanup and age-based deletion that could discard an active upload.

Render routine Agent waits as a neutral AI Elements Checkpoint with a spinner while running. Remove the orange background, progress bar and local countdown.

## Validation

- `pnpm lint` passed.
- `git diff --check` passed.
- Standard `pnpm test:e2e`: 82 passed, including empty/old Node/old Codex upgrades, npm layout and staging cleanup, desktop/mobile scroll, notifications, files and preview.
- Slow/stalled production transfers still need observation after deployment; the E2E environments verify successful upgrade paths.
