### PR TITLE
fix: restore legacy turn disclosure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,30 +3,31 @@
 ## 项目结构
 
 - `app/`：Nuxt 前端与客户端状态。页面入口在 `app/app.vue`，业务组件按领域放在 `app/components/{chat,common,settings,sidebar,thread}`。
-- `app/components/ui/`：shadcn-vue 组件目录。已有 shadcn 组件必须优先复用，不要在业务组件里手写可替代的原生控件。
-- `app/stores/gateway/`：Pinia gateway store。复杂状态和动作拆到 `actions/`、`domain-events.ts`、`domain-subscribers.ts`，不要继续把逻辑堆回单个 store 文件。
-- `server/api/`：Nuxt/Nitro server routes，是浏览器访问 gateway 的唯一入口。
+- `packages/gateway-ui/`、`packages/gateway-ai-elements/`：预编译的 shadcn-vue 和 AI Elements 组件；`packages/gateway-browser-runtime/`：重型浏览器依赖。业务组件优先复用这些包的公开导出。
+- `app/stores/`：按领域拆分的 Pinia store；状态和动作放在对应领域，跨领域事件沿用现有 `gateway/domain-events.ts` 等机制，不重新集中到单个 gateway store。
+- `server/api/`、`server/routes/`：Nuxt/Nitro HTTP、WebSocket 和代理入口，浏览器通过 Gateway 访问远端服务。
 - `server/utils/gateway/`：后端 gateway 核心，包括 SSH、Codex app-server RPC、thread broker、运行时索引。
 - `shared/types.ts`：前后端共享 DTO 和类型。
 - `i18n/locales/`：UI 文案。默认中文，新增可见文案必须同步维护中英文。
 - `tests/e2e/`：Playwright E2E。测试必须走真实 Nuxt server、真实 SSH 环境、真实 Codex app-server。
 - `third_party/openai-codex/`：官方 Codex 源码 submodule，只用于参考。除非任务明确要求，不要修改其中内容。
-- Codex 协议基准是 npm `@openai/codex` 的 latest 发布版；参考源码时必须把 submodule 切到对应发布 tag，不按未发布 main 分支或旧版本实现。
+- Codex 协议基准是 `server/utils/gateway/infra/codex/codex-version.ts` 中的 `SUPPORTED_CODEX_VERSION`，submodule 对齐该发布 tag。明确升级 Codex 时再核对 npm latest 并同步适配，普通任务不顺手升级。
 
 ## 运行命令
 
 - 安装依赖：`pnpm install`
 - 本地开发：`pnpm dev`
-- 类型检查：`pnpm lint`
+- 类型、规则与格式检查：`pnpm lint`
+- 子包类型检查：`pnpm typecheck:dependencies`；根 `lint` 不检查子包源码，`postinstall` 会构建并检查子包。
 - 构建：`pnpm build`
 - E2E：`pnpm test:e2e`
 
 ## 测试命令
 
-- 常规改动至少运行 `pnpm lint`。
-- 涉及 SSH、RPC、thread、实时同步、上传、配置导入导出、路由恢复、i18n 的改动，必须运行 `pnpm test:e2e`,不要使用`pnpm exec playwright ..`启动宿主机测试。
-- `pnpm test:e2e` 会启动 Nuxt dev server，并通过 Docker 启动真实 SSH 测试环境；不要把 E2E 改成 mock app-server 或 fake 数据。
-- 如果 E2E 失败，先看 Playwright trace、webServer 日志和 Docker SSH 环境日志，再判断是测试环境还是代码问题。
+- 常规代码改动至少运行 `pnpm lint`；纯文档改动检查内容和 `git diff --check` 即可。
+- 改变 SSH、RPC、thread 数据流、实时同步、上传、配置导入导出、路由恢复或语言切换行为时，必须运行 `pnpm test:e2e`。纯文案或样式改动按影响范围验证，不仅凭文件所在目录决定全量回归。
+- `pnpm test:e2e` 在 Docker 中构建生产产物，应用、浏览器和构建使用独立容器，并连接真实 SSH/Codex 测试环境。统一使用该脚本，不在宿主机直接运行 Playwright，不用 mock app-server 替代真实集成链路。
+- 如果 E2E 失败，先看 Playwright trace、Gateway 测试容器和 SSH 测试容器日志，再判断是测试环境还是代码问题。
 - 构建、完整 E2E、镜像导出等长任务应使用一次足够长的前台等待或 `sleep` 后再检查结果，不要用短间隔频繁轮询刷日志。
 
 ## Git 协作
