### PR TITLE
fix: defer MFA prompt until SSH connection

### DIFF
--- a/app/components/sidebar/host-tree/HostMfaButton.vue
+++ b/app/components/sidebar/host-tree/HostMfaButton.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ShieldAlertIcon } from "@lucide/vue";
+import { LoaderCircleIcon, ShieldAlertIcon } from "@lucide/vue";
 import { Button } from "@codex-gateway/ui/button";
+import { computed } from "vue";
 
-const { hostId } = defineProps<{
+const props = defineProps<{
   hostId: number;
+  connecting?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -11,20 +13,22 @@ const emit = defineEmits<{
 }>();
 
 function handleClick() {
-  emit("click", hostId);
+  emit("click", props.hostId);
 }
+
+const icon = computed(() => (props.connecting ? LoaderCircleIcon : ShieldAlertIcon));
 </script>
 
 <template>
   <Button
-    :data-testid="`host-mfa-button-${hostId}`"
+    :data-testid="`host-mfa-button-${props.hostId}`"
     variant="ghost"
     size="icon"
     class="size-5 shrink-0 rounded-full p-0 text-accent-orange hover:bg-accent-orange/10"
-    :title="$t('app.hostMfaRequired')"
-    :aria-label="$t('app.hostMfaRequired')"
+    :title="$t(props.connecting ? 'app.hostMfaConnecting' : 'app.hostMfaRequired')"
+    :aria-label="$t(props.connecting ? 'app.hostMfaConnecting' : 'app.hostMfaRequired')"
     @click.stop="handleClick"
   >
-    <ShieldAlertIcon class="size-3.5" />
+    <component :is="icon" class="size-3.5" :class="{ 'animate-spin': props.connecting }" />
   </Button>
 </template>

--- a/app/components/sidebar/host-tree/HostTreeNode.vue
+++ b/app/components/sidebar/host-tree/HostTreeNode.vue
@@ -25,19 +25,36 @@ import ThreadRow from "../thread-list/ThreadRow.vue";
 import { requireHostTreeController } from "./controller";
 import { useHostMfaDialog } from "@/composables/host-mfa/useHostMfaDialog";
 import { useGatewayHostMfaStore } from "@/stores/gateway-host-mfa";
+import { ref, watch } from "vue";
 
-defineProps<{ host: HostRecord }>();
+const props = defineProps<{ host: HostRecord }>();
 const controller = requireHostTreeController();
 const mfaDialog = useHostMfaDialog();
 const mfaStore = useGatewayHostMfaStore();
 
 function handleMfaClick(hostId: number) {
   if (mfaStore.hasPendingMfa(hostId)) {
+    // This prompt came from a live SSH keyboard-interactive exchange, so no new connection is
+    // needed and the code can be entered immediately after the explicit button click.
     mfaDialog.openMfaDialog(hostId);
     return;
   }
+  waitingForMfaPrompt.value = true;
   mfaStore.connectMfaHost(hostId);
 }
+
+const waitingForMfaPrompt = ref(false);
+
+// A pending request is only actionable after this click starts a fresh SSH attempt. Background
+// detection must keep the button closed until the user explicitly asks to reconnect.
+watch(
+  () => mfaStore.hasPendingMfa(props.host.id),
+  (pending) => {
+    if (!pending || !waitingForMfaPrompt.value) return;
+    waitingForMfaPrompt.value = false;
+    mfaDialog.openMfaDialog(props.host.id);
+  },
+);
 </script>
 
 <template>
@@ -65,8 +82,13 @@ function handleMfaClick(hostId: number) {
                 :label="controller.hostConnectionStatuses[host.id]?.message"
               />
               <HostMfaButton
-                v-if="controller.hostConnectionStatuses[host.id]?.status === 'mfaRequired'"
+                v-if="
+                  ['mfaRequired', 'mfaConnecting'].includes(
+                    controller.hostConnectionStatuses[host.id]?.status ?? '',
+                  )
+                "
                 :host-id="host.id"
+                :connecting="controller.hostConnectionStatuses[host.id]?.status === 'mfaConnecting'"
                 @click="handleMfaClick"
               />
             </template>

--- a/app/components/sidebar/sidebar-utils.ts
+++ b/app/components/sidebar/sidebar-utils.ts
@@ -21,6 +21,7 @@ const busyHostConnectionStatuses = new Set([
   "upgrading",
   "restarting",
   "connecting",
+  "mfaConnecting",
 ]);
 
 const hostConnectionClassByStatus: Record<string, string> = {
@@ -28,6 +29,7 @@ const hostConnectionClassByStatus: Record<string, string> = {
   upgrading: "text-primary",
   restarting: "text-primary",
   connecting: "text-primary",
+  mfaConnecting: "text-accent-orange",
   mfaRequired: "text-accent-orange",
   connected: "text-accent-green",
   failed: "text-destructive",
@@ -38,6 +40,7 @@ const hostConnectionLabelKeyByStatus: Record<string, string> = {
   upgrading: "app.hostUpgrading",
   restarting: "app.hostRestarting",
   connecting: "app.hostConnecting",
+  mfaConnecting: "app.hostMfaConnecting",
   mfaRequired: "app.hostMfaRequired",
   connected: "app.connected",
   failed: "app.hostConnectionFailed",

--- a/app/stores/gateway-host-mfa/index.ts
+++ b/app/stores/gateway-host-mfa/index.ts
@@ -36,11 +36,12 @@ export const useGatewayHostMfaStore = defineStore("gateway-host-mfa", () => {
     const realtime = useGatewayRealtimeStore();
     realtime.send({ type: "host.mfa.submit", hostId, code });
     clearPendingMfa(hostId);
-    useGatewayCatalogStore().setHostConnectionStatus(hostId, "connecting");
+    useGatewayCatalogStore().setHostConnectionStatus(hostId, "mfaConnecting");
   }
 
   function connectMfaHost(hostId: number) {
     const realtime = useGatewayRealtimeStore();
+    useGatewayCatalogStore().setHostConnectionStatus(hostId, "mfaConnecting");
     realtime.send({ type: "host.mfa.connect", hostId });
   }
 

--- a/app/stores/gateway/domain-subscribers/gateway-lifecycle.ts
+++ b/app/stores/gateway/domain-subscribers/gateway-lifecycle.ts
@@ -80,10 +80,14 @@ export function registerGatewayLifecycleSubscribers() {
     ) {
       return;
     }
+    const status =
+      event.status === "connecting" && current?.status === "mfaConnecting"
+        ? "mfaConnecting"
+        : event.status;
     catalog.hostConnectionStatuses = {
       ...catalog.hostConnectionStatuses,
       [event.hostId]: {
-        status: event.status,
+        status,
         message: event.message,
         updatedAt: Number.isFinite(eventTime) ? eventTime : Date.now(),
       },

--- a/app/stores/gateway/types.ts
+++ b/app/stores/gateway/types.ts
@@ -19,6 +19,7 @@ export type HostConnectionStatus =
   | "upgrading"
   | "restarting"
   | "connecting"
+  | "mfaConnecting"
   | "connected"
   | "failed"
   | "mfaRequired";

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -314,6 +314,7 @@
     "hostConnecting": "Connecting",
     "hostConnectionFailed": "Connection failed",
     "hostMfaRequired": "MFA required",
+    "hostMfaConnecting": "Connecting to MFA host",
     "hostMfaTitle": "MFA Verification Required",
     "hostMfaDescription": "Enter the verification code for {host}",
     "hostMfaCodeLabel": "Verification code",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -314,6 +314,7 @@
     "hostConnecting": "正在连接",
     "hostConnectionFailed": "连接失败",
     "hostMfaRequired": "需要 MFA 验证",
+    "hostMfaConnecting": "正在连接 MFA 主机",
     "hostMfaTitle": "需要 MFA 验证",
     "hostMfaDescription": "请输入 {host} 的验证码",
     "hostMfaCodeLabel": "验证码",

--- a/server/utils/gateway/runtime/host-runtime-retry.ts
+++ b/server/utils/gateway/runtime/host-runtime-retry.ts
@@ -1,5 +1,8 @@
 const INITIAL_RETRY_DELAY_MS = 1_000;
-const MAX_RETRY_DELAY_MS = 60_000;
+// A dead or unreachable host must not be dialed every minute forever. The slot remains
+// single-flight, while this longer ceiling leaves recovery available without hammering SSH or
+// the proxy path.
+const MAX_RETRY_DELAY_MS = 300_000;
 
 export function retryDelay(retryCount: number) {
   return Math.min(MAX_RETRY_DELAY_MS, INITIAL_RETRY_DELAY_MS * 2 ** Math.max(0, retryCount - 1));


### PR DESCRIPTION
## Summary
- keep MFA hosts in a connecting state while the user-triggered SSH handshake is in progress
- show the MFA prompt only after the live keyboard-interactive request arrives
- preserve single-flight reconnect behavior and increase unreachable-host retry backoff

## Verification
- `pnpm lint`
- `pnpm test:e2e` (84 passed)
- `git diff --check