### PR TITLE
fix: keep thread updates within FIFO cache

### DIFF
--- a/app/stores/gateway-thread-turns/older-turns.ts
+++ b/app/stores/gateway-thread-turns/older-turns.ts
@@ -29,8 +29,11 @@ export async function loadOlderTurns(t: Translate, options: { limit?: number } =
   const hostId = navigation.selectedHostId;
   const projectId = navigation.selectedProjectId;
   const threadId = navigation.selectedThreadId;
+  // This is a recent-turn FIFO cache, not a second history store. Once it is full, older-page
+  // loading would immediately evict the page just fetched while realtime events continue to
+  // append normally. Stop pagination silently instead of surfacing a recoverable cache condition
+  // as an error and keep the opaque cursor for a later fresh activation.
   if (threadTurnsFromHistory(views.history).length >= CLIENT_THREAD_TURN_CACHE_LIMIT) {
-    gateway.setError(t("app.threadHistoryCacheLimitReached"), { hostId, projectId, threadId });
     return;
   }
   views.loadingOlderTurns = true;

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -363,7 +363,6 @@
     "interruptTurnFailed": "Failed to stop generation",
     "noActiveTurnToInterrupt": "No active turn to stop",
     "loadOlderTurnsFailed": "Failed to load older messages",
-    "threadHistoryCacheLimitReached": "This conversation has reached the in-memory history limit. Reload the page to browse a different history window.",
     "loadTurnItemsFailed": "Failed to load Turn content",
     "misalignmentRecoveryTitle": "Codex needs confirmation to continue",
     "misalignmentRecoveryConfirm": "Send correction",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -363,7 +363,6 @@
     "interruptTurnFailed": "停止生成失败",
     "noActiveTurnToInterrupt": "没有正在运行的回合可停止",
     "loadOlderTurnsFailed": "加载更早消息失败",
-    "threadHistoryCacheLimitReached": "此对话已达到内存历史上限。刷新页面后可浏览其他历史区间。",
     "loadTurnItemsFailed": "加载回合内容失败",
     "misalignmentRecoveryTitle": "Codex 需要确认后继续",
     "misalignmentRecoveryConfirm": "发送修正内容",


### PR DESCRIPTION
## Summary
- keep realtime thread updates flowing when the client turn cache reaches its limit
- evict the oldest cached turns through the existing FIFO retention path
- stop older-page pagination quietly when the bounded recent window is full
- remove the obsolete cache-limit error translations

## Verification
- `pnpm lint` passed
- `git diff --check` passed
- `pnpm test:e2e`: 83 passed, 1 unrelated Bark monitoring test timed out while waiting for simulated agent output