@@ -34,23 +35,23 @@
 - 任何代码更改必须先从 `main`/`master` checkout 新分支，例如 `feat/*`、`fix/*`；如果当前已经位于非 `main`/`master` 分支，则无需再次创建分支。
 - 禁止直接在 `main` 或 `master` 分支提交与推送代码更改。多人协作统一通过“分支 + PR + Review”完成合并，避免直接推送造成冲突。
 - 当用户要求提交、合并并部署时，必须按以下顺序执行，不得从功能分支直接部署：
-  1. 在当前功能分支完成 `pnpm lint`、适用的 `pnpm test:e2e` 和 `git diff --check`。
+  1. 在当前功能分支完成上述适用检查和 `git diff --check`。
   2. 提交全部任务相关改动并推送当前分支到 `origin`。
   3. 使用 `gh pr create` 创建 PR，确认检查结果和变更范围后使用 `gh pr merge` 合并；禁止绕过 PR 直接推送 `main`。
   4. 切换回 `main`，使用 `git pull --ff-only origin main` 获取远端合并结果，并确认工作区干净且提交与远端一致。
-  5. 仅从最新 `main` 执行 `docker compose up -d --build codex-gateway`，随后检查容器状态、容器日志和公网健康响应。
+  5. 仅从最新 `main` 执行 `docker compose up -d --build codex-gateway`；确认容器健康、连接 `web-common`、公网首页返回 200，并检查启动日志。需要认证的 API 应带凭据验证，不将未登录的 401 当作启动失败。
 
 ## 代码风格
 
 - 全项目使用 Nuxt 4 + TypeScript；前后端都写 TS，不引入 Go/Python/Rust 等新服务实现。
-- 浏览器永远不直接连接远端 Codex app-server，也不持有 SSH key、Codex token 以外的非必要派生状态；浏览器只访问 Nuxt server API 和页面级 WebSocket 实时总线。
-- 实时交互统一走每个浏览器页面一条 WebSocket；同一页面内多个 host/thread/terminal topic 必须复用同一个 WS 消息总线，非实时配置、版本、列表等请求继续走 HTTP。
+- 浏览器不直接连接远端 Codex app-server；登录使用 Gateway token，SSH/Codex 凭据由服务端管理。凭据录入可提交到 Gateway，但不在浏览器持久化远端凭据。
+- Gateway 业务实时交互统一走每个浏览器页面一条 WebSocket，复用 host/thread/terminal 等 topic。配置、版本等 HTTP 请求和文件/Git 等既有 WS 查询沿用各自 transport；预览页面自身的代理连接不属于这条业务总线。
 - 同一 host 在 gateway 后端只维护一个共享 SSH 连接；多个浏览器页面必须复用同一个 gateway-side SSH/RPC 生命周期管理。
 - Codex app-server/thread 是事实源。前端和 gateway 只做配置、索引、缓存和广播，不发明不可失效的二次 timeline。
-- 远端 Codex 低于 npm latest 时，gateway 负责升级并重启 app-server；升级/重启状态必须推送到前端。
-- 连接配置以服务端 SQLite 为事实源，按用户加密保存 host/project/thread runtime config；浏览器只保存 Bearer token 和轻量路由选择，不再使用 localStorage 保存连接配置。
+- 远端 Codex 低于 `SUPPORTED_CODEX_VERSION` 时，gateway 负责升级并重启 app-server；升级/重启状态必须推送到前端。
+- Host、Project、置顶等用户配置以服务端 SQLite 为事实源，敏感连接配置加密保存。订阅、运行状态和历史快照是内存运行态；浏览器可保存登录、路由、布局和文件 tab 等偏好，不用 localStorage 作为连接配置的事实源。
 - UI 默认中文，交互布局参考 Codex Desktop。不要做营销页或假数据页面。
-- 前端业务界面必须全局响应式布局；业务组件和业务样式禁止使用 `px` 级固定宽高、固定列宽、固定弹窗尺寸或固定字体，优先使用 Tailwind scale、`rem`、`clamp()`、`min()/max()`、`minmax()` 和容器约束。`app/components/ui/` 的 shadcn-vue 基础组件除非任务明确要求，不作为业务布局清理范围。
+- 前端业务界面必须全局响应式布局；业务组件和业务样式禁止使用 `px` 级固定宽高、固定列宽、固定弹窗尺寸或固定字体，优先使用 Tailwind scale、`rem`、`clamp()`、`min()/max()`、`minmax()` 和容器约束。`packages/gateway-ui/`、`packages/gateway-ai-elements/` 的上游基础组件除非任务明确要求，不作为业务布局清理范围。
 - 业务组件按领域拆分；通用能力沉到 `app/components/common/` 或对应领域目录。避免单文件持续膨胀。
 - Markdown、diff、图片查看、上传、模型/审批/推理设置等功能必须使用真实 app-server 语义和真实数据。
 - 使用成熟库处理协议、SSH、WebSocket、Markdown、拖拽/弹层等复杂行为；不要手写脆弱协议解析。
@@ -61,7 +62,7 @@
 
 - 禁止添加 fake/mock thread、fake host、fake progress 来绕过真实 app-server。
 - 禁止为旧的本机 `local` host 或旧字段写兼容迁移，除非用户明确要求；配置 schema 应该严格暴露错误。
-- 禁止为旧 Codex 协议或未发布 main 分支协议写兼容分支；本项目只支持当前 npm latest。
+- 不为旧版服务端或未发布 main 协议增加兼容分支；当前支持版本仍可返回 legacy 历史格式，其必要读取路径不属于旧服务端兼容，不能因此删除。
 - 禁止让每个浏览器 tab 建立独立 SSH 连接。
 - 禁止把 SSH 密码、私钥、Codex token 打到日志、toast、测试输出或提交记录中。
 - 禁止无关重构、格式化第三方 submodule、改动用户未要求的文件。
@@ -75,8 +76,8 @@
 - 功能使用真实远端 SSH/Codex app-server 跑通，不依赖假数据。
 - 多浏览器打开同一 thread 时，事件流、运行状态、发送消息、完成状态保持一致。
 - 页面刷新后能通过 URL/localStorage 恢复合理状态，不能出现空白、假加载或需要重复手动滚动才能看到最新消息的问题。
-- 错误要从后端透传到前端可见位置，尤其是 SSH 登录、代理、app-server RPC、schema 校验错误。
-- 新增 UI 在桌面宽度下不重叠、不溢出，滚动区域和弹窗可用。
+- Gateway 请求错误经脱敏后统一通过 Sonner 通知，不重复插入 Agent loop；详细诊断留在服务端日志，官方对话中的错误事件仍按其语义展示。
+- 新增 UI 在桌面和移动端均不重叠、不溢出，滚动区域和弹窗可用。
 - 涉及全项目 UI 布局清理时，必须确认业务前端代码没有新增 `px` 级布局，并说明 shadcn/第三方内部代码是否被排除。
 - 涉及全项目或系统性重构时，必须能说明排查范围、实际修改范围和未覆盖范围；不能用机械替换结果替代人工判断。
 - 相关类型检查和 E2E 通过；未运行的测试必须在最终说明里明确写出原因。

--- a/server/utils/gateway/infra/rpc/rpc-transport.ts
+++ b/server/utils/gateway/infra/rpc/rpc-transport.ts
@@ -1,4 +1,4 @@
-import WebSocket, { type RawData } from "ws";
+import WebSocket from "ws";
 import type { HostRecord, RpcEnvelope } from "~~/shared/types";
 import { sshConnections } from "../host-services";
 import {
@@ -7,6 +7,7 @@ import {
   remoteLoginShellCommand,
 } from "../ssh/remote-command";
 import { createRpcTransportError, type RpcTransportCloseDetail } from "./rpc-errors";
+import { rawWebSocketDataToString } from "../ws/raw-data";
 
 export interface CodexRpcTransportOptions {
   requireExistingAppServer: boolean;
@@ -166,10 +167,4 @@ export class CodexRpcTransport {
       .join(", ");
     return detail === "" ? "Codex RPC transport closed" : `Codex RPC transport closed (${detail})`;
   }
-}
-
-function rawWebSocketDataToString(data: RawData) {
-  if (Buffer.isBuffer(data)) return data.toString("utf8");
-  if (Array.isArray(data)) return Buffer.concat(data).toString("utf8");
-  return Buffer.from(data).toString("utf8");
 }

--- a/server/utils/gateway/infra/ws/raw-data.ts
+++ b/server/utils/gateway/infra/ws/raw-data.ts
@@ -1,0 +1,7 @@
+import type { RawData } from "ws";
+
+export function rawWebSocketDataToString(data: RawData) {
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (Array.isArray(data)) return Buffer.concat(data).toString("utf8");
+  return Buffer.from(data).toString("utf8");
+}

--- a/server/utils/gateway/runtime/legacy-turn-items.ts
+++ b/server/utils/gateway/runtime/legacy-turn-items.ts
@@ -1,0 +1,58 @@
+import type { HostRecord, ThreadTimelineTurn } from "~~/shared/types";
+import { parseThreadReadResult } from "~~/shared/runtime/app-server";
+import { asThreadTimelineTurn } from "~~/shared/thread-history/timeline";
+import type { CodexRpcClient } from "../infra/rpc/rpc";
+import { threadSnapshotStore } from "../state/thread-snapshots";
+
+export async function readLegacyTurnItems(
+  client: CodexRpcClient,
+  host: HostRecord,
+  threadId: string,
+  turnId: string,
+) {
+  // App Server deliberately keeps two history contracts. Legacy threads are materialized through
+  // thread/read(includeTurns), while thread/turns/list + thread/items/list are the paginated
+  // contract. A live completion notification contains only a summary, so a later disclosure must
+  // use the Legacy read API; asking the paginated API for a just-finished Legacy Turn can race the
+  // rollout store and report that the Turn is missing. This full replay is intentionally deferred
+  // until the reader expands an unloaded Legacy Turn, then retained in the server snapshot.
+  const result = await client.request(
+    "thread/read",
+    { threadId, includeTurns: true },
+    120_000,
+    parseThreadReadResult,
+  );
+  const turn = result.thread.turns.find((candidate) => candidate.id === turnId);
+  if (turn !== undefined) {
+    const projected = asThreadTimelineTurn(turn);
+    if (projected === null || projected.itemsView !== "full") {
+      throw new Error("App Server did not return full legacy Turn content");
+    }
+    cacheCompletedTurn(host.id, threadId, projected);
+    return projected.items;
+  }
+  throw new Error("Requested legacy Turn was not found in app-server history");
+}
+
+function cacheCompletedTurn(hostId: number, threadId: string, turn: ThreadTimelineTurn) {
+  // Do not overwrite an active snapshot with a read that raced streaming deltas. Finished turns
+  // are reusable across browsers; update only an already-retained row, leaving page bounds intact.
+  if (turn.status !== "completed" && turn.status !== "failed" && turn.status !== "interrupted")
+    return;
+  threadSnapshotStore.update(hostId, threadId, (snapshot) => {
+    if (snapshot === null) return null;
+    return {
+      ...snapshot,
+      history: {
+        thread: {
+          ...snapshot.history.thread,
+          turns: snapshot.history.thread.turns.map((existing) =>
+            existing.id === turn.id && existing.status === turn.status
+              ? { ...existing, ...turn }
+              : existing,
+          ),
+        },
+      },
+    };
+  });
+}

--- a/server/utils/gateway/runtime/thread-history-reader.ts
+++ b/server/utils/gateway/runtime/thread-history-reader.ts
@@ -8,6 +8,7 @@ import { threadSnapshotStore } from "../state/thread-snapshots";
 import type { ControllerRegistry } from "./controller-registry";
 import { pageCursorState, pageToFullHistory } from "./thread-history-pages";
 import { DEFAULT_TURN_PAGE_LIMIT, type TurnsPage } from "./types";
+import { readLegacyTurnItems } from "./legacy-turn-items";
 
 export interface ThreadTurnsListInput {
   cursor?: string | null;
@@ -26,9 +27,8 @@ export class ThreadHistoryReader {
   ) {
     // Keep the two upstream history contracts separate at this boundary. Paginated histories can
     // reuse thread/resume's bounded summary page and fetch items on demand. Legacy histories have
-    // no stable item-page API, so their Turn pages are requested with full items and are never
-    // exposed to the browser as lazily expandable rows. Mixing both contracts behind page locators
-    // previously let a newly-started live Turn trigger a read before it existed in the rollout.
+    // no stable item-page API, so initial Turn pages are requested with full items. Subsequent live
+    // notifications may still need hydration; that separate path reads full legacy Turn pages too.
     if (resumedPage !== undefined) {
       return resumedPage;
     }
@@ -59,12 +59,25 @@ export class ThreadHistoryReader {
     },
   ) {
     const snapshot = this.requireSnapshot(host.id, threadId);
-    if (snapshot.thread.historyMode === "legacy") {
-      // This is an invariant violation rather than a compatibility path: legacy pages already
-      // contain full items, so a browser item request means projection logic regressed.
-      throw new Error("Legacy Turn items are loaded with their Turn page");
+    const cached = snapshot.history.thread.turns.find((turn) => turn.id === input.turnId);
+    if (cached?.itemsView === "full" && input.cursor == null) {
+      return {
+        turnId: input.turnId,
+        items: input.sortDirection === "desc" ? [...cached.items].reverse() : cached.items,
+        nextCursor: null,
+        backwardsCursor: null,
+      };
     }
     const client = await this.registry.getHostClient(host);
+    if (snapshot.thread.historyMode === "legacy") {
+      const items = await readLegacyTurnItems(client, host, threadId, input.turnId);
+      return {
+        turnId: input.turnId,
+        items: input.sortDirection === "desc" ? [...items].reverse() : items,
+        nextCursor: null,
+        backwardsCursor: null,
+      };
+    }
     const page = await client.request(
       "thread/items/list",
       {

--- a/shared/thread-history/turns.ts
+++ b/shared/thread-history/turns.ts
@@ -57,6 +57,11 @@ export function syncCompletedTurn(
     turns[index] = {
       ...existingTurn,
       ...syncedTurn,
+      // A lifecycle notification describes its own payload, not our accumulated history.
+      // turn/completed carries only a summary (or no items), including for legacy threads.
+      // Never downgrade a full page we already loaded; conversely, receiving live items alone
+      // does not prove completeness when a client subscribed halfway through a turn.
+      itemsView: existingTurn.itemsView === "full" ? "full" : syncedTurn.itemsView,
       items: mergeTurnItems(existingItems, incomingItems),
     };
   } else {


### PR DESCRIPTION
保留并合并 Legacy 回合内容读取与实时协议修复，移除切换对话状态修复及其测试。

验证：
- pnpm lint
- git diff --check
- pnpm test:e2e：82 passed
- E2E 仅使用浏览器真实交互和现有真实 SSH/app-server 测试环境，不注入伪造 WebSocket。